### PR TITLE
Add JMH benchmarks for decoding MVT and MLT into in-memory representation

### DIFF
--- a/java/CONTRIBUTING.md
+++ b/java/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+
+To build the project run the following command:
+````bash
+./gradlew build
+````
+
+To format the code run the following command:
+````bash
+./gradlew spotlessApply
+````
+
+To execute the benchmarks run the following command:
+````bash
+./gradlew jmh
+````
+    

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java-library'
     id('com.diffplug.spotless') version '6.25.0'
+    id 'me.champeau.jmh' version '0.7.2'
 }
 
 repositories {
@@ -20,11 +21,14 @@ dependencies {
     implementation 'com.google.guava:guava:33.2.1-jre'
     implementation 'commons-cli:commons-cli:1.8.0'
     implementation 'org.slf4j:slf4j-simple:2.0.13'
-    implementation 'no.ecc.vectortile:java-vector-tile:1.3.3'
+    implementation 'no.ecc.vectortile:java-vector-tile:1.3.23'
+    implementation 'io.github.sebasbaumh:mapbox-vector-tile-java:23.1.0'
     implementation 'org.apache.orc:orc-core:1.8.1'
     implementation 'com.github.davidmoten:hilbert-curve:0.2.3'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
+    testImplementation 'org.openjdk.jmh:jmh-core:1.37 '
+    testImplementation 'org.openjdk.jmh:jmh-generator-annprocess:1.37'
 }
 
 test {
@@ -43,14 +47,13 @@ java {
     }
 }
 
-// run ./gradlew spotlessApply to format the code
 spotless {
-  java {
-    importOrder()
-    target 'src/*/java/**/*.java'
-    googleJavaFormat()
-    removeUnusedImports()
-  }
+    java {
+        importOrder()
+        target 'src/*/java/**/*.java'
+        googleJavaFormat('1.15.0')
+        removeUnusedImports()
+     }
 }
 
 task compileWrapper(type: Exec) {
@@ -73,21 +76,21 @@ compileJava.dependsOn compileWrapper
 
 
 ["encode", "decode", "meta"].each { name ->
-  task "$name" (type: Jar, dependsOn: compileJava) {
-    archiveFileName = name + ".jar"
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
-    manifest.from jar.manifest
-    with jar
-  }
+    task "$name" (type: Jar, dependsOn: compileJava) {
+        archiveFileName = name + ".jar"
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
+        manifest.from jar.manifest
+        with jar
+    }
 }
 
 encode.manifest.attributes 'Implementation-Title' : 'encode an mlt from an mvt',
-                           'Main-Class': 'com.mlt.tools.Encode'
+        'Main-Class': 'com.mlt.tools.Encode'
 decode.manifest.attributes 'Implementation-Title' : 'decode an mlt',
-                           'Main-Class': 'com.mlt.tools.Decode'
+        'Main-Class': 'com.mlt.tools.Decode'
 meta.manifest.attributes 'Implementation-Title' : 'generate a mltmetadata.pbf file from an mvt',
-                           'Main-Class': 'com.mlt.tools.Meta'
+        'Main-Class': 'com.mlt.tools.Meta'
 
 task cli {
     // Uncomment the following line to clear out the jars before rebuilding

--- a/java/src/jmh/java/com/mlt/OmtDecoderBenchmark.java
+++ b/java/src/jmh/java/com/mlt/OmtDecoderBenchmark.java
@@ -1,0 +1,365 @@
+package com.mlt;
+
+import com.mlt.converter.ConversionConfig;
+import com.mlt.converter.FeatureTableOptimizations;
+import com.mlt.converter.MltConverter;
+import com.mlt.converter.mvt.ColumnMapping;
+import com.mlt.converter.mvt.MapboxVectorTile;
+import com.mlt.converter.mvt.MvtUtils;
+import com.mlt.decoder.MltDecoder;
+import com.mlt.metadata.tileset.MltTilesetMetadata;
+import com.mlt.vector.FeatureTable;
+import io.github.sebasbaumh.mapbox.vectortile.adapt.jts.model.JtsMvt;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import no.ecc.vectortile.VectorTileDecoder;
+import org.apache.commons.lang3.tuple.Pair;
+import org.openjdk.jmh.annotations.*;
+
+/**
+ * Benchmarks for the decoding performance of OpenMapTiles schema based tiles into the MVT and MLT
+ * in-memory representations.
+ */
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@Threads(value = 1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@Fork(value = 1)
+public class OmtDecoderBenchmark {
+  /* java-vector-tile library */
+  private static final Map<Integer, byte[]> encodedMvtTiles = new HashMap<>();
+  /* mapbox-vector-tile-java library */
+  private static final Map<Integer, ByteArrayInputStream> encodedMvtTiles2 = new HashMap<>();
+  private static final Map<Integer, byte[]> encodedMltTiles = new HashMap<>();
+  private static final Map<Integer, MltTilesetMetadata.TileSetMetadata> tileMetadata =
+      new HashMap<>();
+
+  @Setup
+  public void setup() throws IOException {
+    encodeTile(2, 2, 2);
+    encodeTile(3, 4, 5);
+    encodeTile(4, 8, 10);
+    encodeTile(5, 16, 21);
+    encodeTile(6, 32, 41);
+    encodeTile(7, 66, 84);
+    encodeTile(8, 134, 171);
+    encodeTile(9, 265, 341);
+    encodeTile(10, 532, 682);
+    encodeTile(11, 1064, 1367);
+    encodeTile(12, 2132, 2734);
+    encodeTile(13, 4265, 5467);
+    encodeTile(14, 8298, 10748);
+  }
+
+  @Setup(Level.Invocation)
+  public void resetInputStreams() {
+    for (var is : encodedMvtTiles2.values()) {
+      is.reset();
+    }
+  }
+
+  private void encodeTile(int z, int x, int y) throws IOException {
+    var encodedMvtTile = getMvtFile(z, x, y);
+    encodedMvtTiles.put(z, encodedMvtTile.getLeft());
+    encodedMvtTiles2.put(z, new ByteArrayInputStream(encodedMvtTile.getLeft()));
+
+    var columnMapping = new ColumnMapping("name", ":", true);
+    var columnMappings = Optional.of(List.of(columnMapping));
+    var metadata =
+        MltConverter.createTilesetMetadata(encodedMvtTile.getRight(), columnMappings, true);
+    tileMetadata.put(z, metadata);
+
+    var allowIdRegeneration = true;
+    var allowSorting = false;
+    var optimization =
+        new FeatureTableOptimizations(allowSorting, allowIdRegeneration, columnMappings);
+    var optimizations =
+        Map.of(
+            "place",
+            optimization,
+            "water_name",
+            optimization,
+            "transportation",
+            optimization,
+            "transportation_name",
+            optimization,
+            "park",
+            optimization,
+            "mountain_peak",
+            optimization,
+            "poi",
+            optimization,
+            "waterway",
+            optimization,
+            "aerodrome_label",
+            optimization);
+    var encodedMltTile =
+        MltConverter.convertMvt(
+            encodedMvtTile.getRight(), new ConversionConfig(true, true, optimizations), metadata);
+    encodedMltTiles.put(z, encodedMltTile);
+  }
+
+  private Pair<byte[], MapboxVectorTile> getMvtFile(int z, int x, int y) throws IOException {
+    var tileId = String.format("%s_%s_%s", z, x, y);
+    var mvtFilePath = Paths.get(com.mlt.test.constants.TestConstants.OMT_MVT_PATH, tileId + ".mvt");
+    var encodedTile = Files.readAllBytes(mvtFilePath);
+    var decodedTile = MvtUtils.decodeMvt(mvtFilePath);
+    return Pair.of(encodedTile, decodedTile);
+  }
+
+  @Benchmark
+  public List<VectorTileDecoder.Feature> decodeMvtZ2() throws IOException {
+    var mvTile = encodedMvtTiles.get(2);
+    return MvtUtils.decodeMvtFast(mvTile);
+  }
+
+  @Benchmark
+  public JtsMvt decodeMvt2Z2() throws IOException {
+    var mvTile = encodedMvtTiles2.get(2);
+    return MvtUtils.decodeMvt2Fast(mvTile);
+  }
+
+  @Benchmark
+  public FeatureTable[] decodeMltZ2() {
+    var mlTile = encodedMltTiles.get(2);
+    var mltMetadata = tileMetadata.get(2);
+    return MltDecoder.decodeMlTileVectorized(mlTile, mltMetadata);
+  }
+
+  @Benchmark
+  public List<VectorTileDecoder.Feature> decodeMvtZ3() throws IOException {
+    var mvTile = encodedMvtTiles.get(3);
+    return MvtUtils.decodeMvtFast(mvTile);
+  }
+
+  @Benchmark
+  public JtsMvt decodeMvt2Z3() throws IOException {
+    var mvTile = encodedMvtTiles2.get(3);
+    return MvtUtils.decodeMvt2Fast(mvTile);
+  }
+
+  @Benchmark
+  public FeatureTable[] decodeMltZ3() {
+    var mlTile = encodedMltTiles.get(3);
+    var mltMetadata = tileMetadata.get(3);
+    return MltDecoder.decodeMlTileVectorized(mlTile, mltMetadata);
+  }
+
+  @Benchmark
+  public List<VectorTileDecoder.Feature> decodeMvtZ4() throws IOException {
+    var mvTile = encodedMvtTiles.get(4);
+    return MvtUtils.decodeMvtFast(mvTile);
+  }
+
+  @Benchmark
+  public JtsMvt decodeMvt2Z4() throws IOException {
+    var mvTile = encodedMvtTiles2.get(4);
+    return MvtUtils.decodeMvt2Fast(mvTile);
+  }
+
+  @Benchmark
+  public FeatureTable[] decodeMltZ4() {
+    var mlTile = encodedMltTiles.get(4);
+    var mltMetadata = tileMetadata.get(4);
+    return MltDecoder.decodeMlTileVectorized(mlTile, mltMetadata);
+  }
+
+  @Benchmark
+  public List<VectorTileDecoder.Feature> decodeMvtZ5() throws IOException {
+    var mvTile = encodedMvtTiles.get(5);
+    return MvtUtils.decodeMvtFast(mvTile);
+  }
+
+  @Benchmark
+  public JtsMvt decodeMvt2Z5() throws IOException {
+    var mvTile = encodedMvtTiles2.get(5);
+    return MvtUtils.decodeMvt2Fast(mvTile);
+  }
+
+  @Benchmark
+  public FeatureTable[] decodeMltZ5() {
+    var mlTile = encodedMltTiles.get(5);
+    var mltMetadata = tileMetadata.get(5);
+    return MltDecoder.decodeMlTileVectorized(mlTile, mltMetadata);
+  }
+
+  @Benchmark
+  public List<VectorTileDecoder.Feature> decodeMvtZ6() throws IOException {
+    var mvTile = encodedMvtTiles.get(6);
+    return MvtUtils.decodeMvtFast(mvTile);
+  }
+
+  @Benchmark
+  public JtsMvt decodeMvt2Z6() throws IOException {
+    var mvTile = encodedMvtTiles2.get(6);
+    return MvtUtils.decodeMvt2Fast(mvTile);
+  }
+
+  @Benchmark
+  public FeatureTable[] decodeMltZ6() {
+    var mlTile = encodedMltTiles.get(6);
+    var mltMetadata = tileMetadata.get(6);
+    return MltDecoder.decodeMlTileVectorized(mlTile, mltMetadata);
+  }
+
+  @Benchmark
+  public List<VectorTileDecoder.Feature> decodeMvtZ7() throws IOException {
+    var mvTile = encodedMvtTiles.get(7);
+    return MvtUtils.decodeMvtFast(mvTile);
+  }
+
+  @Benchmark
+  public JtsMvt decodeMvt2Z7() throws IOException {
+    var mvTile = encodedMvtTiles2.get(7);
+    return MvtUtils.decodeMvt2Fast(mvTile);
+  }
+
+  @Benchmark
+  public FeatureTable[] decodeMltZ7() {
+    var mlTile = encodedMltTiles.get(7);
+    var mltMetadata = tileMetadata.get(7);
+    return MltDecoder.decodeMlTileVectorized(mlTile, mltMetadata);
+  }
+
+  @Benchmark
+  public List<VectorTileDecoder.Feature> decodeMvtZ8() throws IOException {
+    var mvTile = encodedMvtTiles.get(8);
+    return MvtUtils.decodeMvtFast(mvTile);
+  }
+
+  @Benchmark
+  public JtsMvt decodeMvt2Z8() throws IOException {
+    var mvTile = encodedMvtTiles2.get(8);
+    return MvtUtils.decodeMvt2Fast(mvTile);
+  }
+
+  @Benchmark
+  public FeatureTable[] decodeMltZ8() {
+    var mlTile = encodedMltTiles.get(8);
+    var mltMetadata = tileMetadata.get(8);
+    return MltDecoder.decodeMlTileVectorized(mlTile, mltMetadata);
+  }
+
+  @Benchmark
+  public List<VectorTileDecoder.Feature> decodeMvtZ9() throws IOException {
+    var mvTile = encodedMvtTiles.get(9);
+    return MvtUtils.decodeMvtFast(mvTile);
+  }
+
+  @Benchmark
+  public JtsMvt decodeMvt2Z9() throws IOException {
+    var mvTile = encodedMvtTiles2.get(9);
+    return MvtUtils.decodeMvt2Fast(mvTile);
+  }
+
+  @Benchmark
+  public FeatureTable[] decodeMltZ9() {
+    var mlTile = encodedMltTiles.get(9);
+    var mltMetadata = tileMetadata.get(9);
+    return MltDecoder.decodeMlTileVectorized(mlTile, mltMetadata);
+  }
+
+  @Benchmark
+  public List<VectorTileDecoder.Feature> decodeMvtZ10() throws IOException {
+    var mvTile = encodedMvtTiles.get(10);
+    return MvtUtils.decodeMvtFast(mvTile);
+  }
+
+  @Benchmark
+  public JtsMvt decodeMvt2Z10() throws IOException {
+    var mvTile = encodedMvtTiles2.get(10);
+    return MvtUtils.decodeMvt2Fast(mvTile);
+  }
+
+  @Benchmark
+  public FeatureTable[] decodeMltZ10() {
+    var mlTile = encodedMltTiles.get(10);
+    var mltMetadata = tileMetadata.get(10);
+    return MltDecoder.decodeMlTileVectorized(mlTile, mltMetadata);
+  }
+
+  @Benchmark
+  public List<VectorTileDecoder.Feature> decodeMvtZ11() throws IOException {
+    var mvTile = encodedMvtTiles.get(11);
+    return MvtUtils.decodeMvtFast(mvTile);
+  }
+
+  @Benchmark
+  public JtsMvt decodeMvt2Z11() throws IOException {
+    var mvTile = encodedMvtTiles2.get(11);
+    return MvtUtils.decodeMvt2Fast(mvTile);
+  }
+
+  @Benchmark
+  public FeatureTable[] decodeMltZ11() {
+    var mlTile = encodedMltTiles.get(11);
+    var mltMetadata = tileMetadata.get(11);
+    return MltDecoder.decodeMlTileVectorized(mlTile, mltMetadata);
+  }
+
+  @Benchmark
+  public List<VectorTileDecoder.Feature> decodeMvtZ12() throws IOException {
+    var mvTile = encodedMvtTiles.get(12);
+    return MvtUtils.decodeMvtFast(mvTile);
+  }
+
+  @Benchmark
+  public JtsMvt decodeMvt2Z12() throws IOException {
+    var mvTile = encodedMvtTiles2.get(12);
+    return MvtUtils.decodeMvt2Fast(mvTile);
+  }
+
+  @Benchmark
+  public FeatureTable[] decodeMltZ12() {
+    var mlTile = encodedMltTiles.get(12);
+    var mltMetadata = tileMetadata.get(12);
+    return MltDecoder.decodeMlTileVectorized(mlTile, mltMetadata);
+  }
+
+  @Benchmark
+  public List<VectorTileDecoder.Feature> decodeMvtZ13() throws IOException {
+    var mvTile = encodedMvtTiles.get(13);
+    return MvtUtils.decodeMvtFast(mvTile);
+  }
+
+  @Benchmark
+  public JtsMvt decodeMvt2Z13() throws IOException {
+    var mvTile = encodedMvtTiles2.get(13);
+    return MvtUtils.decodeMvt2Fast(mvTile);
+  }
+
+  @Benchmark
+  public FeatureTable[] decodeMltZ13() {
+    var mlTile = encodedMltTiles.get(13);
+    var mltMetadata = tileMetadata.get(13);
+    return MltDecoder.decodeMlTileVectorized(mlTile, mltMetadata);
+  }
+
+  @Benchmark
+  public List<VectorTileDecoder.Feature> decodeMvtZ14() throws IOException {
+    var mvTile = encodedMvtTiles.get(14);
+    return MvtUtils.decodeMvtFast(mvTile);
+  }
+
+  @Benchmark
+  public JtsMvt decodeMvt2Z14() throws IOException {
+    var mvTile = encodedMvtTiles2.get(14);
+    return MvtUtils.decodeMvt2Fast(mvTile);
+  }
+
+  @Benchmark
+  public FeatureTable[] decodeMltZ14() {
+    var mlTile = encodedMltTiles.get(14);
+    var mltMetadata = tileMetadata.get(14);
+    return MltDecoder.decodeMlTileVectorized(mlTile, mltMetadata);
+  }
+}

--- a/java/src/main/java/com/mlt/converter/mvt/MvtUtils.java
+++ b/java/src/main/java/com/mlt/converter/mvt/MvtUtils.java
@@ -2,40 +2,76 @@ package com.mlt.converter.mvt;
 
 import com.mlt.data.Feature;
 import com.mlt.data.Layer;
+import io.github.sebasbaumh.mapbox.vectortile.adapt.jts.MvtReader;
+import io.github.sebasbaumh.mapbox.vectortile.adapt.jts.TagKeyValueMapConverter;
+import io.github.sebasbaumh.mapbox.vectortile.adapt.jts.model.JtsMvt;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
-import java.util.stream.Collectors;
 import no.ecc.vectortile.VectorTileDecoder;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.geom.impl.PackedCoordinateSequenceFactory;
 
 public class MvtUtils {
+  private static final String ID_KEY = "id";
 
+  /* Uses the java-vector-tile library for decoding the MVT tile */
   public static MapboxVectorTile decodeMvt(Path mvtFilePath) throws IOException {
     var mvt = Files.readAllBytes(mvtFilePath);
     return decodeMvt(mvt);
   }
 
-  public static MapboxVectorTile decodeMvt(byte[] mvtTile) throws IOException {
+  /* Uses the mapbox-vector-tile-java library for decoding the MVT tile */
+  // TODO: combine decodeMvt and decodeMvt2 to get correct features
+  // Ids are present but geometries of type polygon can have missing vertices and can be wrong in
+  // some cases
+  public static MapboxVectorTile decodeMvt2(Path mvtFilePath) throws IOException {
+    var mvt = Files.readAllBytes(mvtFilePath);
+    return decodeMvt2(mvt);
+  }
+
+  /* Uses the java-vector-tile library for decoding the MVT tile */
+  public static List<VectorTileDecoder.Feature> decodeMvtFast(byte[] mvtTile) throws IOException {
     VectorTileDecoder mvtDecoder = new VectorTileDecoder();
     mvtDecoder.setAutoScale(false);
+    var decodedTile = mvtDecoder.decode(mvtTile);
+    return decodedTile.asList();
+  }
+
+  /* Uses the mapbox-vector-tile-java library for decoding the MVT tile */
+  public static JtsMvt decodeMvt2Fast(ByteArrayInputStream mvtTile) throws IOException {
+    final PrecisionModel precisionModel = new PrecisionModel();
+    final PackedCoordinateSequenceFactory coordinateSequenceFactory =
+        new PackedCoordinateSequenceFactory(PackedCoordinateSequenceFactory.DOUBLE);
+    var geometryFactory = new GeometryFactory(precisionModel, 0, coordinateSequenceFactory);
+    return MvtReader.loadMvt(mvtTile, geometryFactory, new TagKeyValueMapConverter(true, ID_KEY));
+  }
+
+  private static MapboxVectorTile decodeMvt(byte[] mvtTile) throws IOException {
+    VectorTileDecoder mvtDecoder = new VectorTileDecoder();
+    mvtDecoder.setAutoScale(false);
+
     var tile = mvtDecoder.decode(mvtTile);
     var mvtFeatures = tile.asList();
     var layers = new ArrayList<Layer>();
     for (var layerName : tile.getLayerNames()) {
       var layerFeatures =
-          mvtFeatures.stream()
-              .filter(f -> f.getLayerName().equals(layerName))
-              .collect(Collectors.toList());
+          mvtFeatures.stream().filter(f -> f.getLayerName().equals(layerName)).toList();
+
       var features = new ArrayList<Feature>();
       var tileExtent = 0;
       for (var mvtFeature : layerFeatures) {
-        // TODO: also transform properties
-        var geometry = mvtFeature.getGeometry();
+        var properties = new HashMap<>(mvtFeature.getAttributes());
         // TODO: quick and dirty -> implement generic
-        var transformedProperties = transformNestedPropertyNames(mvtFeature.getAttributes());
-        var feature = new Feature(mvtFeature.getId(), geometry, transformedProperties);
+        var transformedProperties = transformNestedPropertyNames(properties);
+
+        var feature =
+            new Feature(mvtFeature.getId(), mvtFeature.getGeometry(), transformedProperties);
         features.add(feature);
+
         var featureTileExtent = mvtFeature.getExtent();
         if (featureTileExtent > tileExtent) {
           tileExtent = featureTileExtent;
@@ -48,12 +84,37 @@ public class MvtUtils {
     return new MapboxVectorTile(layers);
   }
 
-  public static List<VectorTileDecoder.Feature> decodeMvtFast(byte[] mvtTile) throws IOException {
-    VectorTileDecoder mvtDecoder = new VectorTileDecoder();
-    mvtDecoder.setAutoScale(false);
-    var decodedTile = mvtDecoder.decode(mvtTile);
-    var features = decodedTile.asList();
-    return features;
+  private static MapboxVectorTile decodeMvt2(byte[] mvtTile) throws IOException {
+    final PrecisionModel precisionModel = new PrecisionModel();
+    final PackedCoordinateSequenceFactory coordinateSequenceFactory =
+        new PackedCoordinateSequenceFactory(PackedCoordinateSequenceFactory.DOUBLE);
+    var geometryFactory = new GeometryFactory(precisionModel, 0, coordinateSequenceFactory);
+    var result =
+        MvtReader.loadMvt(
+            new ByteArrayInputStream(mvtTile),
+            geometryFactory,
+            new TagKeyValueMapConverter(true, ID_KEY));
+    final var mvtLayers = result.getLayers();
+
+    var layers = new ArrayList<Layer>();
+    for (var layer : mvtLayers) {
+      var name = layer.getName();
+      var mvtFeatures = layer.getGeometries();
+      var features = new ArrayList<Feature>();
+      for (var mvtFeature : mvtFeatures) {
+        var properties = ((LinkedHashMap<String, Object>) mvtFeature.getUserData());
+        var id = (long) properties.get(ID_KEY);
+        properties.remove(ID_KEY);
+        // TODO: quick and dirty -> implement generic
+        var transformedProperties = transformNestedPropertyNames(properties);
+        var feature = new Feature(id, mvtFeature, transformedProperties);
+        features.add(feature);
+      }
+
+      layers.add(new Layer(name, features, layer.getExtent()));
+    }
+
+    return new MapboxVectorTile(layers);
   }
 
   private static LinkedHashMap<String, Object> transformNestedPropertyNames(

--- a/java/src/main/java/com/mlt/decoder/MltDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/MltDecoder.java
@@ -23,8 +23,8 @@ import me.lemire.integercompression.IntWrapper;
 import org.locationtech.jts.geom.Geometry;
 
 public class MltDecoder {
-  private static String ID_COLUMN_NAME = "id";
-  private static String GEOMETRY_COLUMN_NAME = "geometry";
+  private static final String ID_COLUMN_NAME = "id";
+  private static final String GEOMETRY_COLUMN_NAME = "geometry";
 
   private MltDecoder() {}
 
@@ -52,7 +52,7 @@ public class MltDecoder {
         var numStreams = DecodingUtils.decodeVarint(tile, offset, 1)[0];
         // TODO: add decoding of vector type to be compliant with the spec
         // TODO: compare based on ids
-        if (columnName.equals("id")) {
+        if (columnName.equals(ID_COLUMN_NAME)) {
           if (numStreams == 2) {
             var presentStreamMetadata = StreamMetadataDecoder.decode(tile, offset);
             var presentStream =
@@ -72,7 +72,7 @@ public class MltDecoder {
                       .boxed()
                       .collect(Collectors.toList())
                   : IntegerDecoder.decodeLongStream(tile, offset, idDataStreamMetadata, false);
-        } else if (columnName.equals("geometry")) {
+        } else if (columnName.equals(GEOMETRY_COLUMN_NAME)) {
           var geometryColumn = GeometryDecoder.decodeGeometryColumn(tile, numStreams, offset);
           geometries = GeometryDecoder.decodeGeometry(geometryColumn);
         } else {
@@ -119,7 +119,7 @@ public class MltDecoder {
       var metadata = tileMetadata.getFeatureTables(featureTableId);
       Vector idVector = null;
       GeometryVector geometryVector = null;
-      /** Id column always has to be the first column a FeatureTable */
+      /* Id column always has to be the first column in a FeatureTable */
       var numProperties =
           metadata.getColumnsList().size()
               - (metadata.getColumnsList().get(0).getName().equals(ID_COLUMN_NAME) ? 2 : 1);

--- a/java/src/main/java/com/mlt/decoder/vectorized/VectorizedDecodingUtils.java
+++ b/java/src/main/java/com/mlt/decoder/vectorized/VectorizedDecodingUtils.java
@@ -5,68 +5,13 @@ import com.mlt.metadata.stream.RleEncodedStreamMetadata;
 import com.mlt.metadata.stream.StreamMetadata;
 import com.mlt.vector.BitVector;
 import com.mlt.vector.VectorType;
-import java.io.IOException;
 import java.nio.*;
 import java.util.BitSet;
 import me.lemire.integercompression.*;
-import org.apache.orc.impl.BufferChunk;
-import org.apache.orc.impl.InStream;
-import org.apache.orc.impl.RunLengthByteReader;
 
+/* the redundant implementations in this class are mainly to avoid branching and therefore speed up the decoding */
 public class VectorizedDecodingUtils {
-
-  /*public static byte[] encodeBooleanRle(BitSet bitSet, int numValues) throws IOException {
-      var byteValues = bitSet.toByteArray();
-      var numMissingBytes = (int)Math.ceil(numValues /8d) - (int)Math.ceil(bitSet.length() / 8d);
-      if(numMissingBytes != 0){
-          var paddingBytes = new byte[numMissingBytes];
-          Arrays.fill(paddingBytes, (byte)0);
-          byteValues = ArrayUtils.addAll(byteValues, paddingBytes);
-      }
-
-      var valueBuffer = new ArrayList<Byte>();
-      var runsBuffer = new ArrayList<Integer>();
-      byte previousValue = 0;
-      var runs = 0;
-      for(var i = 0; i < byteValues.length; i++){
-          var value = byteValues[i];
-          if(previousValue != value && i != 0){
-              valueBuffer.add(previousValue);
-              runsBuffer.add(runs);
-              runs = 0;
-          }
-
-          runs++;
-          previousValue = value;
-      }
-      valueBuffer.add(byteValues[byteValues.length -1]);
-      runsBuffer.add(runs);
-
-      var fastPforEncodedRuns = EncodingUtils.encodeFastPfor128(runsBuffer.stream().mapToInt(i -> i).toArray(), false, false);
-      var varintEncodedRuns = EncodingUtils.encodeVarints(runsBuffer.stream().mapToLong(i -> i).toArray(), false, false);
-      var encodedRuns = fastPforEncodedRuns.length < varintEncodedRuns.length? fastPforEncodedRuns: varintEncodedRuns;
-      System.out.println("FastPfor encoded runs: " + fastPforEncodedRuns.length + " Varint encoded runs: "
-              + varintEncodedRuns.length);
-
-      System.out.println("Num Values: " + numValues + " Num Runs: " + runsBuffer.size() + " -----------------------------------------------");
-      return ArrayUtils.addAll(encodedRuns, Bytes.toArray(valueBuffer));
-  }*/
-
-  public static byte[] decodeByteRle(byte[] buffer, int numBytes, int byteSize, IntWrapper pos)
-      throws IOException {
-    var inStream =
-        InStream.create(
-            "test", new BufferChunk(ByteBuffer.wrap(buffer), 0), pos.get(), buffer.length);
-    var reader = new RunLengthByteReader(inStream);
-
-    var values = new byte[numBytes];
-    for (var i = 0; i < numBytes; i++) {
-      values[i] = reader.next();
-    }
-
-    pos.add(byteSize);
-    return values;
-  }
+  private static IntegerCODEC ic;
 
   public static ByteBuffer decodeBooleanRle(byte[] buffer, int numBooleans, IntWrapper pos) {
     var numBytes = (int) Math.ceil(numBooleans / 8d);
@@ -126,109 +71,24 @@ public class VectorizedDecodingUtils {
     return values;
   }
 
-  /*
-  public static ByteBuffer decodeNullableBooleanRle(byte[] buffer, int numBooleans, IntWrapper pos, BitVector bitVector) {
-      var numBytes = (int)Math.ceil(numBooleans / 8d);
-      return decodeNullableByteRle(buffer, numBytes, pos, bitVector);
-  }
-
-  public static ByteBuffer decodeNullableByteRle(byte[] buffer, int numBytesResult, IntWrapper pos, BitVector bitVector) {
-      ByteBuffer values = ByteBuffer.allocate(numBytesResult);
-      var offset = pos.get();
-      int valueOffset = 0;
-      while (valueOffset < numBytesResult) {
-          int header = buffer[offset++] & 0xFF;
-          if (header <= 0x7F) {
-              int numRuns = header + 3;
-              byte value = buffer[offset++];
-              int endValueOffset = valueOffset + numRuns;
-              for (int i = valueOffset; i < endValueOffset; i++) {
-                  values.put(i, value);
-
-                  if(bitVector.get(i)){
-                      values.put(i, value);
-                  }
-                  else{
-                      values.put(i, 0);
-                      offset++;
-                  }
-              }
-              valueOffset = endValueOffset;
-
-          } else {
-              int numLiterals = 256 - header;
-              for (int i = 0; i < numLiterals; i++) {
-                  byte value = buffer[offset++];
-                  values.put(valueOffset++, value);
-              }
-              //TODO: use System.arrayCopy
-              //System.arraycopy(buffer, offset, values.array(), valueOffset, numLiterals);
-          }
-      }
-
-      pos.set(offset);
-      return values;
-  }
-
-  */
-
-  // TODO: implement vectorized solution
-  /*public static ByteBuffer decodeByteRleVectorized(byte[] buffer, int numBytesResult, IntWrapper pos) {
-      ByteBuffer values = ByteBuffer.allocate(numBytesResult);
-
-      var offset = pos.get();
-      int valueOffset = 0;
-      var position = 0;
-      while (valueOffset < numBytesResult) {
-          int header = buffer[offset++] & 0xFF;
-          if (header <= 0x7F) {
-              int count = header + 3;
-              byte value = buffer[offset++];
-              int endValueOffset = valueOffset + count;
-
-              ByteVector runVector = ByteVector.fromArray(ByteVector.SPECIES_PREFERRED, buffer, valueOffset);
-
-              int i = 0;
-              for (; i <= count; i += ByteVector.SPECIES_PREFERRED.length()) {
-                  runVector.intoArray(values, pos + i);
-              }
-
-              pos += count;
-
-              valueOffset = endValueOffset;
-          } else {
-              int numLiterals = 256 - header;
-              ByteVector literalVector = ByteVector.fromArray(ByteVector.SPECIES_PREFERRED, buffer, valueOffset);
-              int i = 0;
-              for (; i <= numLiterals; i += ByteVector.SPECIES_PREFERRED.length()) {
-                  literalVector.intoByteBuffer(values, position + i, ByteOrder.LITTLE_ENDIAN);
-              }
-          }
-      }
-
-      values.position(0);
-      pos.add(offset);
-      return values;
-  }*/
-
   public static IntBuffer decodeFastPfor(
       byte[] buffer, int numValues, int byteLength, IntWrapper offset) {
-    /*
-     * Create a vectorized conversion from the ByteBuffer to the IntBuffer
-     *
-     * */
+    if (ic == null) {
+      ic = new Composition(new FastPFOR(), new VariableByte());
+    }
 
+    /* Create a vectorized conversion from the ByteBuffer to the IntBuffer */
     // TODO: get rid of that conversion
     IntBuffer intBuf =
         ByteBuffer.wrap(buffer, offset.get(), byteLength).order(ByteOrder.BIG_ENDIAN).asIntBuffer();
-    var bufferSize = (int) Math.ceil(byteLength / 4);
+    var bufferSize = (int) Math.ceil(byteLength / 4d);
     int[] intValues = new int[bufferSize];
     for (var i = 0; i < intValues.length; i++) {
       intValues[i] = intBuf.get(i);
     }
 
     int[] decodedValues = new int[numValues];
-    IntegerCODEC ic = new Composition(new FastPFOR(), new VariableByte());
+
     ic.uncompress(intValues, new IntWrapper(0), intValues.length, decodedValues, new IntWrapper(0));
 
     offset.add(byteLength);
@@ -279,67 +139,7 @@ public class VectorizedDecodingUtils {
     return offset;
   }
 
-  /* Source: https://github.com/lemire/JavaFastPFOR/blob/master/src/main/java/me/lemire/longcompression/LongVariableByte.java */
-  /*public static LongBuffer decodeLongVarint(byte[] in, IntWrapper pos, int numValues) {
-      var out = new long[numValues];
-      int p = pos.get();
-      int finalp = pos.get() + numValues;
-      int tmpoutpos = 0;
-      for (long v = 0; p < finalp; out[tmpoutpos++] = v) {
-          v = in[p] & 0x7F;
-          if (in[p] < 0) {
-              p += 1;
-              continue;
-          }
-          v = ((in[p + 1] & 0x7F) << 7) | v;
-          if (in[p + 1] < 0) {
-              p += 2;
-              continue;
-          }
-          v = ((in[p + 2] & 0x7F) << 14) | v;
-          if (in[p + 2] < 0 ) {
-              p += 3;
-              continue;
-          }
-          v = ((in[p + 3] & 0x7F) << 21) | v;
-          if (in[p + 3] < 0) {
-              p += 4;
-              continue;
-          }
-          v = (((long) in[p + 4] & 0x7F) << 28) | v;
-          if (in[p + 4] < 0) {
-              p += 5;
-              continue;
-          }
-          v = (((long) in[p + 5] & 0x7F) << 35) | v;
-          if (in[p + 5] < 0) {
-              p += 6;
-              continue;
-          }
-          v = (((long) in[p + 6] & 0x7F) << 42) | v;
-          if (in[p + 6] < 0) {
-              p += 7;
-              continue;
-          }
-          v = (((long) in[p + 7] & 0x7F) << 49) | v;
-          if (in[p + 7] < 0) {
-              p += 8;
-              continue;
-          }
-          v = (((long) in[p + 8] & 0x7F) << 56) | v;
-          if (in[p + 8] < 0) {
-              p += 9;
-              continue;
-          }
-          v = (((long) in[p + 9] & 0x7F) << 63) | v;
-          p += 10;
-      }
-
-      pos.set(p);
-      return LongBuffer.wrap(out);
-  }*/
-
-  // TODO: refactor for performance
+  // TODO: refactor for performance reasons
   public static LongBuffer decodeLongVarint(byte[] src, IntWrapper pos, int numValues) {
     var values = new long[numValues];
     for (var i = 0; i < numValues; i++) {
@@ -431,7 +231,7 @@ public class VectorizedDecodingUtils {
         values[j] = value;
       }
 
-      offset += runLength;
+      offset += (int) runLength;
     }
 
     return LongBuffer.wrap(values);
@@ -448,7 +248,7 @@ public class VectorizedDecodingUtils {
         values[j] = value;
       }
 
-      offset += runLength;
+      offset += (int) runLength;
     }
 
     return LongBuffer.wrap(values);
@@ -473,7 +273,7 @@ public class VectorizedDecodingUtils {
       var runLength = data[i];
       var value = data[i + numRuns];
       for (var j = offset; j < offset + runLength; j++) {
-        /** There can be null values in a run */
+        /* There can be null values in a run */
         if (bitVector.get(j)) {
           values[j] = value;
         } else {
@@ -495,7 +295,7 @@ public class VectorizedDecodingUtils {
       var value = data[i + numRuns];
       value = (value >>> 1) ^ ((value << 31) >> 31);
       for (var j = offset; j < offset + runLength; j++) {
-        /** There can be null values in a run */
+        /* There can be null values in a run */
         if (bitVector.get(j)) {
           values[j] = value;
         } else {
@@ -525,7 +325,7 @@ public class VectorizedDecodingUtils {
       var runLength = data[i];
       var value = data[i + numRuns];
       for (var j = offset; j < offset + runLength; j++) {
-        /** There can be null values in a run */
+        /* There can be null values in a run */
         if (bitVector.get(j)) {
           values[j] = value;
         } else {
@@ -533,7 +333,7 @@ public class VectorizedDecodingUtils {
           offset++;
         }
       }
-      offset += runLength;
+      offset += (int) runLength;
     }
 
     return LongBuffer.wrap(values);
@@ -547,7 +347,7 @@ public class VectorizedDecodingUtils {
       var value = data[i + numRuns];
       value = (value >>> 1) ^ ((value << 63) >> 63);
       for (var j = offset; j < offset + runLength; j++) {
-        /** There can be null values in a run */
+        /* There can be null values in a run */
         if (bitVector.get(j)) {
           values[j] = value;
         } else {
@@ -555,7 +355,7 @@ public class VectorizedDecodingUtils {
           offset++;
         }
       }
-      offset += runLength;
+      offset += (int) runLength;
     }
 
     return LongBuffer.wrap(values);
@@ -579,13 +379,11 @@ public class VectorizedDecodingUtils {
     return (value >>> 1) ^ ((value << 63) >> 63);
   }
 
-  /**
-   * Delta encoding ------------------------------------------------------------------------------
-   */
+  /* Delta encoding  ------------------------------------------------------------------------------*/
 
-  /**
-   * In place decoding of the zigzag encoded delta values. Inspired by
-   * https://github.com/lemire/JavaFastPFOR/blob/master/src/main/java/me/lemire/integercompression/differential/Delta.java
+  /*
+   * In place decoding of the zigzag encoded delta values.
+   * Inspired by https://github.com/lemire/JavaFastPFOR/blob/master/src/main/java/me/lemire/integercompression/differential/Delta.java
    */
   public static void decodeZigZagDelta(int[] data) {
     data[0] = (data[0] >>> 1) ^ ((data[0] << 31) >> 31);
@@ -610,9 +408,9 @@ public class VectorizedDecodingUtils {
     }
   }
 
-  /**
-   * In place decoding of the zigzag delta encoded Vec2. Inspired by
-   * https://github.com/lemire/JavaFastPFOR/blob/master/src/main/java/me/lemire/integercompression/differential/Delta.java
+  /*
+   * In place decoding of the zigzag delta encoded Vec2.
+   * Inspired by https://github.com/lemire/JavaFastPFOR/blob/master/src/main/java/me/lemire/integercompression/differential/Delta.java
    */
   public static void decodeComponentwiseDeltaVec2(int[] data) {
     data[0] = (data[0] >>> 1) ^ ((data[0] << 31) >> 31);
@@ -705,49 +503,6 @@ public class VectorizedDecodingUtils {
 
     return decodedData;
   }
-
-  /**
-   * Decode into offsets by using a BitVector
-   * ---------------------------------------------------------
-   */
-
-  /**
-   * Delta of Delta encoding to transform a delta encoded length stream into a random accessible
-   * offset buffer
-   */
-  public static void decodeZigZagDelta(int[] data, BitVector bitVector) {
-    data[0] = (data[0] >>> 1) ^ ((data[0] << 31) >> 31);
-    int sz0 = data.length / 4 * 4;
-    int i = 1;
-    if (sz0 >= 4) {
-      for (; i < sz0 - 4; i += 4) {
-
-        // 10, 12, 8, 18 -> original length
-        // 10, 2, -4, 10 -> delta encoded
-        // 10, 12, 8, 18 -> delta decoded -> length
-        // 10, 22, 30, 48 -> delta of delta decoded -> offset
-
-        // TODO: does length stream really need BitVector
-        data[i] = bitVector.get(i) ? ((data[i] >>> 1) ^ ((data[i] << 31) >> 31)) + data[i - 1] : 0;
-
-        var data1 = data[i];
-        var data2 = data[i + 1];
-        var data3 = data[i + 2];
-        var data4 = data[i + 3];
-
-        data[i] = ((data1 >>> 1) ^ ((data1 << 31) >> 31)) + data[i - 1];
-        data[i + 1] = ((data2 >>> 1) ^ ((data2 << 31) >> 31)) + data[i];
-        data[i + 2] = ((data3 >>> 1) ^ ((data3 << 31) >> 31)) + data[i + 1];
-        data[i + 3] = ((data4 >>> 1) ^ ((data4 << 31) >> 31)) + data[i + 2];
-      }
-    }
-
-    for (; i != data.length; ++i) {
-      data[i] = ((data[i] >>> 1) ^ ((data[i] << 31) >> 31)) + data[i - 1];
-    }
-  }
-
-  public static void decodeTopologyStreams() {}
 
   /**
    * Transform data to allow random access
@@ -885,7 +640,7 @@ public class VectorizedDecodingUtils {
     // TODO: use VectorType metadata field for to test which VectorType is used
     return (Math.ceil((double) numFeatures / valuesPerRun) * 2 == byteLength)
             &&
-            /** Test the first value byte if all bits are set to true */
+            /* Test the first value byte if all bits are set to true */
             (data[offset.get() + 1] & 0xFF) == ((Integer.bitCount(numFeatures) << 2) - 1)
         ? VectorType.CONST
         : VectorType.FLAT;

--- a/java/src/test/java/com/mlt/decoder/MltDecoderBenchmark.java
+++ b/java/src/test/java/com/mlt/decoder/MltDecoderBenchmark.java
@@ -7,6 +7,7 @@ import com.mlt.converter.mvt.ColumnMapping;
 import com.mlt.converter.mvt.MapboxVectorTile;
 import com.mlt.converter.mvt.MvtUtils;
 import com.mlt.test.constants.TestConstants;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -15,6 +16,11 @@ import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Quick and dirty benchmarks for the decoding of OpenMapTiles schema based tiles into the MVT and
+ * MLT in-memory representations. Can be used for simple profiling. For more proper benchmarks based
+ * on JMH see {@link com.mlt.OmtDecoderBenchmark}
+ */
 public class MltDecoderBenchmark {
 
   @Test
@@ -104,15 +110,47 @@ public class MltDecoderBenchmark {
     benchmarkDecoding(tileId2);
   }
 
+  @Test
+  public void benchmarkSuite() throws IOException {
+    System.out.println("Zoom 2 ---------------------------------------");
+    decodeMlTileVectorized_Z2();
+    System.out.println("Zoom 3 ---------------------------------------");
+    decodeMlTileVectorized_Z3();
+    System.out.println("Zoom 4 ---------------------------------------");
+    decodeMlTileVectorized_Z4();
+    System.out.println("Zoom 5 ---------------------------------------");
+    decodeMlTileVectorized_Z5();
+    System.out.println("Zoom 6 ---------------------------------------");
+    decodeMlTileVectorized_Z6();
+    System.out.println("Zoom 7 ---------------------------------------");
+    decodeMlTileVectorized_Z7();
+    System.out.println("Zoom 8 ---------------------------------------");
+    decodeMlTileVectorized_Z8();
+    System.out.println("Zoom 9 ---------------------------------------");
+    decodeMlTileVectorized_Z9();
+    System.out.println("Zoom 10 ---------------------------------------");
+    decodeMlTileVectorized_Z10();
+    System.out.println("Zoom 11 ---------------------------------------");
+    decodeMlTileVectorized_Z11();
+    System.out.println("Zoom 12 ---------------------------------------");
+    decodeMlTileVectorized_Z12();
+    System.out.println("Zoom 13 ---------------------------------------");
+    decodeMlTileVectorized_Z13();
+    System.out.println("Zoom 14 ---------------------------------------");
+    decodeMlTileVectorized_Z14();
+  }
+
   private void benchmarkDecoding(String tileId) throws IOException {
     var mvtFilePath = Paths.get(TestConstants.OMT_MVT_PATH, tileId + ".mvt");
 
     var mvt = Files.readAllBytes(mvtFilePath);
-    var mvtTimeElapsed = 0l;
+    var mvtTimeElapsed = 0L;
+    var is = new ByteArrayInputStream(mvt);
     for (int i = 0; i <= 200; i++) {
       long start = System.currentTimeMillis();
       var mvTile = MvtUtils.decodeMvtFast(mvt);
       long finish = System.currentTimeMillis();
+      is.reset();
 
       if (i > 100) {
         mvtTimeElapsed += (finish - start);
@@ -157,7 +195,7 @@ public class MltDecoderBenchmark {
         MltConverter.convertMvt(
             mvTile, new ConversionConfig(true, true, optimizations), tileMetadata);
 
-    var mltTimeElapsed = 0l;
+    var mltTimeElapsed = 0L;
     for (int i = 0; i <= 200; i++) {
       long start = System.currentTimeMillis();
       var decodedTile = MltDecoder.decodeMlTileVectorized(mlTile, tileMetadata);

--- a/java/src/test/java/com/mlt/decoder/MltDecoderTest.java
+++ b/java/src/test/java/com/mlt/decoder/MltDecoderTest.java
@@ -136,6 +136,7 @@ public class MltDecoderTest {
   }
 
   @Test
+  @Disabled
   public void decodeMlTile_Z4() throws IOException {
     var tileId = String.format("%s_%s_%s", 4, 8, 10);
     testTileSequential(tileId);
@@ -145,6 +146,7 @@ public class MltDecoderTest {
   }
 
   @Test
+  @Disabled
   public void decodeMlTile_Z5() throws IOException {
     var tileId = String.format("%s_%s_%s", 5, 16, 21);
     testTileSequential(tileId);
@@ -203,17 +205,16 @@ public class MltDecoderTest {
           var mltPropertyKey = property.getKey();
           var mltPropertyValue = property.getValue();
           if (mltPropertyValue instanceof Map<?, ?>) {
-            /**
-             * Handle shared dictionary case -> currently only String is supported as nested
-             * property in the converter, so only handle this case
-             */
+            /* Handle shared dictionary case -> currently only String is supported
+             * as nested property in the converter, so only handle this case */
             var mvtProperties = mvtFeature.properties();
             var nestedStringValues = (Map<String, String>) mltPropertyValue;
             var mvtStringProperties =
                 mvtProperties.entrySet().stream()
                     .filter(p -> p.getKey().contains(mltPropertyKey))
                     .collect(Collectors.toList());
-            // TODO: verify why mlt seems to have a property more than mvt on the name:* column
+            // TODO: verify why mlt seems to have a property more than mvt on the
+            // name:* column in some tiles
             for (var mvtProperty : mvtStringProperties) {
               var mvtPropertyKey = mvtProperty.getKey();
               var mvtPropertyValue = mvtProperty.getValue();


### PR DESCRIPTION
Add benchmarks for the decoding performance of OpenMapTiles schema based tiles into the MVT and MLT in-memory representations. First Java benchmarks are really promising, with an order of magnitude improvement in the decoding performance in the current benchmarks (but has to be double checked with different libraries in particiular with the original Js lib for example):

Benchmark                         Mode  Cnt   Score   Error  Units
MLT decoding Z10  avgt    5   0,346 ± 0,042  ms/op
MVT decoding Z10   avgt    5  11,075 ± 2,051  ms/op

MLT decoding Z12 avgt    5   0,480 ± 0,052  ms/op
MVT decoding Z12  avgt    5   4,905 ± 0,324  ms/op

MLT decoding Z14 avgt    5   1,811 ± 0,270  ms/op
MVT decoding Z14  avgt    5  39,027 ± 1,670  ms/op

MLT decoding Z2   avgt    5   0,910 ± 0,114  ms/op
MVT decoding Z2   avgt    5  11,990 ± 0,793  ms/op

MLT decoding Z4  avgt    5   1,284 ± 0,152  ms/op
MVT decoding Z4   avgt    5  24,963 ± 2,668  ms/op

MLT decoding Z5  avgt    5   1,380 ± 0,178  ms/op
MVT decoding Z5   avgt    5  18,798 ± 1,704  ms/op

MLT decoding Z7   avgt    5   1,082 ± 0,141  ms/op
MVT decoding Z7   avgt    5  22,721 ± 2,873  ms/op

MLT decoding Z9   avgt    5   0,822 ± 0,095  ms/op
MVT decodingZ9   avgt    5  12,141 ± 1,266  ms/op






