### PR TITLE
[java][cli] use absolute path to avoid parent being null

### DIFF
--- a/java/src/main/java/com/mlt/converter/MltCliAdapter.java
+++ b/java/src/main/java/com/mlt/converter/MltCliAdapter.java
@@ -219,7 +219,7 @@ public class MltCliAdapter {
                 } else if (cmd.hasOption(OUTPUT_FILE_ARG)) {
                     outputPath = Paths.get(cmd.getOptionValue(OUTPUT_FILE_ARG));
                 }
-                var outputDirPath = outputPath.getParent();
+                var outputDirPath = outputPath.toAbsolutePath().getParent();
                 if (!Files.exists(outputDirPath)) {
                     System.out.println("Creating directory: " + outputDirPath);
                     Files.createDirectories(outputDirPath);


### PR DESCRIPTION
Small fix to avoid an error if you pass an argument to the cli like `-mlt tile.mlt` without a directory in the name.