### PR TITLE
Java encoding and decoding improvements & fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,17 @@ jobs:
           cache-dependency-path: 'js/package-lock.json'
       - run: npm ci
       - run: npm test
+  format-java:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - uses: gradle/actions/setup-gradle@v3
+      - name: Java build
+        run: ./gradlew build # includes spotlessJavaCheck
   test-java:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -40,8 +51,6 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - uses: gradle/actions/setup-gradle@v3
-      - name: Java build
-        run: ./gradlew build # includes spotlessJavaCheck
       - name: Java converter tests
         run: ./gradlew test
       - name: Test running CLI
@@ -68,7 +77,7 @@ jobs:
     name: CI Finished
     runs-on: ubuntu-latest
     # List of all the other jobs that must pass for this job to start
-    needs: [ test-java, test-js ]
+    needs: [ test-java, test-js, format-java ]
     steps:
       - name: Finished
         run: echo "CI finished successfully"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
     name: CI Finished
     runs-on: ubuntu-latest
     # List of all the other jobs that must pass for this job to start
-    needs: [ test-java, test-js, format-java ]
+    needs: [ test-java, test-js ]
     steps:
       - name: Finished
         run: echo "CI finished successfully"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,8 +37,8 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - uses: gradle/actions/setup-gradle@v3
-      - name: Java build
-        run: ./gradlew build # includes spotlessJavaCheck
+      - name: Java formatting check
+        run: ./gradlew spotlessJavaCheck
   test-java:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,9 @@ jobs:
       - run: npm test
   format-java:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: 'java'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/java/src/main/java/com/mlt/cli/CliUtil.java
+++ b/java/src/main/java/com/mlt/cli/CliUtil.java
@@ -1,0 +1,48 @@
+package com.mlt.tools;
+
+import com.mlt.data.MapLibreTile;
+import com.mlt.vector.FeatureTable;
+
+public class CliUtil {
+
+  private CliUtil() {}
+
+  public static void decodeFeatureTables(FeatureTable[] featureTables) {
+    for (var i = 0; i < featureTables.length; i++) {
+      var featureTable = featureTables[i];
+      var featureIterator = featureTable.iterator();
+      while (featureIterator.hasNext()) {
+        var mltFeature = featureIterator.next();
+        // Trigger decoding of the feature
+        mltFeature.id();
+        mltFeature.geometry();
+        mltFeature.properties();
+      }
+    }
+  }
+
+  public static void printMLT(MapLibreTile mlTile) {
+    var mltLayers = mlTile.layers();
+    for (var i = 0; i < mltLayers.size(); i++) {
+      var mltLayer = mltLayers.get(i);
+      System.out.println(mltLayer.name());
+      var mltFeatures = mltLayer.features();
+      for (var j = 0; j < mltFeatures.size(); j++) {
+        var mltFeature = mltFeatures.get(j);
+        System.out.println("  " + mltFeature);
+      }
+    }
+  }
+
+  public static void printMLTVectorized(FeatureTable[] featureTables) {
+    for (var i = 0; i < featureTables.length; i++) {
+      var featureTable = featureTables[i];
+      System.out.println(featureTable.getName());
+      var featureIterator = featureTable.iterator();
+      while (featureIterator.hasNext()) {
+        var mltFeature = featureIterator.next();
+        System.out.println("  " + mltFeature);
+      }
+    }
+  }
+}

