### PR TITLE
fix: StreamMetadata decoder unhandled types

### DIFF
--- a/rust/mlt/src/decoder/decode.rs
+++ b/rust/mlt/src/decoder/decode.rs
@@ -25,15 +25,26 @@ pub struct Config {
 pub struct Decoder {
     pub tile: Bytes,
     pub config: Option<Config>,
+    pub original_tile_size: usize,
 }
 
 impl Decoder {
     pub fn new(tile: Vec<u8>, config: Option<Config>) -> Self {
+        let tile = Bytes::from(tile);
         Self {
-            tile: Bytes::from(tile),
+            original_tile_size: tile.len(),
+            tile,
             config,
         }
     }
+
+    // Returns the offset of the tile data for debugging purposes
+    // NOTE: This is a temporary workaround to track the offset,
+    // and should be removed once `Bytes` supports offset tracking internally.
+    pub fn offset(&self) -> usize {
+        self.original_tile_size - self.tile.len()
+    }
+
     #[expect(unused_variables)]
     pub fn decode(&mut self, tile_metadata: &TileSetMetadata) -> MltResult<MapLibreTile> {
         while self.tile.has_remaining() {

--- a/rust/mlt/src/metadata/stream_encoding.rs
+++ b/rust/mlt/src/metadata/stream_encoding.rs
@@ -41,6 +41,7 @@ pub enum LogicalStreamType {
 #[derive(Debug, Clone, TryFromPrimitive, PartialEq)]
 #[repr(u8)]
 pub enum LogicalLevelTechnique {
+    None,
     Delta,
     ComponentwiseDelta,
     Rle,
@@ -52,14 +53,14 @@ pub enum LogicalLevelTechnique {
 
 #[derive(Debug, Clone)]
 pub struct Logical {
-    r#type: LogicalStreamType,
+    pub r#type: Option<LogicalStreamType>,
     pub technique1: Option<LogicalLevelTechnique>,
     pub technique2: Option<LogicalLevelTechnique>,
 }
 
 impl Logical {
     pub fn new(
-        r#type: LogicalStreamType,
+        r#type: Option<LogicalStreamType>,
         technique1: LogicalLevelTechnique,
         technique2: LogicalLevelTechnique,
     ) -> Self {
@@ -71,7 +72,7 @@ impl Logical {
     }
 }
 
-#[derive(Debug, Clone, TryFromPrimitive)]
+#[derive(Debug, Clone, TryFromPrimitive, PartialEq)]
 #[repr(u8)]
 pub enum PhysicalStreamType {
     Present,
@@ -83,6 +84,7 @@ pub enum PhysicalStreamType {
 #[derive(Debug, Clone, TryFromPrimitive, PartialEq)]
 #[repr(u8)]
 pub enum PhysicalLevelTechnique {
+    None,
     FastPfor,
     Varint,
     Alp,
@@ -90,15 +92,12 @@ pub enum PhysicalLevelTechnique {
 
 #[derive(Debug, Clone)]
 pub struct Physical {
-    r#type: PhysicalStreamType,
-    pub technique: Option<PhysicalLevelTechnique>,
+    pub r#type: PhysicalStreamType,
+    pub technique: PhysicalLevelTechnique,
 }
 
 impl Physical {
     pub fn new(r#type: PhysicalStreamType, technique: PhysicalLevelTechnique) -> Self {
-        Self {
-            r#type,
-            technique: Some(technique),
-        }
+        Self { r#type, technique }
     }
 }


### PR DESCRIPTION
Context:
Previously, the following decoding path caused StreamMetadata::decode to be skipped entirely:
```
let property_column_names: Option<&String> = self.config.as_ref().and_then(|cfg| {
    cfg.feature_table_decoding
        .as_ref()
        .and_then(|ftd| ftd.get(&feature_table_metadata.name))
});

if property_column_names.is_none() {
    self.tile.advance(*feature_table_body_size as usize);
    continue;
}
```
As a result, the decoder was never exercised in practice. Upon investigation:
- The present physical stream type is currently unhandled.
- Decoded metadata values appear to be inconsistent or incorrect.

To-be-implemented:
- [x] Add a handler for the `Present` stream type
- [x] Change `LogicalStreamType` to be Option because None is not a variant in the enum, but it can be None.
- [x] Add missing None for `LogicalLevelTechnique` and `PhysicalLevelTechnique` to match the enum
- [x] Add offset tracking for debugging
- [x] Add unit tests