### PR TITLE
Add CLI tool to convert an MVT into an MLT

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,4 +79,5 @@ jobs:
       - name: Test running CLI
         run: |
           java -jar ./build/libs/mvt2mlt-1.0-SNAPSHOT.jar -mvt ../../test/fixtures/omt/mvt/10_530_682.mvt -output output
-          python -c 'import os; assert os.path.getsize("output/10_530_682.mlt") == 64722'
+          python -c 'import os; print(os.path.getsize("output/10_530_682.mlt"))'
+          python -c 'import os; assert os.path.getsize("output/10_530_682.mlt") == 66980'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,3 +62,21 @@ jobs:
         uses: e-t-l/setup-mingw@patch-1
       - name: Java converter tests
         run: ./gradlew test
+  test-java-cli:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: 'converter/java'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - uses: gradle/actions/setup-gradle@v3
+      - name: Build CLI
+        run: ./gradlew cli
+      - name: Test running CLI
+        run: |
+          java -jar ./build/libs/mvt2mlt-1.0-SNAPSHOT.jar -mvt ../../test/fixtures/bing/mvt/4-8-5.mvt -output output
+          python -c 'import os; assert os.path.getsize("output/4-8-5.mlt") == 169690'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,5 +78,5 @@ jobs:
         run: ./gradlew cli
       - name: Test running CLI
         run: |
-          java -jar ./build/libs/mvt2mlt-1.0-SNAPSHOT.jar -mvt ../../test/fixtures/bing/mvt/4-8-5.mvt -output output
-          python -c 'import os; assert os.path.getsize("output/4-8-5.mlt") == 169690'
+          java -jar ./build/libs/mvt2mlt-1.0-SNAPSHOT.jar -mvt ../../test/fixtures/omt/mvt/10_530_682.mvt -output output
+          python -c 'import os; assert os.path.getsize("output/10_530_682.mlt") == 64722'

--- a/converter/java/build.gradle
+++ b/converter/java/build.gradle
@@ -53,3 +53,16 @@ task compileWrapper(type: Exec) {
 }
 
 compileJava.dependsOn compileWrapper
+
+task cli(type: Jar) {
+    archiveBaseName = 'mvt2mlt'
+    manifest {
+        attributes 'Implementation-Title': 'MVT2MLT Converter',
+                    'Implementation-Version': archiveVersion,
+                    'Main-Class': 'com.mlt.converter.MltCliAdapter'
+    }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
+    manifest.from jar.manifest
+    with jar
+}

