### PR TITLE
[java] drop unused roaringbitmap, fasterxml, and sqlite-jdbc

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -14,16 +14,13 @@ version '1.0-SNAPSHOT'
 
 dependencies {
     implementation 'me.lemire.integercompression:JavaFastPFOR:0.1.12'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.0'
     implementation 'io.github.sebasbaumh:mapbox-vector-tile-java:23.1.0'
-    implementation 'org.xerial:sqlite-jdbc:3.41.2.1'
     implementation 'com.google.guava:guava:31.1-jre'
     implementation 'commons-cli:commons-cli:1.4'
     implementation 'org.slf4j:slf4j-simple:2.0.13'
     implementation 'no.ecc.vectortile:java-vector-tile:1.3.1'
     implementation 'org.apache.orc:orc-core:1.8.1'
     implementation 'com.github.davidmoten:hilbert-curve:0.2.2'
-    implementation 'org.roaringbitmap:RoaringBitmap:0.9.38'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 }


### PR DESCRIPTION
Removes a few dependencies declared in the build.gradle but not actually used in the code.