### PR TITLE
Fix fastpfor JS tests

### DIFF
--- a/encodings/fastpfor/js/package.json
+++ b/encodings/fastpfor/js/package.json
@@ -19,7 +19,7 @@
     "test:lint": "eslint src --ext .ts",
     "test:prettier": "prettier \"src/**/*.ts\" --list-different",
     "test:spelling": "cspell \"{README.md,.github/*.md,src/**/*.ts}\"",
-    "test:unit": "nyc --silent ava",
+    "test:unit": "nyc --silent ava src/tests/unit/**/*.ts",
     "check-cli": "run-s test diff-integration-tests check-integration-tests",
     "check-integration-tests": "run-s check-integration-test:*",
     "diff-integration-tests": "mkdir -p diff && rm -rf diff/test && cp -r test diff/test && rm -rf diff/test/test-*/.git && cd diff && git init --quiet && git add -A && git commit --quiet --no-verify --allow-empty -m 'WIP' && echo '\\n\\nCommitted most recent integration test output in the \"diff\" directory. Review the changes with \"cd diff && git diff HEAD\" or your preferred git diff viewer.'",

--- a/encodings/fastpfor/js/src/index.ts
+++ b/encodings/fastpfor/js/src/index.ts
@@ -9,7 +9,7 @@
 
 import ByteBuffer from 'bytebuffer';
 
-import { fastunpack } from './BitPacking';
+import { fastunpack } from './bitpacking';
 import { arraycopy, greatestMultiple } from './util';
 
 export class FastPFOR {


### PR DESCRIPTION
Building and testing the fastpfor library are currently failing, this PR attempts to fix this by:
 * Fixing the `bitpacking` reference (capitalization)
 * Only running unit tests (not benchmarks), we'll probably want to do that separately if we want those to be automated 