### PR TITLE
add @mapbox/point-geometry to dependencies

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -10,6 +10,7 @@
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@bufbuild/protobuf": "^1.10.0",
+        "@mapbox/point-geometry": "^0.1.0",
         "@types/bytebuffer": "^5.0.49",
         "bitset": "^5.1.1",
         "bytebuffer": "^5.0.1"
@@ -1289,7 +1290,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
       "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
-      "dev": true
+      "license": "ISC"
     },
     "node_modules/@mapbox/unitbezier": {
       "version": "0.0.1",

--- a/js/package.json
+++ b/js/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^1.10.0",
+    "@mapbox/point-geometry": "^0.1.0",
     "@types/bytebuffer": "^5.0.49",
     "bitset": "^5.1.1",
     "bytebuffer": "^5.0.1"


### PR DESCRIPTION
Currently `@mapbox/point-geometry` is a runtime/production dependency of the JS decoder in order to be compatible with [maplibre-gl-js](https://github.com/maplibre/maplibre-gl-js/blob/c75919f19d39ab7a7fdb7e30a00212e2ce0ba5b1/package.json#L22) which depends on it for the vertex storage format.

But we were not explicitly depending upon it. This only worked because other dependencies were pulling it in transitively (either maplibre-gl-js or @mapbox/vector-tile).

Fixes #239 