### PR TITLE
Enhance the java CLI tool

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,5 +76,5 @@ jobs:
       - name: Test running CLI
         run: |
           ./gradlew cli
-          java -jar ./build/libs/mvt2mlt-1.0-SNAPSHOT.jar -mvt ../../test/fixtures/omt/mvt/10_530_682.mvt -output output
+          java -jar ./build/libs/mvt2mlt-1.0-SNAPSHOT.jar -mvt ../../test/fixtures/omt/mvt/10_530_682.mvt -dir output
           python -c 'import os; expected=66984; ts=os.path.getsize("output/10_530_682.mlt"); assert ts == expected, f"tile size changed from expected ({expected}), got: {ts}"'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,5 +76,7 @@ jobs:
       - name: Test running CLI
         run: |
           ./gradlew cli
-          java -jar ./build/libs/mvt2mlt-1.0-SNAPSHOT.jar -mvt ../../test/fixtures/omt/mvt/10_530_682.mvt -dir output
-          python -c 'import os; expected=66984; ts=os.path.getsize("output/10_530_682.mlt"); assert ts == expected, f"tile size changed from expected ({expected}), got: {ts}"'
+          java -jar ./build/libs/mvt2mlt-1.0-SNAPSHOT.jar -mvt ../../test/fixtures/omt/mvt/10_530_682.mvt -mlt output/varint.mvt
+          java -jar ./build/libs/mvt2mlt-1.0-SNAPSHOT.jar -mvt ../../test/fixtures/omt/mvt/10_530_682.mvt -advanced -mlt output/advanced.mvt
+          python -c 'import os; expected=66984; ts=os.path.getsize("output/varint.mvt"); assert ts == expected, f"tile size changed from expected ({expected}), got: {ts}"'
+          python -c 'import os; expected=64728; ts=os.path.getsize("output/advanced.mvt"); assert ts == expected, f"tile size changed from expected ({expected}), got: {ts}"'

--- a/converter/java/src/main/java/com/mlt/converter/MltCliAdapter.java
+++ b/converter/java/src/main/java/com/mlt/converter/MltCliAdapter.java
@@ -13,29 +13,160 @@ import com.mlt.converter.MltConverter;
 import com.mlt.decoder.MltDecoder;
 import com.mlt.converter.mvt.MvtUtils;
 import com.mlt.converter.mvt.ColumnMapping;
