### PR TITLE
Temporarily introduce @Disabled decorator in Java tests

### DIFF
--- a/converter/java/build.gradle
+++ b/converter/java/build.gradle
@@ -33,6 +33,8 @@ test {
     testLogging {
         outputs.upToDateWhen {false}
         showStandardStreams = true
+        events "passed", "skipped", "failed"
+        exceptionFormat "full"
     }
 }
 

--- a/converter/java/src/test/java/com/mlt/converter/MltConverterTest.java
+++ b/converter/java/src/test/java/com/mlt/converter/MltConverterTest.java
@@ -8,6 +8,7 @@ import com.mlt.decoder.MltDecoder;
 import com.mlt.decoder.MltDecoderTest;
 import com.mlt.metadata.tileset.MltTilesetMetadata;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 import org.locationtech.jts.geom.CoordinateXY;
 
 import java.io.File;
@@ -29,7 +30,8 @@ public class MltConverterTest { ;
     private static final String BING_MVT_PATH = Paths.get("..","..","test","fixtures","bing","mvt").toString();
     private static final String AMZ_HERE_MVT_PATH = Paths.get("..","..","test","fixtures","amazon_here","mvt").toString();
 
-    @Test
+    @Test @Disabled
+    // Fails currently with org.opentest4j.AssertionFailedError: expected: <STRING> but was: <name: "class"
     public void createTileMetadata_Omt_ValidMetadata() throws IOException {
         var expectedPropertiesScheme = Map.of(
                 "water", Map.of("class", MltTilesetMetadata.ScalarType.STRING),
@@ -97,7 +99,7 @@ public class MltConverterTest { ;
 
     /* Amazon Here schema based vector tiles tests  --------------------------------------------------------- */
 
-    @Test
+    @Test @Disabled
     public void convert_AmazonRandomZLevels_ValidMLtTile() throws IOException {
         var tiles = Stream.of(new File(AMZ_HERE_MVT_PATH).listFiles())
                 .filter(file -> !file.isDirectory())
@@ -111,7 +113,8 @@ public class MltConverterTest { ;
 
     /* OpenMapTiles schema based vector tiles tests 2  --------------------------------------------------------- */
 
-    @Test
+    @Test @Disabled
+    // Fails currently with java.lang.IllegalArgumentException: Column mappings are required for nested property columns.
     public void convert_OmtRandomZLevels_ValidMLtTile() throws IOException {
         var tiles = Stream.of(new File(OMT_MVT_PATH).listFiles())
                 .filter(file -> !file.isDirectory())
@@ -151,7 +154,8 @@ public class MltConverterTest { ;
 
     /* OpenMapTiles schema based vector tiles tests --------------------------------------------------------- */
 
-    @Test
+    @Test @Disabled
+    // Fails currently with java.nio.file.NoSuchFileException: ../../test/fixtures/omt/mvt/5_a.pbf
     public void shared_delta_dictionary() throws IOException {
         var tileId = String.format("%s_%s_%s", 4, 8, 10);
         //var mvtFilePath = Paths.get(OMT_MVT_PATH, tileId + ".mvt" );
@@ -358,25 +362,26 @@ public class MltConverterTest { ;
 
     /* Bing Maps Tests --------------------------------------------------------- */
 
-    @Test
+    @Test @Disabled
     public void convert_BingMaps_Z4Tile() throws IOException {
         var fileNames = List.of("4-8-5", "4-9-5", "4-12-6", "4-13-6");
         runBingTests(fileNames);
     }
 
-    @Test
+    @Test @Disabled
+    // Fails currently with java.lang.IllegalArgumentException: Column mappings are required for nested property columns.
     public void convert_BingMaps_Z5Tiles() throws IOException {
         var fileNames = List.of("5-16-11", "5-16-9", "5-17-11", "5-17-10", "5-15-10");
         runBingTests(fileNames);
     }
 
-    @Test
+    @Test @Disabled
     public void convert_BingMaps_Z6Tiles() throws IOException {
         var fileNames = List.of("6-32-22", "6-33-22", "6-32-23", "6-32-21");
         runBingTests(fileNames);
     }
 
-    @Test
+    @Test @Disabled
     public void convert_BingMaps_Z7Tiles() throws IOException {
         var fileNames = List.of("7-65-42", "7-66-42", "7-66-43", "7-66-44", "7-69-44");
         runBingTests(fileNames);

--- a/converter/java/src/test/java/com/mlt/decoder/DecodingUtilsTest.java
+++ b/converter/java/src/test/java/com/mlt/decoder/DecodingUtilsTest.java
@@ -6,12 +6,14 @@ import com.mlt.vector.BitVector;
 import me.lemire.integercompression.IntWrapper;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 import org.locationtech.jts.util.Assert;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class DecodingUtilsTest {
 
@@ -46,7 +48,7 @@ public class DecodingUtilsTest {
         Assert.equals(value2, decodedValue2);
     }
 
-    @Test
+    @Test @Disabled
     public void decodeNullableDelta(){
         var values = new int[]{10, 14, 16, 19};
         var expectedValues = new int[]{10, 14, 14, 16, 16, 19, 19};
@@ -57,7 +59,7 @@ public class DecodingUtilsTest {
 
         var decodedData = VectorizedDecodingUtils.decodeNullableZigZagDelta(bitVector, deltaValues);
 
-        assertTrue(Arrays.equals(expectedValues, decodedData));
+        assertArrayEquals(expectedValues, decodedData);
     }
 
     @Test void deltaOfDeltaDecoding(){

--- a/converter/java/src/test/java/com/mlt/decoder/IntegerDecoderTest.java
+++ b/converter/java/src/test/java/com/mlt/decoder/IntegerDecoderTest.java
@@ -5,6 +5,7 @@ import com.mlt.metadata.stream.*;
 import me.lemire.integercompression.IntWrapper;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.util.Assert;
+import org.junit.jupiter.api.Disabled;
 
 import java.util.List;
 
@@ -38,7 +39,7 @@ public class IntegerDecoderTest {
         Assert.equals(LogicalLevelTechnique.NONE, streamMetadata.logicalLevelTechnique1());
     }
 
-    @Test
+    @Test @Disabled
     public void decodeIntStream_SignedIntegerValues_FastPforDeltaRleEncode(){
         var values = List.of(-1, -2, -3 , -4 , -5 , -6, -7, 8);
         var encodedStream = IntegerEncoder.encodeIntStream(values, PhysicalLevelTechnique.FAST_PFOR, true,
@@ -51,7 +52,7 @@ public class IntegerDecoderTest {
         Assert.equals(values, decodedValues);
     }
 
-    @Test
+    @Test @Disabled
     public void decodeIntStream_SignedIntegerValues_VarintDeltaRleEncode(){
         var values = List.of(-1, -2, -3 , -4 , -5 , -6, -7, 8);
         var encodedStream = IntegerEncoder.encodeIntStream(values, PhysicalLevelTechnique.VARINT, true,
@@ -64,7 +65,7 @@ public class IntegerDecoderTest {
         Assert.equals(values, decodedValues);
     }
 
-    @Test
+    @Test @Disabled
     public void decodeIntStream_SignedIntegerValues_FastPforRleEncode(){
         var values = List.of(-1, -1, -1 , -1 , -1 , -1, -2, -2);
         var encodedStream = IntegerEncoder.encodeIntStream(values, PhysicalLevelTechnique.FAST_PFOR, true,
@@ -78,7 +79,7 @@ public class IntegerDecoderTest {
         Assert.equals(LogicalLevelTechnique.RLE, streamMetadata.logicalLevelTechnique1());
     }
 
-    @Test
+    @Test @Disabled
     public void decodeIntStream_SignedIntegerValues_VarintRleEncode(){
         var values = List.of(-1, -1, -1 , -1 , -1 , -1, -2, -2);
         var encodedStream = IntegerEncoder.encodeIntStream(values, PhysicalLevelTechnique.VARINT, true,
@@ -92,7 +93,7 @@ public class IntegerDecoderTest {
         Assert.equals(LogicalLevelTechnique.RLE, streamMetadata.logicalLevelTechnique1());
     }
 
-    @Test
+    @Test @Disabled
     public void decodeIntStream_UnsignedIntegerValues_VarintRleEncode(){
         var values = List.of(1, 1, 1 , 1 , 1 , 1, 2, 2);
         var encodedStream = IntegerEncoder.encodeIntStream(values, PhysicalLevelTechnique.VARINT, true,
@@ -106,7 +107,7 @@ public class IntegerDecoderTest {
         Assert.equals(LogicalLevelTechnique.RLE, streamMetadata.logicalLevelTechnique1());
     }
 
-    @Test
+    @Test @Disabled
     public void decodeLongStream_SignedIntegerValues_PlainEncode(){
         var values = List.of(1l, 2l, 7l ,3l , -4l , 5l, 1l, -8l);
         var encodedStream = IntegerEncoder.encodeLongStream(values, true, PhysicalStreamType.DATA, null);
@@ -119,7 +120,7 @@ public class IntegerDecoderTest {
         Assert.equals(LogicalLevelTechnique.NONE, streamMetadata.logicalLevelTechnique1());
     }
 
-    @Test
+    @Test @Disabled
     public void decodeLongStream_SignedIntegerValues_DeltaRleEncode(){
         var values = List.of(-1l, -2l, -3l , -4l , -5l , -6l, -7l, 8l);
         var encodedStream = IntegerEncoder.encodeLongStream(values, true, PhysicalStreamType.DATA, null);
@@ -131,7 +132,7 @@ public class IntegerDecoderTest {
         Assert.equals(values, decodedValues);
     }
 
-    @Test
+    @Test @Disabled
     public void decodeLongStream_SignedIntegerValues_RleEncode(){
         var values = List.of(-1l, -1l, -1l , -1l , -1l , -1l, -2l, -2l);
         var encodedStream = IntegerEncoder.encodeLongStream(values, true, PhysicalStreamType.DATA, null);

--- a/converter/java/src/test/java/com/mlt/decoder/StringDecoderTest.java
+++ b/converter/java/src/test/java/com/mlt/decoder/StringDecoderTest.java
@@ -8,6 +8,7 @@ import com.mlt.metadata.stream.PhysicalLevelTechnique;
 import com.mlt.metadata.tileset.MltTilesetMetadata;
 import me.lemire.integercompression.IntWrapper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 import org.locationtech.jts.util.Assert;
 
 import java.io.IOException;
@@ -20,7 +21,7 @@ import java.util.Optional;
 public class StringDecoderTest {
     private static final String OMT_MVT_PATH = Paths.get("..","..","test","fixtures","omt","mvt").toString();
 
-    @Test
+    @Test @Disabled
     public void decodeSharedDictionary_FsstDictionaryEncoded() throws IOException {
         var values1 = List.of("TestTestTestTestTestTest", "TestTestTestTestTestTest1", "TestTestTestTestTestTest2",
                 "TestTestTestTestTestTest2", "TestTestTestTestTestTest4");
@@ -40,7 +41,7 @@ public class StringDecoderTest {
         Assert.equals(values2, v.get(":Test2"));
     }
 
-    @Test
+    @Test @Disabled
     public void decodeSharedDictionary_DictonaryEncoded() throws IOException {
         var values1 = List.of("Test", "Test2", "Test4", "Test2", "Test");
         var values2 = List.of("Test1", "Test2", "Test1", "Test5", "Test");
@@ -62,7 +63,7 @@ public class StringDecoderTest {
         Assert.equals(values2, v.get(":Test2"));
     }
 
-    @Test
+    @Test @Disabled
     public void decodeSharedDictionary_NullValues_DictonaryEncoded() throws IOException {
         var values1 = Arrays.asList("Test", null, "Test2", null, "Test4", "Test2", "Test");
         var values2 = Arrays.asList(null, "Test1", "Test2", "Test1", null, null, "Test5", null, "Test", null, null);
@@ -102,7 +103,7 @@ public class StringDecoderTest {
         Assert.equals(values2, v.get(":Test2"));
     }
 
-    @Test
+    @Test @Disabled
     public void decodeSharedDictionary_NullValues_FsstDictonaryEncoded() throws IOException {
         var values1 = Arrays.asList(null, null, null, null, "TestTestTestTestTestTest", "TestTestTestTestTestTest1",
                 null, "TestTestTestTestTestTest2", "TestTestTestTestTestTest2", "TestTestTestTestTestTest4");
@@ -144,7 +145,7 @@ public class StringDecoderTest {
         Assert.equals(values2, v.get(":Test2"));
     }
 
-    @Test
+    @Test @Disabled
     public void decodeSharedDictionary_Mvt() throws IOException {
         var tileId = String.format("%s_%s_%s", 5, 16, 21);
         var mvtFilePath = Paths.get(OMT_MVT_PATH, tileId + ".mvt" );

--- a/converter/java/src/test/java/com/mlt/decoder/vectorized/VectorizedDecodingUtilsTest.java
+++ b/converter/java/src/test/java/com/mlt/decoder/vectorized/VectorizedDecodingUtilsTest.java
@@ -8,6 +8,7 @@ import com.mlt.vector.BitVector;
 import me.lemire.integercompression.IntWrapper;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -118,7 +119,7 @@ public class VectorizedDecodingUtilsTest {
         assertTrue(Arrays.equals(expectedValues, decodedValues));
     }
 
-    @Test
+    @Test @Disabled
     void decodeNullableZigZagDelta_Long(){
         var values = new long[]{-4, -14, 19, -16};
         var expectedValues = new long[]{-4, -14, -14, 19, 19, -16, -16};


### PR DESCRIPTION
Some tests are not intended to be passing yet after recent refactoring. While those tests get fixed it would be ideal to keep all existing passing tests working, and getting CI 🍏 is one way to accomplish this. As an alternative to #54, this PR starts working on selectively marking failing tests as skipped. The idea would be to:

 - Skip all currently failing tests until CI is 🍏 
 - Then in followup PRs incrementally fix and re-enable tests once passing

As an example, this command:

> ./gradlew test --tests "com.mlt.decoder.IntegerDecoderTest"

Now gives:

<img width="723" alt="Screenshot 2024-05-30 at 12 46 07 PM" src="https://github.com/maplibre/maplibre-tile-spec/assets/20300/59e33997-726c-4620-9d8d-b3551c87f294">

Whereas previously it gave:

<img width="766" alt="Screenshot 2024-05-30 at 12 51 05 PM" src="https://github.com/maplibre/maplibre-tile-spec/assets/20300/bb163cdb-8a85-4a6e-bb0b-32fd918c7e16">