--- a/converter/java/src/main/java/com/mlt/converter/MltCliAdapter.java
+++ b/converter/java/src/main/java/com/mlt/converter/MltCliAdapter.java
@@ -1,0 +1,89 @@
+package com.mlt.converter;
+
+import java.io.IOException;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+import com.mlt.converter.MltConverter;
+import com.mlt.decoder.MltDecoder;
+import com.mlt.converter.mvt.MvtUtils;
+import com.mlt.converter.mvt.ColumnMapping;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class MltCliAdapter {
+    private static final String FILE_NAME_ARG = "mvt";
+    private static final String OUTPUT_DIR_ARG = "output";
+
+    public static void main(String[] args) {
+        Options options = new Options();
+        options.addOption(Option.builder(FILE_NAME_ARG)
+            .hasArg(true)
+            .desc("Path to the MVT file to convert ([REQUIRED])")
+            .required(true)
+            .build());
+        options.addOption(Option.builder(OUTPUT_DIR_ARG)
+            .hasArg(true)
+            .desc("Output directory to write the converted MLT file to ([REQUIRED])")
+            .required(true)
+            .build());
+        CommandLineParser parser = new DefaultParser();
+        try {
+            CommandLine cmd = parser.parse(options, args);
+            var fileName = cmd.getOptionValue(FILE_NAME_ARG);
+            if (fileName == null) {
+                throw new ParseException("Missing required argument: " + FILE_NAME_ARG);
+            }
+            var outputDir = cmd.getOptionValue(OUTPUT_DIR_ARG);
+            if (outputDir == null) {
+                throw new ParseException("Missing required argument: " + OUTPUT_DIR_ARG);
+            }
+            var inputTilePath = Paths.get(fileName);
+            var inputTileName = inputTilePath.getFileName().toString();
+            var outputTileName = String.format("%s.mlt", inputTileName.split("\\.")[0]);
+            var outputPath = Paths.get(outputDir, outputTileName);
+            System.out.println("Converting " + fileName + " to " + outputPath.toString());
+            var outputDirPath = outputPath.getParent();
+            if (!Files.exists(outputDirPath)) {
+                System.out.println("Creating directory: " + outputDirPath);
+                Files.createDirectories(outputDirPath);
+            }                
+            // TODO: fails with ../../test/fixtures/bing/mvt/4-12-6.mvt
+            // java.lang.IndexOutOfBoundsException: Index 6 out of bounds for length 6
+            var decodedMvTile = MvtUtils.decodeMvt(inputTilePath);
+
+            var columnMapping = new ColumnMapping("name", ":", true);
+            var columnMappings = Optional.of(List.of(columnMapping));
+            var tileMetadata = MltConverter.createTilesetMetadata(decodedMvTile, columnMappings, true);
+
+            var allowIdRegeneration = true;
+            var allowSorting = false;
+            var optimization = new FeatureTableOptimizations(allowSorting, allowIdRegeneration, columnMappings);
+            //TODO: fix -> either add columMappings per layer or global like when creating the scheme
+            var optimizations = Map.of("place", optimization, "water_name", optimization, "transportation", optimization,
+            "transportation_name", optimization, "park", optimization, "mountain_peak", optimization,
+            "poi", optimization);
+            var conversionConfig = new ConversionConfig(true, true, optimizations);
+            System.out.println("converting data now...");
+            long startTime = System.nanoTime();
+            var mlTile = MltConverter.convertMvt(decodedMvTile, conversionConfig, tileMetadata);
+            long endTime = System.nanoTime();            
+            long duration = (endTime - startTime);  //divide by 1000000 to get milliseconds.
+            System.out.println("Conversion took: " + duration / 1000000 + "ms");
+            System.out.println("Writing converted tile to " + outputPath);
+            Files.write(outputPath, mlTile);
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+}

--- a/converter/java/src/main/java/com/mlt/converter/MltCliAdapter.java
+++ b/converter/java/src/main/java/com/mlt/converter/MltCliAdapter.java
@@ -16,6 +16,7 @@ import com.mlt.converter.mvt.ColumnMapping;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -61,18 +62,19 @@ public class MltCliAdapter {
             // java.lang.IndexOutOfBoundsException: Index 6 out of bounds for length 6
             var decodedMvTile = MvtUtils.decodeMvt(inputTilePath);
 
-            var columnMapping = new ColumnMapping("name", ":", true);
-            var columnMappings = Optional.of(List.of(columnMapping));
-            var tileMetadata = MltConverter.createTilesetMetadata(decodedMvTile, columnMappings, true);
+            // No ColumnMapping as support is still buggy: https://github.com/maplibre/maplibre-tile-spec/issues/59
+            var columnMappings = Optional.<List<ColumnMapping>>empty();
+            var isIdPresent = true;
+            var tileMetadata = MltConverter.createTilesetMetadata(decodedMvTile, columnMappings, isIdPresent);
 
             var allowIdRegeneration = true;
             var allowSorting = false;
             var optimization = new FeatureTableOptimizations(allowSorting, allowIdRegeneration, columnMappings);
-            //TODO: fix -> either add columMappings per layer or global like when creating the scheme
-            var optimizations = Map.of("place", optimization, "water_name", optimization, "transportation", optimization,
-            "transportation_name", optimization, "park", optimization, "mountain_peak", optimization,
-            "poi", optimization);
-            var conversionConfig = new ConversionConfig(true, true, optimizations);
+            // No FeatureTableOptimizations
+            var optimizations = new HashMap<String, FeatureTableOptimizations>();
+            var useAdvancedEncodingSchemes = false;
+            var includeIds = true;
+            var conversionConfig = new ConversionConfig(includeIds, useAdvancedEncodingSchemes, optimizations);
             System.out.println("converting data now...");
             long startTime = System.nanoTime();
             var mlTile = MltConverter.convertMvt(decodedMvTile, conversionConfig, tileMetadata);

--- a/converter/java/src/main/java/com/mlt/converter/MltConverter.java
+++ b/converter/java/src/main/java/com/mlt/converter/MltConverter.java
@@ -74,38 +74,38 @@ public class MltConverter {
                     /* MVT can only contain scalar types */
                     var scalarType = getScalarType(property);
 
-                    // if(columnMappings.isPresent()){
-                    //     if(columnMappings.get().stream().anyMatch(m -> mvtPropertyName.equals(m.mvtPropertyPrefix())) &&
-                    //             !complexPropertyColumnSchemes.containsKey(mvtPropertyName)){
-                    //         /* case where the top-level field is present like name (name:de, name:us, ...) and has a value.
-                    //          *  In this case the field is mapped to the name default. */
-                    //         var childField = createScalarFieldScheme("default", true, scalarType);
-                    //         var fieldMetadataBuilder = createComplexColumnBuilder(childField);
-                    //         complexPropertyColumnSchemes.put(mvtPropertyName, fieldMetadataBuilder);
-                    //         continue;
-                    //     }
-                    //     else if (columnMappings.get().stream().anyMatch(m -> mvtPropertyName.contains(m.mvtPropertyPrefix() + m.mvtDelimiterSign()))){
-                    //         var columnMapping = columnMappings.get().stream().
-                    //                 filter(m ->  mvtPropertyName.contains(m.mvtPropertyPrefix() + m.mvtDelimiterSign())).findFirst().get();
-                    //         var columnName = columnMapping.mvtPropertyPrefix();
-                    //         var fieldName = mvtPropertyName.split(columnMapping.mvtDelimiterSign())[1];
-                    //         var children = createScalarFieldScheme(fieldName, true, scalarType);
-                    //         if(complexPropertyColumnSchemes.containsKey(columnName)){
-                    //             /* add the nested properties to the parent like the name:* properties to the name parent struct */
-                    //             if(!complexPropertyColumnSchemes.get(columnName).getChildrenList().stream().
-                    //                     anyMatch(c -> c.getName().equals(fieldName))){
-                    //                 complexPropertyColumnSchemes.get(columnName).addChildren(children);
-                    //             }
-                    //         }
-                    //         else{
-                    //             /* Case where there is no explicit property available which serves as the name
-                    //              * for the top-level field. For example there is no name property only name:* */
-                    //             var complexColumnBuilder = createComplexColumnBuilder(children);
-                    //             complexPropertyColumnSchemes.put(mvtPropertyName, complexColumnBuilder);
-                    //         }
-                    //         continue;
-                    //     }
-                    // }
+                    if(columnMappings.isPresent()){
+                        if(columnMappings.get().stream().anyMatch(m -> mvtPropertyName.equals(m.mvtPropertyPrefix())) &&
+                                !complexPropertyColumnSchemes.containsKey(mvtPropertyName)){
+                            /* case where the top-level field is present like name (name:de, name:us, ...) and has a value.
+                             *  In this case the field is mapped to the name default. */
+                            var childField = createScalarFieldScheme("default", true, scalarType);
+                            var fieldMetadataBuilder = createComplexColumnBuilder(childField);
+                            complexPropertyColumnSchemes.put(mvtPropertyName, fieldMetadataBuilder);
+                            continue;
+                        }
+                        else if (columnMappings.get().stream().anyMatch(m -> mvtPropertyName.contains(m.mvtPropertyPrefix() + m.mvtDelimiterSign()))){
+                            var columnMapping = columnMappings.get().stream().
+                                    filter(m ->  mvtPropertyName.contains(m.mvtPropertyPrefix() + m.mvtDelimiterSign())).findFirst().get();
+                            var columnName = columnMapping.mvtPropertyPrefix();
+                            var fieldName = mvtPropertyName.split(columnMapping.mvtDelimiterSign())[1];
+                            var children = createScalarFieldScheme(fieldName, true, scalarType);
+                            if(complexPropertyColumnSchemes.containsKey(columnName)){
+                                /* add the nested properties to the parent like the name:* properties to the name parent struct */
+                                if(!complexPropertyColumnSchemes.get(columnName).getChildrenList().stream().
+                                        anyMatch(c -> c.getName().equals(fieldName))){
+                                    complexPropertyColumnSchemes.get(columnName).addChildren(children);
+                                }
+                            }
+                            else{
+                                /* Case where there is no explicit property available which serves as the name
+                                 * for the top-level field. For example there is no name property only name:* */
+                                var complexColumnBuilder = createComplexColumnBuilder(children);
+                                complexPropertyColumnSchemes.put(mvtPropertyName, complexColumnBuilder);
+                            }
+                            continue;
+                        }
+                    }
 
                     var columnScheme = createScalarColumnScheme(mvtPropertyName, true, scalarType);
                     featureTableScheme.put(mvtPropertyName, columnScheme);

--- a/converter/java/src/main/java/com/mlt/converter/MltConverter.java
+++ b/converter/java/src/main/java/com/mlt/converter/MltConverter.java
@@ -74,38 +74,38 @@ public class MltConverter {
                     /* MVT can only contain scalar types */
                     var scalarType = getScalarType(property);
 
-                    if(columnMappings.isPresent()){
-                        if(columnMappings.get().stream().anyMatch(m -> mvtPropertyName.equals(m.mvtPropertyPrefix())) &&
-                                !complexPropertyColumnSchemes.containsKey(mvtPropertyName)){
-                            /* case where the top-level field is present like name (name:de, name:us, ...) and has a value.
-                             *  In this case the field is mapped to the name default. */
-                            var childField = createScalarFieldScheme("default", true, scalarType);
-                            var fieldMetadataBuilder = createComplexColumnBuilder(childField);
-                            complexPropertyColumnSchemes.put(mvtPropertyName, fieldMetadataBuilder);
-                            continue;
-                        }
-                        else if (columnMappings.get().stream().anyMatch(m -> mvtPropertyName.contains(m.mvtPropertyPrefix() + m.mvtDelimiterSign()))){
-                            var columnMapping = columnMappings.get().stream().
-                                    filter(m ->  mvtPropertyName.contains(m.mvtPropertyPrefix() + m.mvtDelimiterSign())).findFirst().get();
-                            var columnName = columnMapping.mvtPropertyPrefix();
-                            var fieldName = mvtPropertyName.split(columnMapping.mvtDelimiterSign())[1];
-                            var children = createScalarFieldScheme(fieldName, true, scalarType);
-                            if(complexPropertyColumnSchemes.containsKey(columnName)){
-                                /* add the nested properties to the parent like the name:* properties to the name parent struct */
-                                if(!complexPropertyColumnSchemes.get(columnName).getChildrenList().stream().
-                                        anyMatch(c -> c.getName().equals(fieldName))){
-                                    complexPropertyColumnSchemes.get(columnName).addChildren(children);
-                                }
-                            }
-                            else{
-                                /* Case where there is no explicit property available which serves as the name
-                                 * for the top-level field. For example there is no name property only name:* */
-                                var complexColumnBuilder = createComplexColumnBuilder(children);
-                                complexPropertyColumnSchemes.put(mvtPropertyName, complexColumnBuilder);
-                            }
-                            continue;
-                        }
-                    }
+                    // if(columnMappings.isPresent()){
+                    //     if(columnMappings.get().stream().anyMatch(m -> mvtPropertyName.equals(m.mvtPropertyPrefix())) &&
+                    //             !complexPropertyColumnSchemes.containsKey(mvtPropertyName)){
+                    //         /* case where the top-level field is present like name (name:de, name:us, ...) and has a value.
+                    //          *  In this case the field is mapped to the name default. */
+                    //         var childField = createScalarFieldScheme("default", true, scalarType);
+                    //         var fieldMetadataBuilder = createComplexColumnBuilder(childField);
+                    //         complexPropertyColumnSchemes.put(mvtPropertyName, fieldMetadataBuilder);
+                    //         continue;
+                    //     }
+                    //     else if (columnMappings.get().stream().anyMatch(m -> mvtPropertyName.contains(m.mvtPropertyPrefix() + m.mvtDelimiterSign()))){
+                    //         var columnMapping = columnMappings.get().stream().
+                    //                 filter(m ->  mvtPropertyName.contains(m.mvtPropertyPrefix() + m.mvtDelimiterSign())).findFirst().get();
+                    //         var columnName = columnMapping.mvtPropertyPrefix();
+                    //         var fieldName = mvtPropertyName.split(columnMapping.mvtDelimiterSign())[1];
+                    //         var children = createScalarFieldScheme(fieldName, true, scalarType);
+                    //         if(complexPropertyColumnSchemes.containsKey(columnName)){
+                    //             /* add the nested properties to the parent like the name:* properties to the name parent struct */
+                    //             if(!complexPropertyColumnSchemes.get(columnName).getChildrenList().stream().
+                    //                     anyMatch(c -> c.getName().equals(fieldName))){
+                    //                 complexPropertyColumnSchemes.get(columnName).addChildren(children);
+                    //             }
+                    //         }
+                    //         else{
+                    //             /* Case where there is no explicit property available which serves as the name
+                    //              * for the top-level field. For example there is no name property only name:* */
+                    //             var complexColumnBuilder = createComplexColumnBuilder(children);
+                    //             complexPropertyColumnSchemes.put(mvtPropertyName, complexColumnBuilder);
+                    //         }
+                    //         continue;
+                    //     }
+                    // }
 
                     var columnScheme = createScalarColumnScheme(mvtPropertyName, true, scalarType);
                     featureTableScheme.put(mvtPropertyName, columnScheme);


### PR DESCRIPTION
This PR:

 - Adds a java command line program to convert an MVT into an MLT (mvt2mlt)
 - Adds a CI job that tests the program can run and outputs a file of the expected length

This is intended as an exploratory tool to ensure that all MVT can be decoded and re-encoded without unexpected errors. If we discover tiles that cannot be converted, then those tiles would be candidates to build into the formal unit tests.

Future PRs to this code could add command line options to control encoding settings. For now all optimizations are disabled by default in order to avoid issues like #59 