--- a/java/src/main/java/com/mlt/cli/Decode.java
+++ b/java/src/main/java/com/mlt/cli/Decode.java
@@ -43,6 +43,7 @@ public class Decode {
   private static final String FILE_NAME_ARG = "mlt";
   private static final String PRINT_MLT_OPTION = "printmlt";
   private static final String VECTORIZED_OPTION = "vectorized";
+  private static final String TIMER_OPTION = "timer";
 
   public static void main(String[] args) {
     Options options = new Options();
@@ -65,6 +66,12 @@ public class Decode {
             .desc("Print the MLT tile after encoding it ([OPTIONAL], default: false)")
             .required(false)
             .build());
+    options.addOption(
+        Option.builder(TIMER_OPTION)
+            .hasArg(false)
+            .desc("Print the time it takes, in ms, to decode a tile ([OPTIONAL])")
+            .required(false)
+            .build());
     CommandLineParser parser = new DefaultParser();
     try {
       CommandLine cmd = parser.parse(options, args);
@@ -74,6 +81,7 @@ public class Decode {
       }
       var willPrintMLT = cmd.hasOption(PRINT_MLT_OPTION);
       var willUseVectorized = cmd.hasOption(VECTORIZED_OPTION);
+      var willTime = cmd.hasOption(TIMER_OPTION);
       var inputTilePath = Paths.get(fileName);
       if (!Files.exists(inputTilePath)) {
         throw new IllegalArgumentException("Input mlt tile path does not exist: " + inputTilePath);
@@ -91,13 +99,13 @@ public class Decode {
       Timer timer = new Timer();
       if (willUseVectorized) {
         var decodedTile = MltDecoder.decodeMlTileVectorized(mltTileBuffer, tileMetadata);
-        timer.stop("decoding");
+        if (willTime) timer.stop("decoding");
         if (willPrintMLT) {
           printMLTVectorized(decodedTile);
         }
       } else {
         var decodedTile = MltDecoder.decodeMlTile(mltTileBuffer, tileMetadata);
-        timer.stop("decoding");
+        if (willTime) timer.stop("decoding");
         if (willPrintMLT) {
           printMLT(decodedTile);
         }

--- a/java/src/main/java/com/mlt/cli/Encode.java
+++ b/java/src/main/java/com/mlt/cli/Encode.java
@@ -62,6 +62,20 @@ public class Encode {
     }
   }
 
+  private static void decodeFeatureTables(FeatureTable[] featureTables) {
+    for (var i = 0; i < featureTables.length; i++) {
+      var featureTable = featureTables[i];
+      var featureIterator = featureTable.iterator();
+      while (featureIterator.hasNext()) {
+        var mltFeature = featureIterator.next();
+        // Trigger decoding of the feature
+        mltFeature.id();
+        mltFeature.geometry();
+        mltFeature.properties();
+      }
+    }
+  }
+
   public static void compare(MapLibreTile mlTile, MapboxVectorTile mvTile) {
     var mltLayers = mlTile.layers();
     var mvtLayers = mvTile.layers();
@@ -277,14 +291,19 @@ public class Encode {
         timer.restart();
         // convert MLT wire format to an MapLibreTile object
         if (willUseVectorized) {
-          var decodedTile = MltDecoder.decodeMlTileVectorized(mlTile, tileMetadata);
+          var featureTables = MltDecoder.decodeMlTileVectorized(mlTile, tileMetadata);
+          // Note: the vectorized result is a FeatureTable array
+          // which provides an iterator to access the features.
+          // Therefore, we must iterate over the FeatureTable array
+          // to trigger actual decoding of the features.
+          decodeFeatureTables(featureTables);
           if (willTime) timer.stop("decoding");
           if (willPrintMLT) {
-            printMLTVectorized(decodedTile);
+            printMLTVectorized(featureTables);
           }
           // TODO: Implement vectorized compare
           // if (willCompare) {
-          //     compareVectorized(decodedTile, decodedMvTile);
+          //     compareVectorized(featureTables, decodedMvTile);
           // }
         } else {
           var decodedTile = MltDecoder.decodeMlTile(mlTile, tileMetadata);

--- a/java/src/main/java/com/mlt/cli/Encode.java
+++ b/java/src/main/java/com/mlt/cli/Encode.java
@@ -8,7 +8,6 @@ import com.mlt.converter.mvt.MapboxVectorTile;
 import com.mlt.converter.mvt.MvtUtils;
 import com.mlt.data.MapLibreTile;
 import com.mlt.decoder.MltDecoder;
-import com.mlt.vector.FeatureTable;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -33,45 +32,6 @@ public class Encode {
       for (var j = 0; j < mvtFeatures.size(); j++) {
         var mvtFeature = mvtFeatures.get(j);
         System.out.println("  " + mvtFeature);
-      }
-    }
-  }
-
-  public static void printMLT(MapLibreTile mlTile) {
-    var mltLayers = mlTile.layers();
-    for (var i = 0; i < mltLayers.size(); i++) {
-      var mltLayer = mltLayers.get(i);
-      System.out.println(mltLayer.name());
-      var mltFeatures = mltLayer.features();
-      for (var j = 0; j < mltFeatures.size(); j++) {
-        var mltFeature = mltFeatures.get(j);
-        System.out.println("  " + mltFeature);
-      }
-    }
-  }
-
-  private static void printMLTVectorized(FeatureTable[] featureTables) {
-    for (var i = 0; i < featureTables.length; i++) {
-      var featureTable = featureTables[i];
-      System.out.println(featureTable.getName());
-      var featureIterator = featureTable.iterator();
-      while (featureIterator.hasNext()) {
-        var mltFeature = featureIterator.next();
-        System.out.println("  " + mltFeature);
-      }
-    }
-  }
-
-  private static void decodeFeatureTables(FeatureTable[] featureTables) {
-    for (var i = 0; i < featureTables.length; i++) {
-      var featureTable = featureTables[i];
-      var featureIterator = featureTable.iterator();
-      while (featureIterator.hasNext()) {
-        var mltFeature = featureIterator.next();
-        // Trigger decoding of the feature
-        mltFeature.id();
-        mltFeature.geometry();
-        mltFeature.properties();
       }
     }
   }
@@ -296,10 +256,10 @@ public class Encode {
           // which provides an iterator to access the features.
           // Therefore, we must iterate over the FeatureTable array
           // to trigger actual decoding of the features.
-          decodeFeatureTables(featureTables);
+          CliUtil.decodeFeatureTables(featureTables);
           if (willTime) timer.stop("decoding");
           if (willPrintMLT) {
-            printMLTVectorized(featureTables);
+            CliUtil.printMLTVectorized(featureTables);
           }
           // TODO: Implement vectorized compare
           // if (willCompare) {
@@ -309,7 +269,7 @@ public class Encode {
           var decodedTile = MltDecoder.decodeMlTile(mlTile, tileMetadata);
           if (willTime) timer.stop("decoding");
           if (willPrintMLT) {
-            printMLT(decodedTile);
+            CliUtil.printMLT(decodedTile);
           }
           if (willCompare) {
             compare(decodedTile, decodedMvTile);

--- a/java/src/main/java/com/mlt/cli/Encode.java
+++ b/java/src/main/java/com/mlt/cli/Encode.java
@@ -201,11 +201,11 @@ public class Encode {
             .required(false)
             .build());
     options.addOption(
-      Option.builder(TIMER_OPTION)
-          .hasArg(false)
-          .desc("Print the time it takes, in ms, to decode a tile ([OPTIONAL])")
-          .required(false)
-          .build());
+        Option.builder(TIMER_OPTION)
+            .hasArg(false)
+            .desc("Print the time it takes, in ms, to decode a tile ([OPTIONAL])")
+            .required(false)
+            .build());
     CommandLineParser parser = new DefaultParser();
     try {
       CommandLine cmd = parser.parse(options, args);

--- a/java/src/main/java/com/mlt/converter/encodings/GeometryEncoder.java
+++ b/java/src/main/java/com/mlt/converter/encodings/GeometryEncoder.java
@@ -17,6 +17,7 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.MultiLineString;
+import org.locationtech.jts.geom.MultiPoint;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
@@ -100,8 +101,23 @@ public class GeometryEncoder {
             }
             break;
           }
+        case Geometry.TYPENAME_MULTIPOINT:
+          {
+            geometryTypes.add(GeometryType.MULTIPOINT.ordinal());
+            var multiPoint = (MultiPoint) geometry;
+            var numPoints = multiPoint.getNumGeometries();
+            numGeometries.add(numPoints);
+            for (var i = 0; i < numPoints; i++) {
+              var point = (Point) multiPoint.getGeometryN(i);
+              var x = (int) point.getX();
+              var y = (int) point.getY();
+              vertexBuffer.add(new Vertex(x, y));
+            }
+            break;
+          }
         default:
-          throw new IllegalArgumentException("Specified geometry type is not (yet) supported.");
+          throw new IllegalArgumentException(
+              "Specified geometry type is not (yet) supported: " + geometryType);
       }
     }
 

--- a/java/src/main/java/com/mlt/converter/encodings/PropertyEncoder.java
+++ b/java/src/main/java/com/mlt/converter/encodings/PropertyEncoder.java
@@ -246,7 +246,15 @@ public class PropertyEncoder {
     for (var feature : features) {
       var propertyValue = feature.properties().get(fieldName);
       if (propertyValue != null) {
-        values.add((float) (double) propertyValue);
+        switch (propertyValue.getClass().getSimpleName()) {
+          case "Double":
+            var doubleValue = (Double) propertyValue;
+            values.add(doubleValue.floatValue());
+            break;
+          default:
+            values.add((float) propertyValue);
+            break;
+        }
         present.add(true);
       } else {
         present.add(false);

--- a/java/src/main/java/com/mlt/converter/encodings/PropertyEncoder.java
+++ b/java/src/main/java/com/mlt/converter/encodings/PropertyEncoder.java
@@ -188,7 +188,7 @@ public class PropertyEncoder {
         }
       default:
         throw new IllegalArgumentException(
-            "The specified scalar data type is currently not supported.");
+            "The specified scalar data type is currently not supported: " + scalarType);
     }
   }
 

--- a/java/src/main/java/com/mlt/converter/encodings/PropertyEncoder.java
+++ b/java/src/main/java/com/mlt/converter/encodings/PropertyEncoder.java
@@ -103,7 +103,7 @@ public class PropertyEncoder {
                 featureScopedPropertyColumns, encodedFieldMetadata, nestedColumns.getRight());
       } else {
         throw new IllegalArgumentException(
-            "The specified data type for the field is currently not supported.");
+            "The specified data type for the field is currently not supported: " + columnMetadata);
       }
     }
 
@@ -151,6 +151,7 @@ public class PropertyEncoder {
           return CollectionUtils.concatByteArrays(encodedFieldMetadata, intColumn);
         }
       case FLOAT:
+      case DOUBLE:
         {
           var floatColumn = encodeFloatColumn(features, columnMetadata.getName());
           var encodedFieldMetadata = EncodingUtils.encodeVarints(new long[] {2}, false, false);
@@ -245,7 +246,7 @@ public class PropertyEncoder {
     for (var feature : features) {
       var propertyValue = feature.properties().get(fieldName);
       if (propertyValue != null) {
-        values.add((float) propertyValue);
+        values.add((float) (double) propertyValue);
         present.add(true);
       } else {
         present.add(false);

--- a/java/src/main/java/com/mlt/decoder/DecodingUtils.java
+++ b/java/src/main/java/com/mlt/decoder/DecodingUtils.java
@@ -274,6 +274,36 @@ public class DecodingUtils {
     return BitSet.valueOf(byteStream);
   }
 
+  public static int[] decodeUnsignedRLE(int[] data, int numRuns, int numTotalValues) {
+    var values = new int[numTotalValues];
+    var offset = 0;
+    for (var i = 0; i < numRuns; i++) {
+      var runLength = data[i];
+      var value = data[i + numRuns];
+      for (var j = offset; j < offset + runLength; j++) {
+        values[j] = value;
+      }
+
+      offset += runLength;
+    }
+    return values;
+  }
+
+  public static long[] decodeUnsignedRLE(long[] data, int numRuns, int numTotalValues) {
+    var values = new long[numTotalValues];
+    var offset = 0;
+    for (var i = 0; i < numRuns; i++) {
+      var runLength = data[i];
+      var value = data[i + numRuns];
+      for (var j = offset; j < offset + runLength; j++) {
+        values[j] = value;
+      }
+
+      offset += runLength;
+    }
+    return values;
+  }
+
   public static int[] decodeMortonCode(List<Integer> mortonCodes, ZOrderCurve zOrderCurve) {
     var vertexBuffer = new int[mortonCodes.size() * 2];
     for (var i = 0; i < mortonCodes.size(); i++) {

--- a/java/src/main/java/com/mlt/decoder/DecodingUtils.java
+++ b/java/src/main/java/com/mlt/decoder/DecodingUtils.java
@@ -181,9 +181,6 @@ public class DecodingUtils {
     var outputOffset = new IntWrapper(0);
     IntegerCODEC ic = new Composition(new FastPFOR(), new VariableByte());
     ic.uncompress(intValues, inputOffset, intValues.length, decodedValues, outputOffset);
-    ByteIntegerCODEC codec = new VariableByte();
-    FastPFOR128 fastPFOR128 = new FastPFOR128();
-    IntegratedIntCompressor iic = new IntegratedIntCompressor();
 
     pos.add(byteLength);
     return decodedValues;

--- a/java/src/main/java/com/mlt/decoder/DecodingUtils.java
+++ b/java/src/main/java/com/mlt/decoder/DecodingUtils.java
@@ -162,7 +162,7 @@ public class DecodingUtils {
     return values;
   }
 
-  public static int[] decodeFastPfor128(
+  public static int[] decodeFastPfor(
       byte[] encodedValues, int numValues, int byteLength, IntWrapper pos) {
     var encodedValuesSlice = Arrays.copyOfRange(encodedValues, pos.get(), pos.get() + byteLength);
     // TODO: get rid of that conversion
@@ -189,50 +189,7 @@ public class DecodingUtils {
     return decodedValues;
   }
 
-  public static void decodeFastPfor128Optimized(
-      byte[] buffer, IntWrapper offset, int byteLength, int[] decodedValues) {
-    // TODO: get rid of that conversion
-    IntBuffer intBuf =
-        ByteBuffer.wrap(buffer, offset.get(), byteLength)
-            // TODO: change to little endian
-            .order(ByteOrder.BIG_ENDIAN)
-            .asIntBuffer();
-    int[] intValues = new int[(int) Math.ceil(byteLength / 4)];
-    for (var i = 0; i < intValues.length; i++) {
-      intValues[i] = intBuf.get(i);
-    }
-
-    IntegerCODEC ic = new Composition(new FastPFOR(), new VariableByte());
-    ic.uncompress(intValues, new IntWrapper(0), intValues.length, decodedValues, new IntWrapper(0));
-
-    offset.add(byteLength);
-  }
-
-  public static byte[] decodeByteRle(byte[] buffer, int numBytes, int byteSize, IntWrapper pos)
-      throws IOException {
-    var inStream =
-        InStream.create(
-            "test", new BufferChunk(ByteBuffer.wrap(buffer), 0), pos.get(), buffer.length);
-    var reader = new RunLengthByteReader(inStream);
-
-    var values = new byte[numBytes];
-    for (var i = 0; i < numBytes; i++) {
-      values[i] = reader.next();
-    }
-
-    pos.add(byteSize);
-    return values;
-  }
-
-  public static BitSet decodeBooleanRle(
-      byte[] buffer, int numBooleans, int byteSize, IntWrapper pos) throws IOException {
-    var numBytes = (int) Math.ceil(numBooleans / 8d);
-    var byteStream = decodeByteRle(buffer, numBytes, byteSize, pos);
-    // TODO: get rid of that conversion
-    return BitSet.valueOf(byteStream);
-  }
-
-  public static int[] decodeFastPfor128DeltaCoordinates(
+  public static int[] decodeFastPforDeltaCoordinates(
       byte[] encodedValues, int numValues, int byteLength, IntWrapper pos) {
     var encodedValuesSlice = Arrays.copyOfRange(encodedValues, pos.get(), pos.get() + byteLength);
     // TODO: get rid of that conversion
@@ -276,6 +233,49 @@ public class DecodingUtils {
     }
 
     return values;
+  }
+
+  public static void decodeFastPforOptimized(
+      byte[] buffer, IntWrapper offset, int byteLength, int[] decodedValues) {
+    // TODO: get rid of that conversion
+    IntBuffer intBuf =
+        ByteBuffer.wrap(buffer, offset.get(), byteLength)
+            // TODO: change to little endian
+            .order(ByteOrder.BIG_ENDIAN)
+            .asIntBuffer();
+    int[] intValues = new int[(int) Math.ceil(byteLength / 4)];
+    for (var i = 0; i < intValues.length; i++) {
+      intValues[i] = intBuf.get(i);
+    }
+
+    IntegerCODEC ic = new Composition(new FastPFOR(), new VariableByte());
+    ic.uncompress(intValues, new IntWrapper(0), intValues.length, decodedValues, new IntWrapper(0));
+
+    offset.add(byteLength);
+  }
+
+  public static byte[] decodeByteRle(byte[] buffer, int numBytes, int byteSize, IntWrapper pos)
+      throws IOException {
+    var inStream =
+        InStream.create(
+            "test", new BufferChunk(ByteBuffer.wrap(buffer), 0), pos.get(), buffer.length);
+    var reader = new RunLengthByteReader(inStream);
+
+    var values = new byte[numBytes];
+    for (var i = 0; i < numBytes; i++) {
+      values[i] = reader.next();
+    }
+
+    pos.add(byteSize);
+    return values;
+  }
+
+  public static BitSet decodeBooleanRle(
+      byte[] buffer, int numBooleans, int byteSize, IntWrapper pos) throws IOException {
+    var numBytes = (int) Math.ceil(numBooleans / 8d);
+    var byteStream = decodeByteRle(buffer, numBytes, byteSize, pos);
+    // TODO: get rid of that conversion
+    return BitSet.valueOf(byteStream);
   }
 
   public static int[] decodeMortonCode(List<Integer> mortonCodes, ZOrderCurve zOrderCurve) {

--- a/java/src/main/java/com/mlt/decoder/DecodingUtils.java
+++ b/java/src/main/java/com/mlt/decoder/DecodingUtils.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 import me.lemire.integercompression.*;
-import me.lemire.integercompression.differential.IntegratedIntCompressor;
 import org.apache.orc.impl.BufferChunk;
 import org.apache.orc.impl.InStream;
 import org.apache.orc.impl.RunLengthByteReader;

--- a/java/src/main/java/com/mlt/decoder/GeometryDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/GeometryDecoder.java
@@ -62,19 +62,20 @@ public class GeometryDecoder {
         case DATA:
           if (DictionaryType.VERTEX.equals(
               geometryStreamMetadata.logicalStreamType().dictionaryType())) {
-            // TODO: add Varint decoding
             if (geometryStreamMetadata.physicalLevelTechnique()
-                != PhysicalLevelTechnique.FAST_PFOR) {
-              throw new IllegalArgumentException(
-                  "Currently only FastPfor encoding supported for the VertexBuffer.");
+                == PhysicalLevelTechnique.FAST_PFOR) {
+              var vertexBuffer =
+                  DecodingUtils.decodeFastPforDeltaCoordinates(
+                      tile,
+                      geometryStreamMetadata.numValues(),
+                      geometryStreamMetadata.byteLength(),
+                      offset);
+              vertexList = Arrays.stream(vertexBuffer).boxed().collect(Collectors.toList());
+            } else {
+              System.out.println("Decoding VARINT stream.");
+              vertexList =
+                  IntegerDecoder.decodeIntStream(tile, offset, geometryStreamMetadata, true);
             }
-            var vertexBuffer =
-                DecodingUtils.decodeFastPforDeltaCoordinates(
-                    tile,
-                    geometryStreamMetadata.numValues(),
-                    geometryStreamMetadata.byteLength(),
-                    offset);
-            vertexList = Arrays.stream(vertexBuffer).boxed().collect(Collectors.toList());
           } else {
             vertexList =
                 IntegerDecoder.decodeMortonStream(

--- a/java/src/main/java/com/mlt/decoder/GeometryDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/GeometryDecoder.java
@@ -218,13 +218,13 @@ public class GeometryDecoder {
           for (var i = 0; i < numPolygons; i++) {
             var numRings = partOffsets.get(partOffsetCounter++);
             var rings = new LinearRing[numRings - 1];
-            numVertices += ringOffsets.get(ringOffsetsCounter++);
+            numVertices = ringOffsets.get(ringOffsetsCounter++);
             LinearRing shell =
                 getLinearRing(vertexBuffer, vertexBufferOffset, numVertices, geometryFactory);
             vertexBufferOffset += numVertices * 2;
             for (var j = 0; j < rings.length; j++) {
               var numRingVertices = ringOffsets.get(ringOffsetsCounter++);
-              rings[i] =
+              rings[j] =
                   getLinearRing(vertexBuffer, vertexBufferOffset, numRingVertices, geometryFactory);
               vertexBufferOffset += numVertices * 2;
             }
@@ -236,14 +236,14 @@ public class GeometryDecoder {
           for (var i = 0; i < numPolygons; i++) {
             var numRings = partOffsets.get(partOffsetCounter++);
             var rings = new LinearRing[numRings - 1];
-            numVertices += ringOffsets.get(ringOffsetsCounter++);
+            numVertices = ringOffsets.get(ringOffsetsCounter++);
             LinearRing shell =
                 decodeDictionaryEncodedLinearRing(
                     vertexBuffer, vertexOffsets, vertexOffsetsOffset, numVertices, geometryFactory);
             vertexOffsetsOffset += numVertices;
             for (var j = 0; j < rings.length; j++) {
               numVertices = ringOffsets.get(ringOffsetsCounter++);
-              rings[i] =
+              rings[j] =
                   decodeDictionaryEncodedLinearRing(
                       vertexBuffer,
                       vertexOffsets,

--- a/java/src/main/java/com/mlt/decoder/GeometryDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/GeometryDecoder.java
@@ -252,10 +252,9 @@ public class GeometryDecoder {
                       geometryFactory);
               vertexOffsetsOffset += numVertices;
             }
-
             polygons[i] = geometryFactory.createPolygon(shell, rings);
-            geometries[geometryCounter++] = geometryFactory.createMultiPolygon(polygons);
           }
+          geometries[geometryCounter++] = geometryFactory.createMultiPolygon(polygons);
         }
       } else {
         throw new IllegalArgumentException(

--- a/java/src/main/java/com/mlt/decoder/GeometryDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/GeometryDecoder.java
@@ -124,6 +124,27 @@ public class GeometryDecoder {
           var coordinate = new Coordinate(x, y);
           geometries[geometryCounter++] = geometryFactory.createPoint(coordinate);
         }
+      } else if (geometryType.equals(GeometryType.MULTIPOINT.ordinal())) {
+        var numPoints = geometryOffsets.get(geometryOffsetsCounter++);
+        var points = new Point[numPoints];
+        if (vertexOffsets == null || vertexOffsets.length == 0) {
+          for (var i = 0; i < numPoints; i++) {
+            var x = vertexBuffer[vertexBufferOffset++];
+            var y = vertexBuffer[vertexBufferOffset++];
+            var coordinate = new Coordinate(x, y);
+            points[i] = geometryFactory.createPoint(coordinate);
+          }
+          geometries[geometryCounter++] = geometryFactory.createMultiPoint(points);
+        } else {
+          for (var i = 0; i < numPoints; i++) {
+            var offset = vertexOffsets[vertexOffsetsOffset++] * 2;
+            var x = vertexBuffer[offset];
+            var y = vertexBuffer[offset + 1];
+            var coordinate = new Coordinate(x, y);
+            points[i] = geometryFactory.createPoint(coordinate);
+          }
+          geometries[geometryCounter++] = geometryFactory.createMultiPoint(points);
+        }
       } else if (geometryType.equals(GeometryType.LINESTRING.ordinal())) {
         if (vertexOffsets == null || vertexOffsets.length == 0) {
           var numVertices = partOffsets.get(partOffsetCounter++);
@@ -238,7 +259,7 @@ public class GeometryDecoder {
         }
       } else {
         throw new IllegalArgumentException(
-            "The specified geometry type is currently not supported.");
+            "The specified geometry type is currently not supported: " + geometryType);
       }
     }
 
@@ -301,6 +322,30 @@ public class GeometryDecoder {
         }
         if (ringOffsets != null) {
           ringOffsetsCounter++;
+        }
+      } else if (geometryType == GeometryType.MULTIPOINT.ordinal()) {
+        var numPoints =
+            geometryOffsets.get(geometryOffsetsCounter)
+                - geometryOffsets.get(geometryOffsetsCounter - 1);
+        geometryOffsetsCounter++;
+        var points = new Point[numPoints];
+        if (vertexOffsets == null || vertexOffsets.length == 0) {
+          for (var j = 0; j < numPoints; j++) {
+            var x = vertexBuffer[vertexBufferOffset++];
+            var y = vertexBuffer[vertexBufferOffset++];
+            var coordinate = new Coordinate(x, y);
+            points[j] = geometryFactory.createPoint(coordinate);
+          }
+          geometries[geometryCounter++] = geometryFactory.createMultiPoint(points);
+        } else {
+          for (var j = 0; j < numPoints; j++) {
+            var offset = vertexOffsets[vertexOffsetsOffset++] * 2;
+            var x = vertexBuffer[offset];
+            var y = vertexBuffer[offset + 1];
+            var coordinate = new Coordinate(x, y);
+            points[j] = geometryFactory.createPoint(coordinate);
+          }
+          geometries[geometryCounter++] = geometryFactory.createMultiPoint(points);
         }
       } else if (geometryType == GeometryType.LINESTRING.ordinal()) {
         var numVertices = 0;

--- a/java/src/main/java/com/mlt/decoder/GeometryDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/GeometryDecoder.java
@@ -72,7 +72,6 @@ public class GeometryDecoder {
                       offset);
               vertexList = Arrays.stream(vertexBuffer).boxed().collect(Collectors.toList());
             } else {
-              System.out.println("Decoding VARINT stream.");
               vertexList =
                   IntegerDecoder.decodeIntStream(tile, offset, geometryStreamMetadata, true);
             }

--- a/java/src/main/java/com/mlt/decoder/GeometryDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/GeometryDecoder.java
@@ -68,7 +68,7 @@ public class GeometryDecoder {
                   "Currently only FastPfor encoding supported for the VertexBuffer.");
             }
             vertexBuffer =
-                DecodingUtils.decodeFastPfor128DeltaCoordinates(
+                DecodingUtils.decodeFastPforDeltaCoordinates(
                     tile,
                     geometryStreamMetadata.numValues(),
                     geometryStreamMetadata.byteLength(),

--- a/java/src/main/java/com/mlt/decoder/GeometryDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/GeometryDecoder.java
@@ -226,7 +226,7 @@ public class GeometryDecoder {
               var numRingVertices = ringOffsets.get(ringOffsetsCounter++);
               rings[j] =
                   getLinearRing(vertexBuffer, vertexBufferOffset, numRingVertices, geometryFactory);
-              vertexBufferOffset += numVertices * 2;
+              vertexBufferOffset += numRingVertices * 2;
             }
 
             polygons[i] = geometryFactory.createPolygon(shell, rings);

--- a/java/src/main/java/com/mlt/decoder/IntegerDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/IntegerDecoder.java
@@ -18,7 +18,7 @@ public class IntegerDecoder {
       // TODO: numValues is not right if rle or delta rle is used -> add separate flag in
       // StreamMetadata
       values =
-          DecodingUtils.decodeFastPfor128(
+          DecodingUtils.decodeFastPfor(
               data, streamMetadata.numValues(), streamMetadata.byteLength(), offset);
     } else if (streamMetadata.physicalLevelTechnique() == PhysicalLevelTechnique.VARINT) {
       values = DecodingUtils.decodeVarint(data, offset, streamMetadata.numValues());
@@ -73,7 +73,7 @@ public class IntegerDecoder {
     int[] values = null;
     if (streamMetadata.physicalLevelTechnique() == PhysicalLevelTechnique.FAST_PFOR) {
       values =
-          DecodingUtils.decodeFastPfor128(
+          DecodingUtils.decodeFastPfor(
               data, streamMetadata.numValues(), streamMetadata.byteLength(), offset);
     } else if (streamMetadata.physicalLevelTechnique() == PhysicalLevelTechnique.VARINT) {
       values = DecodingUtils.decodeVarint(data, offset, streamMetadata.numValues());

--- a/java/src/main/java/com/mlt/decoder/IntegerDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/IntegerDecoder.java
@@ -23,7 +23,7 @@ public class IntegerDecoder {
     } else if (streamMetadata.physicalLevelTechnique() == PhysicalLevelTechnique.VARINT) {
       values = DecodingUtils.decodeVarint(data, offset, streamMetadata.numValues());
     } else {
-      throw new IllegalArgumentException("Specified physical level technique not yet supported.");
+      throw new IllegalArgumentException("Specified physical level technique not yet supported: " + streamMetadata.physicalLevelTechnique());
     }
 
     return decodeMortonDelta(values, streamMetadata.numBits(), streamMetadata.coordinateShift());
@@ -78,7 +78,7 @@ public class IntegerDecoder {
     } else if (streamMetadata.physicalLevelTechnique() == PhysicalLevelTechnique.VARINT) {
       values = DecodingUtils.decodeVarint(data, offset, streamMetadata.numValues());
     } else {
-      throw new IllegalArgumentException("Specified physical level technique not yet supported.");
+      throw new IllegalArgumentException("Specified physical level technique not yet supported: " + streamMetadata.physicalLevelTechnique());
     }
 
     var decodedValues =
@@ -128,7 +128,7 @@ public class IntegerDecoder {
     }
 
     throw new IllegalArgumentException(
-        "The specified logical level technique is not supported for integers.");
+        "The specified logical level technique is not supported for integers: " + logicalLevelTechnique);
   }
 
   public static List<Long> decodeLongStream(
@@ -179,7 +179,7 @@ public class IntegerDecoder {
         }
       default:
         throw new IllegalArgumentException(
-            "The specified logical level technique is not supported for integers.");
+            "The specified logical level technique is not supported for long integers: " + logicalLevelTechnique);
     }
   }
 

--- a/java/src/main/java/com/mlt/decoder/IntegerDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/IntegerDecoder.java
@@ -23,7 +23,9 @@ public class IntegerDecoder {
     } else if (streamMetadata.physicalLevelTechnique() == PhysicalLevelTechnique.VARINT) {
       values = DecodingUtils.decodeVarint(data, offset, streamMetadata.numValues());
     } else {
-      throw new IllegalArgumentException("Specified physical level technique not yet supported: " + streamMetadata.physicalLevelTechnique());
+      throw new IllegalArgumentException(
+          "Specified physical level technique not yet supported: "
+              + streamMetadata.physicalLevelTechnique());
     }
 
     return decodeMortonDelta(values, streamMetadata.numBits(), streamMetadata.coordinateShift());
@@ -78,7 +80,9 @@ public class IntegerDecoder {
     } else if (streamMetadata.physicalLevelTechnique() == PhysicalLevelTechnique.VARINT) {
       values = DecodingUtils.decodeVarint(data, offset, streamMetadata.numValues());
     } else {
-      throw new IllegalArgumentException("Specified physical level technique not yet supported: " + streamMetadata.physicalLevelTechnique());
+      throw new IllegalArgumentException(
+          "Specified physical level technique not yet supported: "
+              + streamMetadata.physicalLevelTechnique());
     }
 
     var decodedValues =
@@ -128,7 +132,8 @@ public class IntegerDecoder {
     }
 
     throw new IllegalArgumentException(
-        "The specified logical level technique is not supported for integers: " + logicalLevelTechnique);
+        "The specified logical level technique is not supported for integers: "
+            + logicalLevelTechnique);
   }
 
   public static List<Long> decodeLongStream(
@@ -179,7 +184,8 @@ public class IntegerDecoder {
         }
       default:
         throw new IllegalArgumentException(
-            "The specified logical level technique is not supported for long integers: " + logicalLevelTechnique);
+            "The specified logical level technique is not supported for long integers: "
+                + logicalLevelTechnique);
     }
   }
 

--- a/java/src/main/java/com/mlt/decoder/IntegerDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/IntegerDecoder.java
@@ -140,7 +140,7 @@ public class IntegerDecoder {
 
   private static List<Long> decodeLongArray(
       long[] values, StreamMetadata streamMetadata, boolean isSigned) {
-      switch (streamMetadata.logicalLevelTechnique1()) {
+    switch (streamMetadata.logicalLevelTechnique1()) {
       case DELTA:
         if (streamMetadata.logicalLevelTechnique2().equals(LogicalLevelTechnique.RLE)) {
           var rleMetadata = (RleEncodedStreamMetadata) streamMetadata;
@@ -151,8 +151,8 @@ public class IntegerDecoder {
         }
         return decodeZigZagDelta(values);
       case RLE:
-      {
-        var rleMetadata = (RleEncodedStreamMetadata) streamMetadata;
+        {
+          var rleMetadata = (RleEncodedStreamMetadata) streamMetadata;
           var decodedValues = decodeRLE(values, rleMetadata.runs(), rleMetadata.numRleValues());
           return isSigned
               ? decodeZigZag(decodedValues.stream().mapToLong(i -> i).toArray())
@@ -168,9 +168,9 @@ public class IntegerDecoder {
     }
 
     throw new IllegalArgumentException(
-      "The specified logical level technique is not supported for long integers: "
-          + streamMetadata.logicalLevelTechnique1());
-}
+        "The specified logical level technique is not supported for long integers: "
+            + streamMetadata.logicalLevelTechnique1());
+  }
 
   // TODO: quick and dirty -> write fast vectorized solution
   private static List<Integer> decodeRLE(int[] data, int numRuns, int numRleValues) {

--- a/java/src/main/java/com/mlt/decoder/IntegerDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/IntegerDecoder.java
@@ -1,5 +1,6 @@
 package com.mlt.decoder;
 
+import com.mlt.decoder.vectorized.VectorizedDecodingUtils;
 import com.mlt.metadata.stream.*;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -123,6 +124,9 @@ public class IntegerDecoder {
               ? decodeZigZag(values)
               : Arrays.stream(values).boxed().collect(Collectors.toList());
         }
+      case COMPONENTWISE_DELTA:
+        VectorizedDecodingUtils.decodeComponentwiseDeltaVec2(values);
+        return Arrays.stream(values).boxed().collect(Collectors.toList());
       case MORTON:
         // TODO: zig-zag decode when morton second logical level technique
         return decodeMortonCodes(

--- a/java/src/main/java/com/mlt/decoder/MltDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/MltDecoder.java
@@ -7,7 +7,6 @@ import com.mlt.decoder.vectorized.VectorizedDecodingUtils;
 import com.mlt.decoder.vectorized.VectorizedGeometryDecoder;
 import com.mlt.decoder.vectorized.VectorizedIntegerDecoder;
 import com.mlt.decoder.vectorized.VectorizedPropertyDecoder;
-import com.mlt.metadata.stream.PhysicalLevelTechnique;
 import com.mlt.metadata.stream.StreamMetadataDecoder;
 import com.mlt.metadata.tileset.MltTilesetMetadata;
 import com.mlt.vector.BitVector;
@@ -64,14 +63,16 @@ public class MltDecoder {
           }
 
           var idDataStreamMetadata = StreamMetadataDecoder.decode(tile, offset);
-          ids =
-              idDataStreamMetadata.physicalLevelTechnique() == PhysicalLevelTechnique.FAST_PFOR
-                  ? IntegerDecoder.decodeIntStream(tile, offset, idDataStreamMetadata, false)
-                      .stream()
-                      .mapToLong(i -> i)
-                      .boxed()
-                      .collect(Collectors.toList())
-                  : IntegerDecoder.decodeLongStream(tile, offset, idDataStreamMetadata, false);
+          var idDataType = columnMetadata.getScalarType().getPhysicalType();
+          if (idDataType.equals(MltTilesetMetadata.ScalarType.UINT_32)) {
+            ids =
+                IntegerDecoder.decodeIntStream(tile, offset, idDataStreamMetadata, false).stream()
+                    .mapToLong(i -> i)
+                    .boxed()
+                    .collect(Collectors.toList());
+          } else {
+            ids = IntegerDecoder.decodeLongStream(tile, offset, idDataStreamMetadata, false);
+          }
         } else if (columnName.equals("geometry")) {
           var geometryColumn = GeometryDecoder.decodeGeometryColumn(tile, numStreams, offset);
           geometries = GeometryDecoder.decodeGeometry(geometryColumn);
@@ -181,8 +182,15 @@ public class MltDecoder {
       MltTilesetMetadata.FeatureTableSchema metadata,
       int numFeatures) {
     if (numFeatures != geometries.length || numFeatures != ids.size()) {
-      throw new IllegalArgumentException(
-          "Invalid decoding: the size of ids, geometries, and features must be equal.");
+      System.out.println(
+          "Warning, in convertToLayer the size of ids("
+              + ids.size()
+              + "), geometries("
+              + geometries.length
+              + "), and features("
+              + numFeatures
+              + ") are not equal for layer: "
+              + metadata.getName());
     }
     var features = new ArrayList<Feature>(numFeatures);
     for (var j = 0; j < numFeatures; j++) {

--- a/java/src/main/java/com/mlt/decoder/MltDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/MltDecoder.java
@@ -180,6 +180,9 @@ public class MltDecoder {
       Map<String, List<Object>> properties,
       MltTilesetMetadata.FeatureTableSchema metadata,
       int numFeatures) {
+    if (numFeatures != geometries.length || numFeatures != ids.size()) {
+      throw new IllegalArgumentException("Invalid decoding: the size of ids, geometries, and features must be equal.");
+    }
     var features = new ArrayList<Feature>(numFeatures);
     for (var j = 0; j < numFeatures; j++) {
       var p = new HashMap<String, Object>();

--- a/java/src/main/java/com/mlt/decoder/MltDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/MltDecoder.java
@@ -181,7 +181,8 @@ public class MltDecoder {
       MltTilesetMetadata.FeatureTableSchema metadata,
       int numFeatures) {
     if (numFeatures != geometries.length || numFeatures != ids.size()) {
-      throw new IllegalArgumentException("Invalid decoding: the size of ids, geometries, and features must be equal.");
+      throw new IllegalArgumentException(
+          "Invalid decoding: the size of ids, geometries, and features must be equal.");
     }
     var features = new ArrayList<Feature>(numFeatures);
     for (var j = 0; j < numFeatures; j++) {

--- a/java/src/main/java/com/mlt/decoder/PropertyDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/PropertyDecoder.java
@@ -47,24 +47,17 @@ public class PropertyDecoder {
             return booleanValues;
           }
         case UINT_32:
-          {
-            var dataStreamMetadata = StreamMetadataDecoder.decode(data, offset);
-            var dataStream =
-                IntegerDecoder.decodeIntStream(data, offset, dataStreamMetadata, false);
-            var counter = 0;
-            var values = new ArrayList<Integer>();
-            for (var i = 0; i < presentStreamMetadata.numValues(); i++) {
-              var value = presentStream.get(i) ? dataStream.get(counter++) : null;
-              values.add(value);
-            }
-            return values;
-          }
         case INT_32:
           {
             var dataStreamMetadata = StreamMetadataDecoder.decode(data, offset);
-            var dataStream = IntegerDecoder.decodeIntStream(data, offset, dataStreamMetadata, true);
-            var values = new ArrayList<Integer>();
+            var dataStream =
+                IntegerDecoder.decodeIntStream(
+                    data,
+                    offset,
+                    dataStreamMetadata,
+                    scalarType.getPhysicalType() == MltTilesetMetadata.ScalarType.INT_32);
             var counter = 0;
+            var values = new ArrayList<Integer>();
             for (var i = 0; i < presentStreamMetadata.numValues(); i++) {
               var value = presentStream.get(i) ? dataStream.get(counter++) : null;
               values.add(value);
@@ -98,23 +91,15 @@ public class PropertyDecoder {
             }
           }
         case UINT_64:
-          {
-            var dataStreamMetadata = StreamMetadataDecoder.decode(data, offset);
-            var dataStream =
-                IntegerDecoder.decodeLongStream(data, offset, dataStreamMetadata, false);
-            var counter = 0;
-            var values = new ArrayList<Long>();
-            for (var i = 0; i < presentStreamMetadata.numValues(); i++) {
-              var value = presentStream.get(i) ? dataStream.get(counter++) : null;
-              values.add(value);
-            }
-            return values;
-          }
         case INT_64:
           {
             var dataStreamMetadata = StreamMetadataDecoder.decode(data, offset);
             var dataStream =
-                IntegerDecoder.decodeLongStream(data, offset, dataStreamMetadata, true);
+                IntegerDecoder.decodeLongStream(
+                    data,
+                    offset,
+                    dataStreamMetadata,
+                    scalarType.getPhysicalType() == MltTilesetMetadata.ScalarType.INT_64);
             var values = new ArrayList<Long>();
             var counter = 0;
             for (var i = 0; i < presentStreamMetadata.numValues(); i++) {

--- a/java/src/main/java/com/mlt/decoder/PropertyDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/PropertyDecoder.java
@@ -71,12 +71,6 @@ public class PropertyDecoder {
             }
             return values;
           }
-          /*case UINT_64:{
-              break;
-          }
-          case INT_64:{
-              break;
-          }*/
         case FLOAT:
           {
             var dataStreamMetadata = StreamMetadataDecoder.decode(data, offset);
@@ -89,9 +83,20 @@ public class PropertyDecoder {
             }
             return values;
           }
-          /*case DOUBLE:{
-              break;
-          }*/
+        case DOUBLE:
+          {
+            {
+              var dataStreamMetadata = StreamMetadataDecoder.decode(data, offset);
+              var dataStream = FloatDecoder.decodeFloatStream(data, offset, dataStreamMetadata);
+              var values = new ArrayList<Float>();
+              var counter = 0;
+              for (var i = 0; i < presentStreamMetadata.numValues(); i++) {
+                var value = presentStream.get(i) ? dataStream.get(counter++) : null;
+                values.add(value);
+              }
+              return values;
+            }
+          }
         case UINT_64:
           {
             var dataStreamMetadata = StreamMetadataDecoder.decode(data, offset);
@@ -126,7 +131,7 @@ public class PropertyDecoder {
           }
         default:
           throw new IllegalArgumentException(
-              "The specified data type for the field is currently not supported.");
+              "The specified data type for the field is currently not supported: " + scalarType);
       }
     }
 

--- a/java/src/main/java/com/mlt/decoder/vectorized/VectorizedDecodingUtils.java
+++ b/java/src/main/java/com/mlt/decoder/vectorized/VectorizedDecodingUtils.java
@@ -5,13 +5,9 @@ import com.mlt.metadata.stream.RleEncodedStreamMetadata;
 import com.mlt.metadata.stream.StreamMetadata;
 import com.mlt.vector.BitVector;
 import com.mlt.vector.VectorType;
-import java.io.IOException;
 import java.nio.*;
 import java.util.BitSet;
 import me.lemire.integercompression.*;
-import org.apache.orc.impl.BufferChunk;
-import org.apache.orc.impl.InStream;
-import org.apache.orc.impl.RunLengthByteReader;
 
 public class VectorizedDecodingUtils {
 
@@ -52,21 +48,21 @@ public class VectorizedDecodingUtils {
       return ArrayUtils.addAll(encodedRuns, Bytes.toArray(valueBuffer));
   }*/
 
-  public static byte[] decodeByteRle(byte[] buffer, int numBytes, int byteSize, IntWrapper pos)
-      throws IOException {
-    var inStream =
-        InStream.create(
-            "test", new BufferChunk(ByteBuffer.wrap(buffer), 0), pos.get(), buffer.length);
-    var reader = new RunLengthByteReader(inStream);
+  // public static byte[] decodeByteRle(byte[] buffer, int numBytes, int byteSize, IntWrapper pos)
+  //     throws IOException {
+  //   var inStream =
+  //       InStream.create(
+  //           "test", new BufferChunk(ByteBuffer.wrap(buffer), 0), pos.get(), buffer.length);
+  //   var reader = new RunLengthByteReader(inStream);
 
-    var values = new byte[numBytes];
-    for (var i = 0; i < numBytes; i++) {
-      values[i] = reader.next();
-    }
+  //   var values = new byte[numBytes];
+  //   for (var i = 0; i < numBytes; i++) {
+  //     values[i] = reader.next();
+  //   }
 
-    pos.add(byteSize);
-    return values;
-  }
+  //   pos.add(byteSize);
+  //   return values;
+  // }
 
   public static ByteBuffer decodeBooleanRle(byte[] buffer, int numBooleans, IntWrapper pos) {
     var numBytes = (int) Math.ceil(numBooleans / 8d);

--- a/java/src/main/java/com/mlt/decoder/vectorized/VectorizedDoubleDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/vectorized/VectorizedDoubleDecoder.java
@@ -1,0 +1,40 @@
+package com.mlt.decoder.vectorized;
+
+import com.mlt.metadata.stream.StreamMetadata;
+import com.mlt.vector.BitVector;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.DoubleBuffer;
+import me.lemire.integercompression.IntWrapper;
+
+public class VectorizedDoubleDecoder {
+  private VectorizedDoubleDecoder() {}
+
+  public static DoubleBuffer decodeDoubleStream(
+      byte[] data, IntWrapper offset, StreamMetadata streamMetadata) {
+    var doubleBuffer =
+        ByteBuffer.wrap(data, offset.get(), streamMetadata.byteLength())
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .asDoubleBuffer();
+    offset.add(streamMetadata.byteLength());
+    return doubleBuffer;
+  }
+
+  public static DoubleBuffer decodeNullableDoubleStream(
+      byte[] data, IntWrapper offset, StreamMetadata streamMetadata, BitVector nullabilityBuffer) {
+    // TODO: refactor for performance
+    var doubleBuffer =
+        ByteBuffer.wrap(data, offset.get(), streamMetadata.byteLength())
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .asDoubleBuffer();
+    offset.add(streamMetadata.byteLength());
+
+    var nullableDoubleBuffer = new double[nullabilityBuffer.size()];
+    for (var i = 0; i < nullabilityBuffer.size(); i++) {
+      // TODO: or use Double.NaN -> check performance
+      nullableDoubleBuffer[i] = nullabilityBuffer.get(i) ? doubleBuffer.get(i) : 0;
+    }
+
+    return DoubleBuffer.wrap(nullableDoubleBuffer);
+  }
+}

--- a/java/src/main/java/com/mlt/decoder/vectorized/VectorizedIntegerDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/vectorized/VectorizedIntegerDecoder.java
@@ -138,7 +138,9 @@ public class VectorizedIntegerDecoder {
         return IntBuffer.wrap(values);
     }
 
-    throw new IllegalArgumentException("The specified Logical level technique is not supported");
+    throw new IllegalArgumentException(
+        "The specified Logical level technique is not supported: "
+            + streamMetadata.logicalLevelTechnique1());
   }
 
   private static LongBuffer decodeLongBuffer(
@@ -180,7 +182,9 @@ public class VectorizedIntegerDecoder {
         return LongBuffer.wrap(values);
     }
 
-    throw new IllegalArgumentException("The specified Logical level technique is not supported");
+    throw new IllegalArgumentException(
+        "The specified Logical level technique is not supported: "
+            + streamMetadata.logicalLevelTechnique1());
   }
 
   private static IntBuffer decodeLengthToOffsetBuffer(int[] values, StreamMetadata streamMetadata) {

--- a/java/src/main/java/com/mlt/decoder/vectorized/VectorizedPropertyDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/vectorized/VectorizedPropertyDecoder.java
@@ -92,7 +92,7 @@ public class VectorizedPropertyDecoder {
           }
         default:
           throw new IllegalArgumentException(
-              "The specified data type for the field is currently not supported.");
+              "The specified data type for the field is currently not supported: " + scalarType);
       }
     }
 
@@ -215,6 +215,7 @@ public class VectorizedPropertyDecoder {
             }
           }
         case FLOAT:
+        case DOUBLE:
           {
             // TODO: add rle encoding and ConstVector
             var dataStreamMetadata = StreamMetadataDecoder.decode(data, offset);
@@ -225,9 +226,6 @@ public class VectorizedPropertyDecoder {
                     : VectorizedFloatDecoder.decodeFloatStream(data, offset, dataStreamMetadata);
             return new FloatFlatVector(column.getName(), nullabilityBuffer, dataStream);
           }
-          /*case DOUBLE:{
-              break;
-          }*/
         case STRING:
           {
             return VectorizedStringDecoder.decodeToRandomAccessFormat(
@@ -235,7 +233,7 @@ public class VectorizedPropertyDecoder {
           }
         default:
           throw new IllegalArgumentException(
-              "The specified data type for the field is currently not supported.");
+              "The specified data type for the field is currently not supported: " + scalarType);
       }
     }
 

--- a/java/src/main/java/com/mlt/decoder/vectorized/VectorizedPropertyDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/vectorized/VectorizedPropertyDecoder.java
@@ -68,7 +68,7 @@ public class VectorizedPropertyDecoder {
                     data,
                     offset,
                     dataStreamMetadata,
-                    scalarType.getPhysicalType() == MltTilesetMetadata.ScalarType.INT_32);
+                    scalarType.getPhysicalType() == MltTilesetMetadata.ScalarType.INT_64);
             return presentStream != null
                 ? new LongFlatVector(column.getName(), presentStream, dataStream)
                 : new LongFlatVector(column.getName(), dataStream);

--- a/java/src/main/java/com/mlt/decoder/vectorized/VectorizedPropertyDecoder.java
+++ b/java/src/main/java/com/mlt/decoder/vectorized/VectorizedPropertyDecoder.java
@@ -9,6 +9,7 @@ import com.mlt.vector.VectorType;
 import com.mlt.vector.constant.IntConstVector;
 import com.mlt.vector.constant.LongConstVector;
 import com.mlt.vector.flat.BooleanFlatVector;
+import com.mlt.vector.flat.DoubleFlatVector;
 import com.mlt.vector.flat.FloatFlatVector;
 import com.mlt.vector.flat.IntFlatVector;
 import com.mlt.vector.flat.LongFlatVector;
@@ -215,7 +216,6 @@ public class VectorizedPropertyDecoder {
             }
           }
         case FLOAT:
-        case DOUBLE:
           {
             // TODO: add rle encoding and ConstVector
             var dataStreamMetadata = StreamMetadataDecoder.decode(data, offset);
@@ -225,6 +225,17 @@ public class VectorizedPropertyDecoder {
                         data, offset, dataStreamMetadata, nullabilityBuffer)
                     : VectorizedFloatDecoder.decodeFloatStream(data, offset, dataStreamMetadata);
             return new FloatFlatVector(column.getName(), nullabilityBuffer, dataStream);
+          }
+        case DOUBLE:
+          {
+            // TODO: add rle encoding and ConstVector
+            var dataStreamMetadata = StreamMetadataDecoder.decode(data, offset);
+            var dataStream =
+                nullabilityBuffer != null
+                    ? VectorizedDoubleDecoder.decodeNullableDoubleStream(
+                        data, offset, dataStreamMetadata, nullabilityBuffer)
+                    : VectorizedDoubleDecoder.decodeDoubleStream(data, offset, dataStreamMetadata);
+            return new DoubleFlatVector(column.getName(), nullabilityBuffer, dataStream);
           }
         case STRING:
           {

--- a/java/src/test/java/com/mlt/decoder/MltDecoderTest.java
+++ b/java/src/test/java/com/mlt/decoder/MltDecoderTest.java
@@ -136,7 +136,6 @@ public class MltDecoderTest {
   }
 
   @Test
-  @Disabled
   public void decodeMlTile_Z4() throws IOException {
     var tileId = String.format("%s_%s_%s", 4, 8, 10);
     testTileSequential(tileId);
@@ -146,7 +145,6 @@ public class MltDecoderTest {
   }
 
   @Test
-  @Disabled
   public void decodeMlTile_Z5() throws IOException {
     var tileId = String.format("%s_%s_%s", 5, 16, 21);
     testTileSequential(tileId);
@@ -156,7 +154,6 @@ public class MltDecoderTest {
   }
 
   @Test
-  @Disabled
   // org.opentest4j.AssertionFailedError: expected: <1> but was: <2>
   public void decodeMlTile_Z6() throws IOException {
     var tileId = String.format("%s_%s_%s", 6, 32, 41);

--- a/justfile
+++ b/justfile
@@ -43,8 +43,8 @@ test-java-cli:
     # Test the using advanced encodings
     java -jar ./build/libs/encode.jar -mvt ../test/fixtures/omt/10_530_682.mvt -metadata -advanced -mlt output/advanced.mlt
     # ensure expected sizes
-    python3 -c 'import os; expected=66984; ts=os.path.getsize("output/varint.mlt"); assert ts == expected, f"tile size changed from expected ({expected}), got: {ts}"'
-    python3 -c 'import os; expected=64728; ts=os.path.getsize("output/advanced.mlt"); assert ts == expected, f"tile size changed from expected ({expected}), got: {ts}"'
+    python3 -c 'import os; expected=67011; ts=os.path.getsize("output/varint.mlt"); assert ts == expected, f"tile size changed from expected ({expected}), got: {ts}"'
+    python3 -c 'import os; expected=64776; ts=os.path.getsize("output/advanced.mlt"); assert ts == expected, f"tile size changed from expected ({expected}), got: {ts}"'
     # ensure we can decode the advanced tile
     java -jar ./build/libs/decode.jar -mlt output/advanced.mlt -vectorized
 


### PR DESCRIPTION
This PR includes various improvements and fixes to the java implementation.

It includes several fix issues in the non-vectorized path, bringing it back up to speed with the vectorized path:
 - #134 
 - #131 
 - #130 

And in includes two general encoding features that were missing:

 - #132 
 - #127

Additional changes, that don't have corresponding tickets:

 - Fixed the Delta encoding in the non-vectorized path to support RLE without multiple passes
 - Improves the `encode` and `decode` cli tools to actually decode vectorized geometries when `-decode` arg is passed
 - Make the spotless check run faster (avoids running builds and tests and just does the formatting check)
 - Fixes a small bug in the vectorized path where the signed boolean was incorrect
 - Makes the benchmark timer in the encode and decode tools quiet by default and now behind an option
 - Adds additional error detail when unsupported encodings are encountered at runtime
 - Comments some unused code
 - Renames some code to match naming better between the vectorized and non-vectorized path