+import com.mlt.data.MapLibreTile;
+import com.mlt.converter.mvt.MapboxVectorTile;
+
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 public class MltCliAdapter {
-    private static final String FILE_NAME_ARG = "mvt";
-    private static final String OUTPUT_DIR_ARG = "output";
 
+    public static class Timer {
+        private long startTime;
+
+        public Timer() {
+            startTime = System.nanoTime();
+        }
+
+        public void restart() {
+            startTime = System.nanoTime();
+        }
+
+        public void stop(String message) {
+            long endTime = System.nanoTime();
+            long elapsedTime = (endTime - startTime) / 1000000; // divide by 1000000 to get milliseconds
+            System.out.println("Time elapsed for " + message + ": " + elapsedTime + " milliseconds");
+        }
+    }
+
+    public static void printMVT(MapboxVectorTile mvTile){
+        var mvtLayers = mvTile.layers();
+        for(var i = 0; i < mvtLayers.size(); i++){
+            var mvtLayer = mvtLayers.get(i);
+            System.out.println(mvtLayer.name());
+            var mvtFeatures = mvtLayer.features();
+            for(var j = 0; j < mvtFeatures.size(); j++){
+                var mvtFeature = mvtFeatures.get(j);
+                System.out.println("  " + mvtFeature);
+            }
+        }
+    }
+
+    public static void printMLT(MapLibreTile mlTile){
+        var mltLayers = mlTile.layers();
+        for(var i = 0; i < mltLayers.size(); i++){
+            var mltLayer = mltLayers.get(i);
+            System.out.println(mltLayer.name());
+            var mltFeatures = mltLayer.features();
+            for(var j = 0; j < mltFeatures.size(); j++){
+                var mltFeature = mltFeatures.get(j);
+                System.out.println("  " + mltFeature);
+            }
+        }
+    }
+
+    public static void compare(MapLibreTile mlTile, MapboxVectorTile mvTile){
+        var mltLayers = mlTile.layers();
+        var mvtLayers = mvTile.layers();
+        if (mltLayers.size() != mvtLayers.size()) {
+            throw new RuntimeException("Number of layers in MLT and MVT tiles do not match");
+        }
+        for(var i = 0; i < mvtLayers.size(); i++){
+            var mltLayer = mltLayers.get(i);
+            var mvtLayer = mvtLayers.get(i);
+            var mltFeatures = mltLayer.features();
+            var mvtFeatures = mvtLayer.features();
+            if (mltFeatures.size() != mvtFeatures.size()) {
+                throw new RuntimeException("Number of features in MLT and MVT layers do not match");
+            }
+            for(var j = 0; j < mvtFeatures.size(); j++){
+                var mvtFeature = mvtFeatures.get(j);
+                var mltFeature = mltFeatures.stream().filter(f -> f.id() == mvtFeature.id()).findFirst().get();
+                if (mvtFeature.id() != mltFeature.id()) {
+                    throw new RuntimeException("Feature IDs in MLT and MVT layers do not match: " + mvtFeature.id() + " != " + mltFeature.id());
+                }
+                var mltGeometry = mltFeature.geometry();
+                var mvtGeometry = mvtFeature.geometry();
+                if (!mltGeometry.equals(mvtGeometry)) {
+                    throw new RuntimeException("Geometries in MLT and MVT layers do not match: " + mvtGeometry + " != " + mltGeometry);
+                }
+                var mltProperties = mltFeature.properties();
+                var mvtProperties = mvtFeature.properties();
+                if (mvtProperties.size() != mltProperties.size()) {
+                    throw new RuntimeException("Number of properties in MLT and MVT features do not match");
+                }
+                var mvtPropertyKeys = mvtProperties.keySet();
+                var mltPropertyKeys = mltProperties.keySet();
+                // compare keys
+                if (!mvtPropertyKeys.equals(mltPropertyKeys)) {
+                    throw new RuntimeException("Property keys in MLT and MVT features do not match");
+                }
+                // compare values
+                var equalValues = mvtProperties.keySet()
+                    .stream()
+                    .allMatch(key -> mvtProperties.get(key).equals(mltProperties.get(key)));
+                if (!equalValues) {
+                    throw new RuntimeException("Property values in MLT and MVT features do not match: \n'" + mvtProperties + "'\n'" + mltProperties + "'");
+                }
+            }
+        }
+    }
+
+    private static final String FILE_NAME_ARG = "mvt";
+    private static final String OUTPUT_DIR_ARG = "dir";
+    private static final String OUTPUT_FILE_ARG = "mlt";
+    private static final String ADVANCED_ENCODING_OPTION = "advanced";
+    private static final String DECODE_OPTION = "decode";
+    private static final String PRINT_MLT_OPTION = "printmlt";
+    private static final String PRINT_MVT_OPTION = "printmvt";
+    private static final String COMPARE_OPTION = "compare";
     public static void main(String[] args) {
         Options options = new Options();
         options.addOption(Option.builder(FILE_NAME_ARG)
             .hasArg(true)
-            .desc("Path to the MVT file to convert ([REQUIRED])")
+            .desc("Path to the input MVT file to read ([REQUIRED])")
             .required(true)
             .build());
         options.addOption(Option.builder(OUTPUT_DIR_ARG)
             .hasArg(true)
-            .desc("Output directory to write the converted MLT file to ([REQUIRED])")
-            .required(true)
+            .desc("Output directory to write an MLT file to ([OPTIONAL], default: no file is written)")
+            .required(false)
+            .build());
+        options.addOption(Option.builder(OUTPUT_FILE_ARG)
+            .hasArg(true)
+            .desc("Output file to write an MLT file to ([OPTIONAL], default: no file is written)")
+            .required(false)
+            .build());
+        options.addOption(Option.builder(ADVANCED_ENCODING_OPTION)
+            .hasArg(false)
+            .desc("Enable advanced encodings (fsst & fastpfor) ([OPTIONAL], default: false")
+            .required(false)
+            .build());
+        options.addOption(Option.builder(DECODE_OPTION)
+            .hasArg(false)
+            .desc("Test decoding the tile after encoding it ([OPTIONAL], default: false)")
+            .required(false)
+            .build());
+        options.addOption(Option.builder(PRINT_MLT_OPTION)
+            .hasArg(false)
+            .desc("Print the MLT tile after encoding it ([OPTIONAL], default: false)")
+            .required(false)
+            .build());
+        options.addOption(Option.builder(PRINT_MVT_OPTION)
+            .hasArg(false)
+            .desc("Print the round tripped MVT tile ([OPTIONAL], default: false)")
+            .required(false)
+            .build());
+        options.addOption(Option.builder(COMPARE_OPTION)
+            .hasArg(false)
+            .desc("Assert that data in the the decoded tile is the same as the data in the input tile ([OPTIONAL], default: false)")
+            .required(false)
             .build());
         CommandLineParser parser = new DefaultParser();
         try {
@@ -44,22 +175,17 @@ public class MltCliAdapter {
             if (fileName == null) {
                 throw new ParseException("Missing required argument: " + FILE_NAME_ARG);
             }
-            var outputDir = cmd.getOptionValue(OUTPUT_DIR_ARG);
-            if (outputDir == null) {
-                throw new ParseException("Missing required argument: " + OUTPUT_DIR_ARG);
+            if (cmd.hasOption(OUTPUT_FILE_ARG) && cmd.hasOption(OUTPUT_DIR_ARG)) {
+                throw new ParseException("Cannot specify both '-" + OUTPUT_FILE_ARG + "' and '-" + OUTPUT_DIR_ARG + "' options");
             }
+            var willOutput = cmd.hasOption(OUTPUT_FILE_ARG) || cmd.hasOption(OUTPUT_DIR_ARG);
+            var useAdvancedEncodingSchemes = cmd.hasOption(ADVANCED_ENCODING_OPTION);
+            var willDecode = cmd.hasOption(DECODE_OPTION);
+            var willPrintMLT = cmd.hasOption(PRINT_MLT_OPTION);
+            var willPrintMVT = cmd.hasOption(PRINT_MVT_OPTION);
+            var willCompare = cmd.hasOption(COMPARE_OPTION);
             var inputTilePath = Paths.get(fileName);
             var inputTileName = inputTilePath.getFileName().toString();
-            var outputTileName = String.format("%s.mlt", inputTileName.split("\\.")[0]);
-            var outputPath = Paths.get(outputDir, outputTileName);
-            System.out.println("Converting " + fileName + " to " + outputPath.toString());
-            var outputDirPath = outputPath.getParent();
-            if (!Files.exists(outputDirPath)) {
-                System.out.println("Creating directory: " + outputDirPath);
-                Files.createDirectories(outputDirPath);
-            }                
-            // TODO: fails with ../../test/fixtures/bing/mvt/4-12-6.mvt
-            // java.lang.IndexOutOfBoundsException: Index 6 out of bounds for length 6
             var decodedMvTile = MvtUtils.decodeMvt(inputTilePath);
 
             // No ColumnMapping as support is still buggy: https://github.com/maplibre/maplibre-tile-spec/issues/59
@@ -72,17 +198,44 @@ public class MltCliAdapter {
             var optimization = new FeatureTableOptimizations(allowSorting, allowIdRegeneration, columnMappings);
             // No FeatureTableOptimizations
             var optimizations = new HashMap<String, FeatureTableOptimizations>();
-            var useAdvancedEncodingSchemes = false;
             var includeIds = true;
             var conversionConfig = new ConversionConfig(includeIds, useAdvancedEncodingSchemes, optimizations);
-            System.out.println("converting data now...");
-            long startTime = System.nanoTime();
+            Timer timer = new Timer();
             var mlTile = MltConverter.convertMvt(decodedMvTile, conversionConfig, tileMetadata);
-            long endTime = System.nanoTime();            
-            long duration = (endTime - startTime);  //divide by 1000000 to get milliseconds.
-            System.out.println("Conversion took: " + duration / 1000000 + "ms");
-            System.out.println("Writing converted tile to " + outputPath);
-            Files.write(outputPath, mlTile);
+            timer.stop("encoding");
+            if (willOutput) {
+                Path outputPath = null;
+                if (cmd.hasOption(OUTPUT_DIR_ARG)) {
+                    var outputDir = cmd.getOptionValue(OUTPUT_DIR_ARG);
+                    var outputTileName = String.format("%s.mlt", inputTileName.split("\\.")[0]);
+                    outputPath = Paths.get(outputDir, outputTileName);
+                    var outputDirPath = outputPath.getParent();
+                    if (!Files.exists(outputDirPath)) {
+                        System.out.println("Creating directory: " + outputDirPath);
+                        Files.createDirectories(outputDirPath);
+                    }
+                } else if (cmd.hasOption(OUTPUT_FILE_ARG)) {
+                    outputPath = Paths.get(cmd.getOptionValue(OUTPUT_FILE_ARG));
+                }
+                System.out.println("Writing converted tile to " + outputPath);
+                Files.write(outputPath, mlTile);
+            }
+            if (willPrintMVT) {
+                printMVT(decodedMvTile);
+            }
+            var needsDecoding = willDecode || willCompare || willPrintMLT;
+            if (needsDecoding) {
+                timer.restart();
+                // convert MLT wire format to an MapLibreTile object
+                var decodedTile = MltDecoder.decodeMlTile(mlTile, tileMetadata);
+                timer.stop("decoding");
+                if (willPrintMLT) {
+                    printMLT(decodedTile);
+                }
+                if (willCompare) {
+                    compare(decodedTile, decodedMvTile);
+                }
+            }
         } catch (Exception e) {
             e.printStackTrace();
             System.exit(1);

--- a/converter/java/src/main/java/com/mlt/converter/MltCliAdapter.java
+++ b/converter/java/src/main/java/com/mlt/converter/MltCliAdapter.java
@@ -209,13 +209,13 @@ public class MltCliAdapter {
                     var outputDir = cmd.getOptionValue(OUTPUT_DIR_ARG);
                     var outputTileName = String.format("%s.mlt", inputTileName.split("\\.")[0]);
                     outputPath = Paths.get(outputDir, outputTileName);
-                    var outputDirPath = outputPath.getParent();
-                    if (!Files.exists(outputDirPath)) {
-                        System.out.println("Creating directory: " + outputDirPath);
-                        Files.createDirectories(outputDirPath);
-                    }
                 } else if (cmd.hasOption(OUTPUT_FILE_ARG)) {
                     outputPath = Paths.get(cmd.getOptionValue(OUTPUT_FILE_ARG));
+                }
+                var outputDirPath = outputPath.getParent();
+                if (!Files.exists(outputDirPath)) {
+                    System.out.println("Creating directory: " + outputDirPath);
+                    Files.createDirectories(outputDirPath);
                 }
                 System.out.println("Writing converted tile to " + outputPath);
                 Files.write(outputPath, mlTile);


### PR DESCRIPTION
I'd like to use the java CLI tool to:

 - Find tiles we don't yet support
 - Debug why conversion is not correct if something fails
 - Write both to a directory and to an individual file
 - Test decoding the MLT wire format to ensure that works without errors
 - Compare the decoded MLT with the original MVT it is based on
 - Be able to toggle advanced encoding options on and off

This PR accomplishes all these features with new options.