### PR TITLE
Run JS Bench on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,24 @@ jobs:
       - name: Lint JS code. If fails, run `just fmt-js` to reformat, and `just lint-js` to see issues locally
         run: just lint-js
       - run: just test-js
+
+  bench-js:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@v2
+        with: { tool: just }
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: 'js/.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'js/package-lock.json'
+      # currently requires java encoder to be run
+      - name: Bench JS code
       - run: just bench-js
 
   lint-java:
@@ -63,7 +81,7 @@ jobs:
     name: CI Finished
     runs-on: ubuntu-latest
     # List of all the other jobs that must pass for this job to start
-    needs: [ test-java, lint-java, test-js ]
+    needs: [ test-java, lint-java, test-js, bench-js ]
     steps:
       - name: Finished
         run: echo "CI finished successfully"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Lint JS code. If fails, run `just fmt-js` to reformat, and `just lint-js` to see issues locally
         run: just lint-js
       - run: just test-js
+      - run: just bench-js
 
   lint-java:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           cache-dependency-path: 'js/package-lock.json'
       # currently requires java encoder to be run
       - name: Bench JS code
-      - run: just bench-js
+        run: just bench-js
 
   lint-java:
     runs-on: ubuntu-latest

--- a/js/bench/decode.ts
+++ b/js/bench/decode.ts
@@ -57,7 +57,7 @@ const runSuite = async (tile) => {
                 const features = [];
                 for (const layer of decoded.layers) {
                   for (const feature of layer.features) {
-                    features.push(feature.toGeoJSON());
+                    features.push(feature.toGeoJSON(z, y, z));
                   }
                 }
                 deferred.resolve();

--- a/js/bench/decode.ts
+++ b/js/bench/decode.ts
@@ -31,8 +31,10 @@ tiles.forEach(tile => {
   }
 });
 
+let maxTime = 10;
 if (process.env.GITHUB_RUN_ID) {
-  console.log('Running in CI, using smaller maxTime');
+  maxTime = 2;
+  console.log(`Running in CI, using smaller maxTime: ${maxTime} seconds`);
 }
 
 const runSuite = async (tile) => {
@@ -56,7 +58,7 @@ const runSuite = async (tile) => {
           })
           .add(`MLT ${tile}`, {
               defer: true,
-              maxTime: process.env.GITHUB_RUN_ID ?  .5 : 10,
+              maxTime: maxTime,
               fn: (deferred: benchmark.Deferred) => {
                 const decoded = MltDecoder.decodeMlTile(mltTile, tilesetMetadata);
                 const features = [];
@@ -70,7 +72,7 @@ const runSuite = async (tile) => {
           })
           .add(`MVT ${tile}`, {
             defer: true,
-            maxTime: process.env.GITHUB_RUN_ID ?  .5 : 10,
+            maxTime: maxTime,
             fn: (deferred: benchmark.Deferred) => {
                 const vectorTile = new VectorTile(new Protobuf(mvtTile));
                 const features = [];

--- a/js/bench/decode.ts
+++ b/js/bench/decode.ts
@@ -31,6 +31,10 @@ tiles.forEach(tile => {
   }
 });
 
+if (process.env.GITHUB_RUN_ID) {
+  console.log('Running in CI, using smaller maxTime');
+}
+
 const runSuite = async (tile) => {
   console.log(`Running benchmarks for ${tile}`);
   const metadata: Buffer = readFileSync(`../test/expected/${tile}.mlt.meta.pbf`);
@@ -52,6 +56,7 @@ const runSuite = async (tile) => {
           })
           .add(`MLT ${tile}`, {
               defer: true,
+              maxTime: process.env.GITHUB_RUN_ID ?  .5 : 10,
               fn: (deferred: benchmark.Deferred) => {
                 const decoded = MltDecoder.decodeMlTile(mltTile, tilesetMetadata);
                 const features = [];
@@ -65,6 +70,7 @@ const runSuite = async (tile) => {
           })
           .add(`MVT ${tile}`, {
             defer: true,
+            maxTime: process.env.GITHUB_RUN_ID ?  .5 : 10,
             fn: (deferred: benchmark.Deferred) => {
                 const vectorTile = new VectorTile(new Protobuf(mvtTile));
                 const features = [];

--- a/justfile
+++ b/justfile
@@ -58,6 +58,14 @@ test-js:
 test-rust:
     cd rust && cargo test
 
+bench-js:
+    cd js && npm run bench
+
+bench-java:
+    cd java && ./gradlew jmh
+
+bench: bench-js bench-java
+
 # Run integration tests, ensuring that the output matches the expected output
 test-int: clean-int-test test-run-int (diff-dirs "test/output" "test/expected")
 

--- a/justfile
+++ b/justfile
@@ -48,17 +48,18 @@ test-java-cli:
     # ensure we can decode the advanced tile
     java -jar ./build/libs/decode.jar -mlt output/advanced.mlt -vectorized
 
+install-js:
+    cd js && npm ci
 
 # Run tests for JavaScript
-test-js:
-    cd js && npm ci
+test-js: install-js
     cd js && npm test
 
 # Run tests for Rust
 test-rust:
     cd rust && cargo test
 
-bench-js:
+bench-js: install-js
     cd js && npm run bench
 
 bench-java:


### PR DESCRIPTION
This gets the JS benchmark script running on CI. It is set to run fast (limited to 2 seconds per test) as the purpose of running on CI currently is just to ensure the script stays working and does not regress.