### PR TITLE
Add justfile with java and js tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,58 +13,39 @@ defaults:
 jobs:
   test-js:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: 'js'
     steps:
       - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@v2
+        with: { tool: just }
       - uses: actions/setup-node@v4
         with:
           node-version-file: 'js/.nvmrc'
           cache: 'npm'
           cache-dependency-path: 'js/package-lock.json'
-      - run: npm ci
-      - run: npm test
+      - run: just test-js
+
   test-java:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-    defaults:
-      run:
-        working-directory: 'java'
     steps:
       - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@v2
+        with: { tool: just }
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
       - uses: gradle/actions/setup-gradle@v3
-      - name: Java build
-        run: ./gradlew build # includes spotlessJavaCheck
-      - name: Java converter tests
-        run: ./gradlew test
-      - name: Test running CLI
-        run: |
-          ./gradlew cli
-          # Test the encoding CLI
-          java -jar ./build/libs/encode.jar -mvt ../test/fixtures/omt/10_530_682.mvt -metadata -mlt output/varint.mlt
-          # ensure expected size
-          python -c 'import os; expected=2432; ts=os.path.getsize("output/varint.mlt.meta.pbf"); assert ts == expected, f"tile size changed from expected ({expected}), got: {ts}"'
-          # Test the meta CLI and ensure it doesn't overwrite the metadata (a sign it correctly matches the encode output)
-          java -jar ./build/libs/meta.jar -mvt ../test/fixtures/omt/10_530_682.mvt -meta output/varint.mlt.meta.pbf
-          # ensure expected size is maintained (meta writes the same meta file as encode)
-          python -c 'import os; expected=2432; ts=os.path.getsize("output/varint.mlt.meta.pbf"); assert ts == expected, f"tile size changed from expected ({expected}), got: {ts}"'
-          # Test the using advanced encodings
-          java -jar ./build/libs/encode.jar -mvt ../test/fixtures/omt/10_530_682.mvt -metadata -advanced -mlt output/advanced.mlt
-          # ensure expected sizes
-          python -c 'import os; expected=66984; ts=os.path.getsize("output/varint.mlt"); assert ts == expected, f"tile size changed from expected ({expected}), got: {ts}"'
-          python -c 'import os; expected=64728; ts=os.path.getsize("output/advanced.mlt"); assert ts == expected, f"tile size changed from expected ({expected}), got: {ts}"'
-          # ensure we can decode the advanced tile
-          java -jar ./build/libs/decode.jar -mlt output/advanced.mlt -vectorized
-  # This final step is needed to mark the whole workflow as successful
+      - name: Test Java
+        run: just test-java
+      - name: Test running Java CLI
+        run: just test-java-cli
+
+  # This final step is needed to mark the entire workflow as successful
   done:
-    # Don't change its name - it is used by the merge protection rules
+    # Don't change this name - it is used by the merge protection rules
     name: CI Finished
     runs-on: ubuntu-latest
     # List of all the other jobs that must pass for this job to start

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ coverage/
 target/
 .gradle/
 build/
+test/output
+java/output

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ In the following, the size of MLT and MVT files are compared based on a selected
 
 Join the #maplibre-tile-format slack channel at OSMUS: get an invite at https://slack.openstreetmap.us/
 
