### PR TITLE
JS Package: shuffle dependencies to only install for testing

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -9,21 +9,18 @@
       "version": "0.0.1-alpha.3",
       "dependencies": {
         "@bufbuild/protobuf": "^1.10.0",
-        "@mapbox/vector-tile": "^1.3.1",
         "@types/bytebuffer": "^5.0.49",
-        "@types/varint": "^6.0.3",
         "bitset": "^5.1.1",
-        "bytebuffer": "^5.0.1",
-        "ieee754": "^1.2.1",
-        "pbf": "^3.2.1",
-        "varint": "^6.0.0"
+        "bytebuffer": "^5.0.1"
       },
       "devDependencies": {
         "@bufbuild/buf": "^1.34.0",
         "@bufbuild/protoc-gen-es": "^1.10.0",
+        "@mapbox/vector-tile": "^1.3.1",
         "@types/benchmark": "^2.1.2",
         "@types/jest": "^29.5.2",
         "@types/node": "^20.14.9",
+        "@types/varint": "^6.0.3",
         "@typescript-eslint/eslint-plugin": "^7.14.1",
         "@typescript-eslint/parser": "^7.14.1",
         "benchmark": "^2.1.4",
@@ -31,11 +28,13 @@
         "jest": "^29.5.0",
         "jest-matcher-deep-close-to": "^3.0.2",
         "nyc": "^17.0.0",
+        "pbf": "^3.2.1",
         "prettier": "^3.3.2",
         "semver": "^7.6.2",
         "ts-jest": "^29.1.5",
         "ts-node": "^10.9.2",
-        "typescript": "^5.5.2"
+        "typescript": "^5.5.2",
+        "varint": "^6.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1357,12 +1356,15 @@
     "node_modules/@mapbox/point-geometry": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
+      "dev": true
     },
     "node_modules/@mapbox/vector-tile": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
       "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/point-geometry": "~0.1.0"
       }
@@ -1572,6 +1574,8 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/varint/-/varint-6.0.3.tgz",
       "integrity": "sha512-DHukoGWdJ2aYkveZJTB2rN2lp6m7APzVsoJQ7j/qy1fQxyamJTPD5xQzCMoJ2Qtgn0mE3wWeNOpbTyBFvF+dyA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -3275,6 +3279,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4924,6 +4929,8 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
       "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
@@ -5108,7 +5115,8 @@
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "dev": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -5241,6 +5249,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "dev": true,
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
       }
@@ -5823,7 +5832,9 @@
     "node_modules/varint": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/walker": {
       "version": "1.0.8",

--- a/js/package.json
+++ b/js/package.json
@@ -21,9 +21,11 @@
   "devDependencies": {
     "@bufbuild/buf": "^1.34.0",
     "@bufbuild/protoc-gen-es": "^1.10.0",
+    "@mapbox/vector-tile": "^1.3.1",
     "@types/benchmark": "^2.1.2",
     "@types/jest": "^29.5.2",
     "@types/node": "^20.14.9",
+    "@types/varint": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "^7.14.1",
     "@typescript-eslint/parser": "^7.14.1",
     "benchmark": "^2.1.4",
@@ -31,21 +33,18 @@
     "jest": "^29.5.0",
     "jest-matcher-deep-close-to": "^3.0.2",
     "nyc": "^17.0.0",
+    "pbf": "^3.2.1",
     "prettier": "^3.3.2",
     "semver": "^7.6.2",
     "ts-jest": "^29.1.5",
     "ts-node": "^10.9.2",
-    "typescript": "^5.5.2"
+    "typescript": "^5.5.2",
+    "varint": "^6.0.0"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^1.10.0",
-    "@mapbox/vector-tile": "^1.3.1",
     "@types/bytebuffer": "^5.0.49",
-    "@types/varint": "^6.0.3",
     "bitset": "^5.1.1",
-    "bytebuffer": "^5.0.1",
-    "ieee754": "^1.2.1",
-    "pbf": "^3.2.1",
-    "varint": "^6.0.0"
+    "bytebuffer": "^5.0.1"
   }
 }


### PR DESCRIPTION
This fixes the package.json to install several dependencies only at `devDependencies` to keep the final package lighter.