### PR TITLE
use com.mlt.converter.encodings.fsst.FsstEncoder

### DIFF
--- a/converter/java/src/main/java/com/mlt/vector/fsstdictionary/StringFsstDictionaryVector.java
+++ b/converter/java/src/main/java/com/mlt/vector/fsstdictionary/StringFsstDictionaryVector.java
@@ -1,6 +1,6 @@
 package com.mlt.vector.fsstdictionary;
 
-import com.fsst.FsstEncoder;
+import com.mlt.converter.encodings.fsst.FsstEncoder;
 import com.mlt.vector.BitVector;
 import com.mlt.vector.VariableSizeVector;
 

--- a/converter/java/src/main/java/com/mlt/vector/fsstdictionary/StringSharedFsstDictionaryVector.java
+++ b/converter/java/src/main/java/com/mlt/vector/fsstdictionary/StringSharedFsstDictionaryVector.java
@@ -1,6 +1,6 @@
 package com.mlt.vector.fsstdictionary;
 
-import com.fsst.FsstEncoder;
+import com.mlt.converter.encodings.fsst.FsstEncoder;
 import com.mlt.vector.VariableSizeVector;
 import com.mlt.vector.dictionary.DictionaryDataVector;
 import com.mlt.vector.dictionary.StringSharedDictionaryVector;


### PR DESCRIPTION
This is a quick followup to #52. #52 fixed a lot of decoder tests, but introduced one build failure:

```
/home/runner/work/maplibre-tile-spec/maplibre-tile-spec/converter/java/src/main/java/com/mlt/vector/fsstdictionary/StringSharedFsstDictionaryVector.java:3: error: package com.fsst does not exist
> Task :compileJava
import com.fsst.FsstEncoder;
               ^
/home/runner/work/maplibre-tile-spec/maplibre-tile-spec/converter/java/src/main/java/com/mlt/vector/fsstdictionary/StringFsstDictionaryVector.java:3: error: package com.fsst does not exist
import com.fsst.FsstEncoder;
```

This fixes the above build failure in order to get the tests running again.