### PR TITLE
Use import instead of require on @mapbox/point-geometry

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -10,6 +10,7 @@
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@bufbuild/protobuf": "^1.10.0",
+        "@mapbox/point-geometry": "^1.1.0",
         "@types/bytebuffer": "^5.0.49",
         "bitset": "^5.1.1",
         "bytebuffer": "^5.0.1"
@@ -1286,10 +1287,9 @@
       }
     },
     "node_modules/@mapbox/point-geometry": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
-      "dev": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ=="
     },
     "node_modules/@mapbox/unitbezier": {
       "version": "0.0.1",
@@ -1306,6 +1306,12 @@
       "dependencies": {
         "@mapbox/point-geometry": "~0.1.0"
       }
+    },
+    "node_modules/@mapbox/vector-tile/node_modules/@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
+      "dev": true
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
       "version": "20.3.0",

--- a/js/package.json
+++ b/js/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^1.10.0",
+    "@mapbox/point-geometry": "^1.1.0",
     "@types/bytebuffer": "^5.0.49",
     "bitset": "^5.1.1",
     "bytebuffer": "^5.0.1"

--- a/js/src/data/Geometry.ts
+++ b/js/src/data/Geometry.ts
@@ -1,4 +1,4 @@
-import Point = require("@mapbox/point-geometry");
+import Point from "@mapbox/point-geometry";
 import { Projection } from './Projection';
 import { GeometryType } from './GeometryType';
 

--- a/js/src/decoder/GeometryDecoder.ts
+++ b/js/src/decoder/GeometryDecoder.ts
@@ -7,7 +7,7 @@ import { IntWrapper } from './IntWrapper';
 import { StreamMetadataDecoder } from '../metadata/stream/StreamMetadataDecoder';
 import { PhysicalLevelTechnique } from '../metadata/stream/PhysicalLevelTechnique';
 import { GeometryFactory, Coordinate, LineString, Polygon, LinearRing } from '../data/Geometry';
-import Point = require("@mapbox/point-geometry");
+import Point from "@mapbox/point-geometry";
 
 export enum GeometryType {
     POINT,
@@ -142,11 +142,11 @@ export class GeometryDecoder {
                 if (!vertexOffsets || vertexOffsets.length === 0) {
                     const vertices = this.getLineString(vertexBuffer, vertexBufferOffset, numVertices, false);
                     vertexBufferOffset += numVertices * 2;
-                    geometries[geometryCounter++] = geometryFactory.createLineString(vertices);
+                    geometries[geometryCounter++] = geometryFactory.createLineString(vertices as Point[]);
                 } else {
                     const vertices = this.decodeDictionaryEncodedLineString(vertexBuffer, vertexOffsets, vertexOffsetsOffset, numVertices, false);
                     vertexOffsetsOffset += numVertices;
-                    geometries[geometryCounter++] = geometryFactory.createLineString(vertices);
+                    geometries[geometryCounter++] = geometryFactory.createLineString(vertices as Point[]);
                 }
             } else if (geometryType === GeometryType.POLYGON) {
                 const numRings = partOffsets[partOffsetCounter++];
@@ -179,7 +179,7 @@ export class GeometryDecoder {
                         const numVertices = containsPolygon
                             ? ringOffsets[ringOffsetsCounter++] : partOffsets[partOffsetCounter++];
                         const vertices = this.getLineString(vertexBuffer, vertexBufferOffset, numVertices, false);
-                        lineStrings[i] = geometryFactory.createLineString(vertices);
+                        lineStrings[i] = geometryFactory.createLineString(vertices as Point[]);
                         vertexBufferOffset += numVertices * 2;
                     }
                     geometries[geometryCounter++] = geometryFactory.createMultiLineString(lineStrings);
@@ -188,7 +188,7 @@ export class GeometryDecoder {
                         const numVertices = containsPolygon
                             ? ringOffsets[ringOffsetsCounter++] : partOffsets[partOffsetCounter++];
                         const vertices = this.decodeDictionaryEncodedLineString(vertexBuffer, vertexOffsets, vertexOffsetsOffset, numVertices, false);
-                        lineStrings[i] = geometryFactory.createLineString(vertices);
+                        lineStrings[i] = geometryFactory.createLineString(vertices as Point[]);
                         vertexOffsetsOffset += numVertices;
                     }
                     geometries[geometryCounter++] = geometryFactory.createMultiLineString(lineStrings);
@@ -237,12 +237,12 @@ export class GeometryDecoder {
 
     private static getLinearRing(vertexBuffer: number[], startIndex: number, numVertices: number, geometryFactory: GeometryFactory): LinearRing {
         const linearRing = this.getLineString(vertexBuffer, startIndex, numVertices, true);
-        return geometryFactory.createLinearRing(linearRing);
+        return geometryFactory.createLinearRing(linearRing as Point[]);
     }
 
     private static decodeDictionaryEncodedLinearRing(vertexBuffer: number[], vertexOffsets: number[], vertexOffset: number, numVertices: number, geometryFactory: GeometryFactory): LinearRing {
         const linearRing = this.decodeDictionaryEncodedLineString(vertexBuffer, vertexOffsets, vertexOffset, numVertices, true);
-        return geometryFactory.createLinearRing(linearRing);
+        return geometryFactory.createLinearRing(linearRing as Point[]);
     }
 
     private static getLineString(vertexBuffer: number[], startIndex: number, numVertices: number, closeLineString: boolean): Coordinate[] {

--- a/js/src/mlt-vector-tile-js/VectorTileFeature.ts
+++ b/js/src/mlt-vector-tile-js/VectorTileFeature.ts
@@ -1,4 +1,4 @@
-import Point = require("@mapbox/point-geometry");
+import Point from "@mapbox/point-geometry";
 
 class VectorTileFeature {
   properties: { [key: string]: any } = {};


### PR DESCRIPTION
Uses an ES6 import for `@mapbox/point-geometry` and uses the latest version of the package which is also ES6 I think.

Closes #239
