### PR TITLE
feat: bytes wrapper for tile with offset

### DIFF
--- a/rust/mlt/src/decoder/decode.rs
+++ b/rust/mlt/src/decoder/decode.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
 
 use bitvec::prelude::*;
-use bytes::{Buf, Bytes};
+use bytes::Buf;
 use geo_types::Geometry;
 use zigzag::ZigZag;
 
 use crate::data::MapLibreTile;
 use crate::decoder::helpers::{decode_boolean_rle, get_data_type_from_column};
+use crate::decoder::tracked_bytes::TrackedBytes;
 use crate::decoder::varint;
 use crate::encoder::geometry::GeometryScaling;
 use crate::metadata::proto_tileset::{Column, TileSetMetadata};
@@ -23,26 +24,14 @@ pub struct Config {
 }
 
 pub struct Decoder {
-    pub tile: Bytes,
+    pub tile: TrackedBytes,
     pub config: Option<Config>,
-    pub original_tile_size: usize,
 }
 
 impl Decoder {
     pub fn new(tile: Vec<u8>, config: Option<Config>) -> Self {
-        let tile = Bytes::from(tile);
-        Self {
-            original_tile_size: tile.len(),
-            tile,
-            config,
-        }
-    }
-
-    // Returns the offset of the tile data for debugging purposes
-    // NOTE: This is a temporary workaround to track the offset,
-    // and should be removed once `Bytes` supports offset tracking internally.
-    pub fn offset(&self) -> usize {
-        self.original_tile_size - self.tile.len()
+        let tile = TrackedBytes::new(tile);
+        Self { tile, config }
     }
 
     #[expect(unused_variables)]

--- a/rust/mlt/src/decoder/decode.rs
+++ b/rust/mlt/src/decoder/decode.rs
@@ -29,9 +29,11 @@ pub struct Decoder {
 }
 
 impl Decoder {
-    pub fn new(tile: Vec<u8>, config: Option<Config>) -> Self {
-        let tile = TrackedBytes::new(tile);
-        Self { tile, config }
+    pub fn new<T: Into<TrackedBytes>>(tile: T, config: Option<Config>) -> Self {
+        Self {
+            tile: tile.into(),
+            config,
+        }
     }
 
     #[expect(unused_variables)]

--- a/rust/mlt/src/decoder/helpers.rs
+++ b/rust/mlt/src/decoder/helpers.rs
@@ -1,5 +1,6 @@
-use bytes::{Buf, Bytes};
+use bytes::Buf;
 
+use crate::decoder::tracked_bytes::TrackedBytes;
 #[allow(unused_imports)]
 use crate::metadata::proto_tileset::{column, scalar_column, Column, ScalarColumn, ScalarType};
 use crate::{MltError, MltResult};
@@ -7,14 +8,14 @@ use crate::{MltError, MltResult};
 /// Decodes boolean RLE from the buffer.
 /// - `num_booleans` is the total number of booleans (bits).
 /// - `byte_size` is inferred as `ceil(num_booleans / 8)`.
-pub fn decode_boolean_rle(tile: &mut Bytes, num_booleans: usize) -> MltResult<Vec<u8>> {
+pub fn decode_boolean_rle(tile: &mut TrackedBytes, num_booleans: usize) -> MltResult<Vec<u8>> {
     let num_bytes = num_booleans.div_ceil(8);
     decode_byte_rle(tile, num_bytes)
 }
 
 /// Decodes byte RLE from the buffer.
 /// - `num_bytes` is how many decoded bytes we expect.
-pub fn decode_byte_rle(tile: &mut Bytes, num_bytes: usize) -> MltResult<Vec<u8>> {
+pub fn decode_byte_rle(tile: &mut TrackedBytes, num_bytes: usize) -> MltResult<Vec<u8>> {
     let mut result = Vec::with_capacity(num_bytes);
     let mut value_offset = 0;
 
@@ -62,7 +63,7 @@ pub fn get_data_type_from_column(column_metadata: &Column) -> MltResult<ScalarTy
 
 #[test]
 fn test_decode_byte_rle() -> MltResult<()> {
-    let mut tile = Bytes::from_static(&[0x03, 0x01]);
+    let mut tile = TrackedBytes::new(vec![0x03, 0x01]);
     let result = decode_byte_rle(&mut tile, 5)?;
     assert_eq!(result, vec![1, 1, 1, 1, 1]);
     Ok(())
@@ -70,7 +71,7 @@ fn test_decode_byte_rle() -> MltResult<()> {
 
 #[test]
 fn test_decode_boolean_rle() -> MltResult<()> {
-    let mut tile = Bytes::from_static(&[0x03, 0x01]);
+    let mut tile = TrackedBytes::new(vec![0x03, 0x01]);
     let result = decode_boolean_rle(&mut tile, 5)?;
     assert_eq!(result, vec![1]);
     Ok(())

--- a/rust/mlt/src/decoder/helpers.rs
+++ b/rust/mlt/src/decoder/helpers.rs
@@ -63,7 +63,7 @@ pub fn get_data_type_from_column(column_metadata: &Column) -> MltResult<ScalarTy
 
 #[test]
 fn test_decode_byte_rle() -> MltResult<()> {
-    let mut tile = TrackedBytes::new(vec![0x03, 0x01]);
+    let mut tile: TrackedBytes = [0x03, 0x01].as_slice().into();
     let result = decode_byte_rle(&mut tile, 5)?;
     assert_eq!(result, vec![1, 1, 1, 1, 1]);
     Ok(())
@@ -71,7 +71,7 @@ fn test_decode_byte_rle() -> MltResult<()> {
 
 #[test]
 fn test_decode_boolean_rle() -> MltResult<()> {
-    let mut tile = TrackedBytes::new(vec![0x03, 0x01]);
+    let mut tile: TrackedBytes = [0x03, 0x01].as_slice().into();
     let result = decode_boolean_rle(&mut tile, 5)?;
     assert_eq!(result, vec![1]);
     Ok(())

--- a/rust/mlt/src/decoder/mod.rs
+++ b/rust/mlt/src/decoder/mod.rs
@@ -1,3 +1,4 @@
 mod decode;
 mod helpers;
+pub mod tracked_bytes;
 pub mod varint;

--- a/rust/mlt/src/decoder/tracked_bytes.rs
+++ b/rust/mlt/src/decoder/tracked_bytes.rs
@@ -44,8 +44,7 @@ mod tests {
 
     #[test]
     fn test_tracked_bytes_offset_and_reads() {
-        let data = vec![0x10, 0x20, 0x30, 0x40];
-        let mut tile = TrackedBytes::new(data);
+        let mut tile: TrackedBytes = [0x10, 0x20, 0x30, 0x40].as_slice().into();
 
         // Initial offset should be 0
         assert_eq!(tile.offset(), 0);

--- a/rust/mlt/src/decoder/tracked_bytes.rs
+++ b/rust/mlt/src/decoder/tracked_bytes.rs
@@ -1,0 +1,69 @@
+use std::ops::{Deref, DerefMut};
+
+use bytes::{Buf, Bytes};
+
+/// A wrapper around `Bytes` that tracks the read offset relative to the original size.
+/// This is useful for debugging and decoding purposes, where knowing how many bytes
+/// have been consumed is critical (e.g., during varint parsing or stream decoding).
+pub struct TrackedBytes(usize, Bytes);
+
+impl TrackedBytes {
+    pub fn new<T: Into<Bytes>>(data: T) -> Self {
+        let bytes = data.into();
+        Self(bytes.len(), bytes)
+    }
+
+    pub fn original_size(&self) -> usize {
+        self.0
+    }
+
+    pub fn offset(&self) -> usize {
+        self.0 - self.1.remaining()
+    }
+}
+
+impl Deref for TrackedBytes {
+    type Target = Bytes;
+
+    fn deref(&self) -> &Self::Target {
+        &self.1
+    }
+}
+
+impl DerefMut for TrackedBytes {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tracked_bytes_offset_and_reads() {
+        let data = vec![0x10, 0x20, 0x30, 0x40];
+        let mut tile = TrackedBytes::new(data);
+
+        // Initial offset should be 0
+        assert_eq!(tile.offset(), 0);
+
+        // Read a single byte
+        let byte = tile.get_u8();
+        assert_eq!(byte, 0x10);
+        assert_eq!(tile.offset(), 1);
+
+        // Read next two bytes as u16 (0x20, 0x30)
+        let u16_val = tile.get_u16();
+        assert_eq!(u16_val, 0x2030);
+        assert_eq!(tile.offset(), 3);
+
+        // Read final byte
+        let last = tile.get_u8();
+        assert_eq!(last, 0x40);
+        assert_eq!(tile.offset(), 4);
+
+        // No bytes remaining
+        assert_eq!(tile.remaining(), 0);
+    }
+}

--- a/rust/mlt/src/decoder/tracked_bytes.rs
+++ b/rust/mlt/src/decoder/tracked_bytes.rs
@@ -8,11 +8,6 @@ use bytes::{Buf, Bytes};
 pub struct TrackedBytes(usize, Bytes);
 
 impl TrackedBytes {
-    pub fn new<T: Into<Bytes>>(data: T) -> Self {
-        let bytes = data.into();
-        Self(bytes.len(), bytes)
-    }
-
     pub fn original_size(&self) -> usize {
         self.0
     }
@@ -33,6 +28,13 @@ impl Deref for TrackedBytes {
 impl DerefMut for TrackedBytes {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.1
+    }
+}
+
+impl<T: Into<Bytes>> From<T> for TrackedBytes {
+    fn from(data: T) -> Self {
+        let bytes = data.into();
+        Self(bytes.len(), bytes)
     }
 }
 

--- a/rust/mlt/src/decoder/varint.rs
+++ b/rust/mlt/src/decoder/varint.rs
@@ -1,7 +1,7 @@
-use bytes::Bytes;
+use crate::decoder::tracked_bytes::TrackedBytes;
 use bytes_varint::*;
 
-pub fn decode(input: &mut Bytes, num_values: usize) -> Vec<u32> {
+pub fn decode(input: &mut TrackedBytes, num_values: usize) -> Vec<u32> {
     let mut values = Vec::with_capacity(num_values);
 
     for _ in 0..num_values {

--- a/rust/mlt/src/metadata/stream.rs
+++ b/rust/mlt/src/metadata/stream.rs
@@ -168,14 +168,15 @@ mod tests {
 
     #[test]
     fn test_decode_stream_metadata() {
-        let tile_bytes = vec![
+        let mut tile: TrackedBytes = [
             0x00, // stream_type
             0x60, // encoding_header
             0xF4, // varint byte 1 → part of `num_values` for size_info
             0x02, // varint byte 2 → completes `num_values` for size_info
             0x04, // varint byte 3 → single-byte varint for `byte_length` for size_info
-        ];
-        let mut tile = TrackedBytes::new(tile_bytes);
+        ]
+        .as_slice()
+        .into();
         let result = StreamMetadata::decode(&mut tile);
         let metadata = result.unwrap();
 


### PR DESCRIPTION
Context:
- Reported issue at https://github.com/maplibre/maplibre-tile-spec/issues/495

Todo:
- [x] Add a bytes wrapper
- [x] Add unit test
- [x] Replace the use of bytes with the wrapper