### PR TITLE
Minor workflow adjustments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     defaults:
       run:
         working-directory: 'java'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: test
 
 on:
   push:
+    branches: [ "main" ]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,7 @@ name: test
 
 on:
   push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
   workflow_dispatch:
 
 defaults:
@@ -29,9 +27,8 @@ jobs:
   test-java:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
     defaults:
       run:
         working-directory: 'java'


### PR DESCRIPTION
 - Remove macOS runner to save resources (the macOS runner has a [10x minute multiplier](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#minute-multipliers), so it is more likely to lead to hitting the 2000 minute limit)
   - Testing on ubuntu is reliable enough predictor of macOS support
 - Remove `fail-fast` option so that we default back to failing fast if any platform fails. This is also useful to save resources.
 - Start allowing workflow runs on any branch or PR. This will allow for better developer flow since @ebrelsford and I are soon planning to target non-main branches in PRs soon as we work to improve the JS decoder.