### PR TITLE
[js][decoder] add intWrapper class + tests

### DIFF
--- a/js/src/decoder/intWrapper.ts
+++ b/js/src/decoder/intWrapper.ts
@@ -1,0 +1,26 @@
+// Ported from https://github.com/lemire/JavaFastPFOR/blob/master/src/main/java/me/lemire/integercompression/IntWrapper.java
+
+export class IntWrapper {
+    private value: number;
+
+    constructor(private readonly v: number) {
+        this.value = v;
+    }
+
+    public get(): number {
+        return this.value;
+    }
+
+    public set(v: number): void {
+        this.value = v;
+    }
+
+    public increment(): number {
+        return this.value++;
+    }
+
+    public add(v: number): void {
+        this.value += v;
+    }
+
+}

--- a/js/test/unit/decoder/intWrapper.spect.ts
+++ b/js/test/unit/decoder/intWrapper.spect.ts
@@ -1,0 +1,12 @@
+import { IntWrapper } from "../../../src/decoder/intWrapper";
+
+describe("IntWrapper", () => {
+    it("should wrap an int like it says it can", async () => {
+        const intWrapper = new IntWrapper(5);
+        expect(intWrapper.get()).toBe(5);
+        intWrapper.set(6);
+        expect(intWrapper.get()).toBe(6);
+        intWrapper.increment();
+        expect(intWrapper.get()).toBe(7);
+    });
+});


### PR DESCRIPTION
Started looking into missing functionality for the JS decoder. Java uses this small `intWrapper` class everywhere, so it seems wise to mimic the class in TS. This adds it + tests. Done against `main` instead of #81 since this code is new, working, tested, and simple. Will pull this back into #81 after it lands and I need it there.