### PR TITLE
Fill in more package details

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -1,0 +1,34 @@
+# maplibre-tile-spec
+
+This package contains a JavaScript decoder for the experimental MapLibre Tile (MLT) vector tile format.
+
+## Install
+
+`npm install @maplibre/maplibre-tile-spec`
+
+## Quick Start
+
+To decode a tile, you will want to load `MltDecoder` and `TileSetMetadata`:
+
+```js
+import { MltDecoder, TileSetMetadata } from '@maplibre/maplibre-tile-spec';
+
+const data = fs.readFileSync(tilePath);
+const metadata = fs.readFileSync(metadataPath);
+const tilesetMetadata = TileSetMetadata.fromBinary(metadata);
+const tile = MltDecoder.decodeMlTile(data, tilesetMetadata);
+```
+
+## Contents
+
+### Code
+
+Code is in `src/`.
+
+### Tests
+
+Tests are in `test/unit/`. Run tests by running `npm run test`.
+
+### Benchmarks
+
+Benchmarks are in `bench/`. Run benchmarks by running `npm run bench`.

--- a/js/package.json
+++ b/js/package.json
@@ -6,6 +6,13 @@
   "files": [
     "/dist/src"
   ],
+  "license": "(MIT OR Apache-2.0)",
+  "homepage": "https://github.com/maplibre/maplibre-tile-spec/#readme",
+  "keywords": [
+    "maplibre",
+    "gis",
+    "vector"
+  ],
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build",
@@ -17,6 +24,9 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maplibre/maplibre-tile-spec.git"
+  },
+  "bugs": {
+    "url": "https://github.com/maplibre/maplibre-tile-spec/issues"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.34.0",


### PR DESCRIPTION
Closes #210.

This fills in details that are expected in the `package.json` to better represent the package on npm.