### PR TITLE
Fix property decoding in JS implementation

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,17 +1,18 @@
 {
-  "name": "cov-tiles",
+  "name": "maplibre-tile-spec",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cov-tiles",
+      "name": "maplibre-tile-spec",
       "version": "0.0.1",
       "dependencies": {
         "@bufbuild/protobuf": "^1.10.0",
         "@mapbox/vector-tile": "^1.3.1",
         "@types/bytebuffer": "^5.0.49",
         "@types/varint": "^6.0.3",
+        "bitset": "^5.1.1",
         "bytebuffer": "^5.0.1",
         "ieee754": "^1.2.1",
         "pbf": "^3.2.1",
@@ -2073,6 +2074,15 @@
       "dependencies": {
         "lodash": "^4.17.4",
         "platform": "^1.3.3"
+      }
+    },
+    "node_modules/bitset": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/bitset/-/bitset-5.1.1.tgz",
+      "integrity": "sha512-oKaRp6mzXedJ1Npo86PKhWfDelI6HxxJo+it9nAcBB0HLVvYVp+5i6yj6DT5hfFgo+TS5T57MRWtw8zhwdTs3g==",
+      "license": "MIT OR GPL-2.0",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/brace-expansion": {

--- a/js/package.json
+++ b/js/package.json
@@ -36,6 +36,7 @@
     "@mapbox/vector-tile": "^1.3.1",
     "@types/bytebuffer": "^5.0.49",
     "@types/varint": "^6.0.3",
+    "bitset": "^5.1.1",
     "bytebuffer": "^5.0.1",
     "ieee754": "^1.2.1",
     "pbf": "^3.2.1",

--- a/js/src/decoder/DecodingUtils.ts
+++ b/js/src/decoder/DecodingUtils.ts
@@ -1,4 +1,5 @@
 import { IntWrapper } from './IntWrapper';
+import { BitSet } from 'bitset';
 
 export class DecodingUtils {
 
@@ -98,7 +99,7 @@ export class DecodingUtils {
         }
     }
 
-    public static decodeByteRle(buffer: Uint8Array, numBytes: number, byteSize: number, pos: IntWrapper): Uint8Array {
+    public static decodeByteRle(buffer: Uint8Array, numBytes: number, pos: IntWrapper): Uint8Array {
         const values = new Uint8Array(numBytes);
 
         let valueOffset = 0;
@@ -147,9 +148,9 @@ export class DecodingUtils {
         return values;
     }
 
-    public static decodeBooleanRle(buffer: Uint8Array, numBooleans: number, byteSize: number, pos: IntWrapper): Uint8Array {
-        const numBytes = Math.ceil(numBooleans / 8);
-        return this.decodeByteRle(buffer, numBytes, byteSize, pos);
+    public static decodeBooleanRle(buffer: Uint8Array, numBooleans: number, pos: IntWrapper): BitSet {
+        const numBytes = Math.ceil(numBooleans / 8.0);
+        return new BitSet(this.decodeByteRle(buffer, numBytes, pos));
     }
 
     public static decodeFloatsLE(encodedValues: Uint8Array, pos: IntWrapper, numValues: number): Float32Array {

--- a/js/src/decoder/PropertyDecoder.ts
+++ b/js/src/decoder/PropertyDecoder.ts
@@ -1,12 +1,12 @@
 import { StreamMetadata } from '../metadata/stream/StreamMetadata';
 import { StreamMetadataDecoder } from '../metadata/stream/StreamMetadataDecoder';
-import { Column, ScalarType } from "../metadata/mlt_tileset_metadata_pb";
 import { IntWrapper } from './IntWrapper';
 import { DecodingUtils } from './DecodingUtils';
 import { IntegerDecoder } from './IntegerDecoder';
 import { FloatDecoder } from './FloatDecoder';
 import { DoubleDecoder } from './DoubleDecoder';
 import { StringDecoder } from './StringDecoder';
+import { Column, ScalarType } from "../metadata/mlt_tileset_metadata_pb";
 
 class PropertyDecoder {
 
@@ -21,17 +21,17 @@ class PropertyDecoder {
             if (numStreams > 1) {
                 presentStreamMetadata = StreamMetadataDecoder.decode(data, offset);
                 numValues = presentStreamMetadata.numValues();
-                presentStream = DecodingUtils.decodeBooleanRle(data, presentStreamMetadata.numValues(), presentStreamMetadata.byteLength(), offset);
+                presentStream = DecodingUtils.decodeBooleanRle(data, presentStreamMetadata.numValues(), offset);
             }
             const physicalType = column.type.value.type.value;
             switch (physicalType) {
                 case ScalarType.BOOLEAN: {
                     const dataStreamMetadata = StreamMetadataDecoder.decode(data, offset);
-                    const dataStream = DecodingUtils.decodeBooleanRle(data, dataStreamMetadata.numValues(), dataStreamMetadata.byteLength(), offset);
+                    const dataStream = DecodingUtils.decodeBooleanRle(data, dataStreamMetadata.numValues(), offset);
                     const booleanValues: (boolean | null)[] = new Array(presentStreamMetadata.numValues());
                     let counter = 0;
                     for (let i = 0; i < presentStreamMetadata.numValues(); i++) {
-                        const value = presentStream[i] ? dataStream[counter++] : null;
+                        const value = presentStream.get(i) ? dataStream.get(counter++) : null;
                         booleanValues[i] = value !== null ? Boolean(value) : null;
                     }
                     return booleanValues;
@@ -42,7 +42,7 @@ class PropertyDecoder {
                     const values: (number | null)[] = new Array(presentStreamMetadata.numValues());
                     let counter = 0;
                     for (let i = 0; i < presentStreamMetadata.numValues(); i++) {
-                        const value = presentStream[i] ? dataStream[counter++] : null;
+                        const value = presentStream.get(i) ? dataStream[counter++] : null;
                         values[i] = value;
                     }
                     return values;
@@ -53,7 +53,7 @@ class PropertyDecoder {
                     const values: (number | null)[] = new Array(presentStreamMetadata.numValues());
                     let counter = 0;
                     for (let i = 0; i < presentStreamMetadata.numValues(); i++) {
-                        const value = presentStream[i] ? dataStream[counter++] : null;
+                        const value = presentStream.get(i) ? dataStream[counter++] : null;
                         values[i] = value;
                     }
                     return values;
@@ -64,7 +64,7 @@ class PropertyDecoder {
                     const values: (number | null)[] = new Array(presentStreamMetadata.numValues());
                     let counter = 0;
                     for (let i = 0; i < presentStreamMetadata.numValues(); i++) {
-                        const value = presentStream[i] ? dataStream[counter++] : null;
+                        const value = presentStream.get(i) ? dataStream[counter++] : null;
                         values[i] = value;
                     }
                     return values;
@@ -75,7 +75,7 @@ class PropertyDecoder {
                     const values: (number | null)[] = new Array(presentStreamMetadata.numValues());
                     let counter = 0;
                     for (let i = 0; i < presentStreamMetadata.numValues(); i++) {
-                        const value = presentStream[i] ? dataStream[counter++] : null;
+                        const value = presentStream.get(i) ? dataStream[counter++] : null;
                         values[i] = value;
                     }
                     return values;
@@ -86,7 +86,7 @@ class PropertyDecoder {
                     const values: (bigint | null)[] = new Array(presentStreamMetadata.numValues());
                     let counter = 0;
                     for (let i = 0; i < presentStreamMetadata.numValues(); i++) {
-                        const value = presentStream[i] ? dataStream[counter++] : null;
+                        const value = presentStream.get(i) ? dataStream[counter++] : null;
                         values[i] = value;
                     }
                     return values;
@@ -97,7 +97,7 @@ class PropertyDecoder {
                     const values: (bigint | null)[] = new Array(presentStreamMetadata.numValues());
                     let counter = 0;
                     for (let i = 0; i < presentStreamMetadata.numValues(); i++) {
-                        const value = presentStream[i] ? dataStream[counter++] : null;
+                        const value = presentStream.get(i) ? dataStream[counter++] : null;
                         values[i] = value;
                     }
                     return values;


### PR DESCRIPTION
Only the first 2 properties were being decoded in the JS decoder. This fixes the problem which was due to a missing implementation of bitsets. New tests are not yet enabled for JS because other bugs prevent the tests from passing (refs #169). So, I will address the java side first and then circle back and enable more property tests in JS once java is working better.