### PR TITLE
fix: remove unintended cursor advancement

### DIFF
--- a/rust/mlt/src/metadata/stream.rs
+++ b/rust/mlt/src/metadata/stream.rs
@@ -62,9 +62,6 @@ impl StreamMetadata {
             }
         };
 
-        // offset.increment();
-        tile.advance(1);
-
         // let encoding_header = *tile
         //     .get(offset.position() as usize)
         //     .ok_or_else(|| MltError::DecodeError("Failed to read encoding header".to_string()))?


### PR DESCRIPTION
Cursor advancement was resulting in incorrect reads and has therefore been removed.