### PR TITLE
refactor: get_data_type_from_column in decode_id_column

### DIFF
--- a/rust/mlt/src/decoder/decode.rs
+++ b/rust/mlt/src/decoder/decode.rs
@@ -6,10 +6,10 @@ use geo_types::Geometry;
 use zigzag::ZigZag;
 
 use crate::data::MapLibreTile;
-use crate::decoder::helpers::decode_boolean_rle;
+use crate::decoder::helpers::{decode_boolean_rle, get_data_type_from_column};
 use crate::decoder::varint;
 use crate::encoder::geometry::GeometryScaling;
-use crate::metadata::proto_tileset::{column, scalar_column, Column, ScalarType, TileSetMetadata};
+use crate::metadata::proto_tileset::{Column, TileSetMetadata};
 use crate::metadata::stream::StreamMetadata;
 use crate::{MltError, MltResult};
 
@@ -123,23 +123,7 @@ impl Decoder {
         id_within_max_safe_integer: bool,
     ) -> MltResult<()> {
         let id_data_stream_metadata = StreamMetadata::decode(&mut self.tile)?;
-
-        let id_data_type = match column_metadata.r#type.as_ref() {
-            Some(column::Type::ScalarType(scalar_column)) => match scalar_column.r#type {
-                Some(scalar_column::Type::PhysicalType(scalar_type)) => {
-                    ScalarType::try_from(scalar_type).map_err(|_| {
-                        MltError::DecodeError("Invalid scalar type value".to_string())
-                    })?
-                }
-                _ => {
-                    return Err(MltError::DecodeError(
-                        "Missing or unsupported scalar type".to_string(),
-                    ))
-                }
-            },
-            _ => return Err(MltError::DecodeError("Missing column type".to_string())),
-        };
-
+        let id_data_type = get_data_type_from_column(column_metadata)?;
         Ok(())
     }
 }


### PR DESCRIPTION
This PR was originally intended to include the full implementation of decode_column_id, but I realized that StreamMetadataDecoder.decode does not currently produce the same result as the Java implementation when given the same input. Therefore, I am submitting this smaller PR first to isolate that issue and keep changes manageable.

Implemented:
- Separated scalar type extraction logic into a standalone helper function to simplify the main decoding flow.
- Added an unit test