+### Development
+
+* This project is easier to develop with [just](https://just.systems/man/en/), a modern alternative to `make`.
+* To get a list of available commands, run `just`.
+* To run tests, use `just test`.
+
 ## License
 
 * All project documentation and specification content is licensed under [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/) - Public Domain Dedication.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,125 @@
+#!/usr/bin/env just --justfile
+set shell := ["bash", "-c"]
+
+# By default, show the list of all available commands
+@_default:
+    {{ just_executable() }} --list --unsorted
+
+# Delete all build files for multiple languages
+clean: clean-java clean-js clean-rust
+
+# Delete build files for Java
+clean-java:
+    echo "TODO: Add java cleanup command"
+
+# Delete build files for JavaScript
+clean-js:
+    echo "TODO: Add js cleanup command"
+
+# Delete build files for Rust
+clean-rust:
+    cd rust && cargo clean
+
+# Run all tests in every language, including integration tests
+test: test-java test-java-cli test-js test-rust test-int
+
+# Run tests for Java
+test-java:
+    cd java && ./gradlew test
+
+# Run Java cli tests
+test-java-cli:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd java  # Changing directory requires this recipe to have the #!/... line at the top, i.e. be a proper script
+    ./gradlew cli
+    # Test the encoding CLI
+    java -jar ./build/libs/encode.jar -mvt ../test/fixtures/omt/10_530_682.mvt -metadata -mlt output/varint.mlt
+    # ensure expected size
+    python3 -c 'import os; expected=2432; ts=os.path.getsize("output/varint.mlt.meta.pbf"); assert ts == expected, f"tile size changed from expected ({expected}), got: {ts}"'
+    # Test the meta CLI and ensure it doesn't overwrite the metadata (a sign it correctly matches the encode output)
+    java -jar ./build/libs/meta.jar -mvt ../test/fixtures/omt/10_530_682.mvt -meta output/varint.mlt.meta.pbf
+    # ensure expected size is maintained (meta writes the same meta file as encode)
+    python3 -c 'import os; expected=2432; ts=os.path.getsize("output/varint.mlt.meta.pbf"); assert ts == expected, f"tile size changed from expected ({expected}), got: {ts}"'
+    # Test the using advanced encodings
+    java -jar ./build/libs/encode.jar -mvt ../test/fixtures/omt/10_530_682.mvt -metadata -advanced -mlt output/advanced.mlt
+    # ensure expected sizes
+    python3 -c 'import os; expected=66984; ts=os.path.getsize("output/varint.mlt"); assert ts == expected, f"tile size changed from expected ({expected}), got: {ts}"'
+    python3 -c 'import os; expected=64728; ts=os.path.getsize("output/advanced.mlt"); assert ts == expected, f"tile size changed from expected ({expected}), got: {ts}"'
+    # ensure we can decode the advanced tile
+    java -jar ./build/libs/decode.jar -mlt output/advanced.mlt -vectorized
+
+
+# Run tests for JavaScript
+test-js:
+    cd js && npm ci
+    cd js && npm test
+
+# Run tests for Rust
+test-rust:
+    cd rust && cargo test
+
+# Run integration tests, ensuring that the output matches the expected output
+test-int: clean-int-test test-run-int (diff-dirs "test/output" "test/expected")
+
+# Run integration tests, and override what we expect the output to be with the actual output
+bless: clean-int-test test-run-int
+    rm -rf test/expected && mv test/output test/expected
+
+# Run linting in every language, failing on lint suggestion or bad formatting. Run `just fmt` to fix formatting issues.
+lint: lint-java lint-js lint-rust
+
+# Run linting for Java
+lint-java:
+    echo "TODO: Add java lint command"
+
+# Run linting for JavaScript
+lint-js:
+    echo "TODO: Add js lint command (e.g. eslint)"
+
+# Run linting for Rust
+lint-rust:
+    cd rust && cargo clippy
+    cd rust && cargo fmt --all -- --check
+
+# Run all formatting in every language
+fmt: fmt-java fmt-js fmt-rust
+
+# Run formatting for Java
+fmt-java:
+    echo "TODO: Add java fmt command"
+
+# Run formatting for JavaScript
+fmt-js:
+    echo "TODO: Add js fmt command (e.g. prettier)"
+
+# Run formatting for Rust
+fmt-rust:
+    cd rust && cargo fmt --all
+
+# Delete integration test output files
+[private]
+clean-int-test:
+    rm -rf test/output && mkdir -p test/output
+
+# Run integration tests
+[private]
+test-run-int:
+    echo "TODO: Add integration test command, outputting to test/output"
+    echo "fake output by copying expected into output so that the rest of the script works"
+    # TODO: REMOVE THIS, and replace it with a real integration test run
+    cp -r test/expected/* test/output
+
+# Compare two directories to ensure they are the same
+[private]
+diff-dirs OUTPUT_DIR EXPECTED_DIR:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "** Comparing {{OUTPUT_DIR}} with {{EXPECTED_DIR}}..."
+    if ! diff --brief --recursive --new-file {{OUTPUT_DIR}} {{EXPECTED_DIR}}; then
+        echo "** Expected output does not match actual output"
+        echo "** You may want to run 'just bless' to update expected output"
+        exit 1
+    else
+        echo "** Expected output matches actual output"
+    fi

--- a/justfile
+++ b/justfile
@@ -1,5 +1,4 @@
 #!/usr/bin/env just --justfile
-set shell := ["bash", "-c"]
 
 # By default, show the list of all available commands
 @_default:


### PR DESCRIPTION
This will allow CI to run exactly the same tests as developers locally.  This also sets up the framework to compare the output of a directory to the expected values. Currently, it gets faked by copying the expected dir to output dir.

Note the `just test-int` -- a good way to compare the results against the expected values. When called, it:

* runs `clean-int-test` to cleanup the `test/output` dir
* runs `test-run-int` to do any kind of output generation (TODO)
* runs `diff-dirs` to compare the content of `test/output` and `test/expected`

Another counterpart to it is to run `just bless` -- which does almost the same, except that it updates the `test/expected` with the new results.