### PR TITLE
feat: implement decode_const_int_stream decoder

### DIFF
--- a/rust/mlt/src/decoder/integer.rs
+++ b/rust/mlt/src/decoder/integer.rs
@@ -2,7 +2,7 @@ use crate::MltError;
 use crate::decoder::helpers::decode_componentwise_delta_vec2s;
 use crate::decoder::tracked_bytes::TrackedBytes;
 use crate::decoder::varint;
-use crate::encoder::integer::encoded_u32s_to_le_bytes;
+use crate::encoder::integer::u32s_to_le_bytes;
 use crate::metadata::stream::{Morton, Rle, StreamMetadata};
 use crate::metadata::stream_encoding::{
     Logical, LogicalLevelTechnique, LogicalStreamType, Physical, PhysicalLevelTechnique,
@@ -42,14 +42,17 @@ pub fn decode_int_stream(
 }
 
 /// Byte-level decoding based on the physical technique and stream type
-fn decode_physical(
+pub fn decode_physical(
     tile: &mut TrackedBytes,
     metadata: &StreamMetadata,
 ) -> Result<Vec<u32>, MltError> {
     match &metadata.physical.technique {
         PhysicalLevelTechnique::FastPfor => decode_fast_pfor(tile, metadata),
         PhysicalLevelTechnique::Varint => varint::decode::<u32>(tile, metadata.num_values as usize),
-        other => Err(MltError::UnsupportedPhysicalTechnique(*other)),
+        PhysicalLevelTechnique::None => le_bytes_to_u32s(tile, metadata.byte_length as usize),
+        PhysicalLevelTechnique::Alp => Err(MltError::UnsupportedPhysicalTechnique(
+            PhysicalLevelTechnique::Alp,
+        )),
     }
 }
 
@@ -112,7 +115,7 @@ fn decode_fast_pfor(
     let expected_len = metadata.num_values as usize;
     let mut decoded = vec![0; expected_len];
     // Regardless of u32 or u64 fastpfor, the encoded data is always u32
-    let encoded_u32s: Vec<u32> = le_bytes_to_encoded_u32s(tile, metadata.byte_length as usize)?;
+    let encoded_u32s: Vec<u32> = le_bytes_to_u32s(tile, metadata.byte_length as usize)?;
     let decoded_slice = codec.decode32(&encoded_u32s, &mut decoded)?;
     let actual_len = decoded_slice.len();
     if actual_len != expected_len {
@@ -125,10 +128,7 @@ fn decode_fast_pfor(
 }
 
 /// Convert a byte stream (little-endian, LE) to a vector of u32 integers.
-fn le_bytes_to_encoded_u32s(
-    tile: &mut TrackedBytes,
-    num_bytes: usize,
-) -> Result<Vec<u32>, MltError> {
+fn le_bytes_to_u32s(tile: &mut TrackedBytes, num_bytes: usize) -> Result<Vec<u32>, MltError> {
     if num_bytes % 4 != 0 {
         return Err(MltError::InvalidByteMultiple {
             ctx: "bytes-to-be-encoded-u32 stream",
@@ -258,10 +258,10 @@ fn generate_physical_decode_cases() -> Vec<PhysicalDecodeCase> {
     let codec = FastPFor128Codec::new();
     let mut tmp = vec![0; input.len()];
     let encoded = codec.encode32(&input, &mut tmp).unwrap();
-    let encoded_bytes = encoded_u32s_to_le_bytes(encoded);
+    let encoded_bytes = u32s_to_le_bytes(encoded);
 
     vec![
-        // FastPFor-encoded example
+        // PhysicalLevelTechnique::FastPfor example
         PhysicalDecodeCase {
             name: "fastpfor_basic",
             encoded_bytes,
@@ -282,6 +282,7 @@ fn generate_physical_decode_cases() -> Vec<PhysicalDecodeCase> {
             },
             expected: input,
         },
+        // PhysicalLevelTechnique::Varint example
         // Varint-encoded value 300 -> [0b10101100, 0b00000010]
         PhysicalDecodeCase {
             name: "varint_single_value",
@@ -302,6 +303,29 @@ fn generate_physical_decode_cases() -> Vec<PhysicalDecodeCase> {
                 rle: None,
             },
             expected: vec![300],
+        },
+        // PyhsicalLevelTechnique::None example
+        // Little-endian bytes for [0x01,0x00,0x00,0x00, 0x00,0x01,0x00,0x00, 0x00,0x00,0x01,0x00] -> [1u32, 256u32, 65536u32]
+        PhysicalDecodeCase {
+            name: "le_bytes_multiple_values",
+            encoded_bytes: vec![
+                0x01, 0x00, 0x00, 0x00, // 1
+                0x00, 0x01, 0x00, 0x00, // 256
+                0x00, 0x00, 0x01, 0x00, // 65536
+            ],
+            metadata: StreamMetadata {
+                physical: Physical::new(PhysicalStreamType::Present, PhysicalLevelTechnique::None),
+                logical: Logical::new(
+                    Some(LogicalStreamType::Dictionary(None)),
+                    LogicalLevelTechnique::None,
+                    LogicalLevelTechnique::None,
+                ),
+                num_values: 3,
+                byte_length: 12,
+                morton: None,
+                rle: None,
+            },
+            expected: vec![1, 256, 65536],
         },
     ]
 }
@@ -528,7 +552,7 @@ mod tests {
         let num_values = input.len() as u32;
 
         // Prepare the tile as a TrackedBytes instance
-        let encoded_bytes: Vec<u8> = encoded_u32s_to_le_bytes(encoded);
+        let encoded_bytes: Vec<u8> = u32s_to_le_bytes(encoded);
         let mut tile: TrackedBytes = encoded_bytes.into();
 
         // Create a StreamMetadata instance
@@ -553,11 +577,11 @@ mod tests {
     }
 
     #[test]
-    fn test_le_bytes_to_encoded_u32s() {
+    fn test_le_bytes_to_u32s() {
         let mut tile: TrackedBytes = [0x78, 0x56, 0x34, 0x12, 0xef, 0xcd, 0xab, 0x90]
             .as_slice()
             .into();
-        let result = le_bytes_to_encoded_u32s(&mut tile, 8).unwrap();
+        let result = le_bytes_to_u32s(&mut tile, 8).unwrap();
         assert_eq!(result, [0x1234_5678, 0x90ab_cdef]);
     }
 

--- a/rust/mlt/src/decoder/integer_stream.rs
+++ b/rust/mlt/src/decoder/integer_stream.rs
@@ -1,6 +1,43 @@
+use crate::decoder::integer::decode_physical;
+use crate::decoder::tracked_bytes::TrackedBytes;
 use crate::metadata::stream::StreamMetadata;
 use crate::metadata::stream_encoding::LogicalLevelTechnique;
 use crate::vector::types::VectorType;
+use crate::{MltError, MltResult};
+
+use num_traits::{PrimInt, Unsigned};
+use zigzag::ZigZag;
+
+/// Decode ([`ZigZag`] + delta) for Vec2s
+// TODO: The encoded process is (delta + ZigZag) for each component
+pub fn decode_componentwise_delta_vec2s<T: ZigZag>(data: &[T::UInt]) -> MltResult<Vec<T>> {
+    let len = data.len();
+    if len < 2 {
+        return Err(MltError::MinLength {
+            ctx: "vec2 delta stream",
+            min: 2,
+            got: len,
+        });
+    }
+    if len % 2 != 0 {
+        return Err(MltError::InvalidValueMultiple {
+            ctx: "vec2 delta stream length",
+            multiple_of: 2,
+            got: len,
+        });
+    }
+
+    let mut result = Vec::with_capacity(len);
+    result.push(T::decode(data[0]));
+    result.push(T::decode(data[1]));
+
+    for i in (2..len).step_by(2) {
+        result.push(T::decode(data[i]) + result[i - 2]);
+        result.push(T::decode(data[i + 1]) + result[i - 1]);
+    }
+
+    Ok(result)
+}
 
 pub fn get_vector_type_int_stream(metadata: &StreamMetadata) -> VectorType {
     let tech1 = metadata.logical.technique1;
@@ -21,6 +58,46 @@ pub fn get_vector_type_int_stream(metadata: &StreamMetadata) -> VectorType {
         // num_values == 1 → CONST; else FLAT
         (_, _, _, 1) => VectorType::Const,
         _ => VectorType::Flat,
+    }
+}
+
+pub fn decode_zigzag_const_rle<T: ZigZag>(data: &[T::UInt]) -> MltResult<T> {
+    let encoded = data.get(1).ok_or(MltError::MinLength {
+        ctx: "zigzag const RLE stream",
+        min: 2,
+        got: data.len(),
+    })?;
+    Ok(T::decode(*encoded))
+}
+
+pub fn decode_unsigned_const_rle<T: PrimInt + Unsigned>(data: &[T]) -> MltResult<T> {
+    let value = data.get(1).ok_or(MltError::MinLength {
+        ctx: "unsigned const RLE stream",
+        min: 2,
+        got: data.len(),
+    })?;
+    Ok(*value)
+}
+
+pub fn decode_const_int_stream_signed(
+    tile: &mut TrackedBytes,
+    metadata: &StreamMetadata,
+) -> MltResult<i32> {
+    let values: Vec<u32> = decode_physical(tile, metadata)?;
+    match values.as_slice() {
+        [v] => Ok(i32::decode(*v)),
+        _ => decode_zigzag_const_rle::<i32>(&values),
+    }
+}
+
+pub fn decode_const_int_stream_unsigned(
+    tile: &mut TrackedBytes,
+    metadata: &StreamMetadata,
+) -> MltResult<u32> {
+    let values: Vec<u32> = decode_physical(tile, metadata)?;
+    match values.as_slice() {
+        [v] => Ok(*v),
+        _ => decode_unsigned_const_rle::<u32>(&values),
     }
 }
 
@@ -101,5 +178,101 @@ mod tests {
             let vt = get_vector_type_int_stream(&meta);
             assert_eq!(vt, expected, "case failed: {desc}");
         }
+    }
+
+    #[test]
+    fn test_decode_zigzag_const_rle() {
+        let encoded: Vec<u32> = vec![0, 10];
+        let decoded = decode_zigzag_const_rle::<i32>(&encoded).unwrap();
+        assert_eq!(decoded, 5);
+
+        let encoded_neg: Vec<u32> = vec![0, 11];
+        let decoded_neg = decode_zigzag_const_rle::<i32>(&encoded_neg).unwrap();
+        assert_eq!(decoded_neg, -6);
+
+        let encoded_extra: Vec<u32> = vec![0, 10, 20, 30];
+        let decoded_extra = decode_zigzag_const_rle::<i32>(&encoded_extra).unwrap();
+        assert_eq!(decoded_extra, 5);
+
+        let encoded_single: Vec<u32> = vec![0];
+        let decoded_single = decode_zigzag_const_rle::<i32>(&encoded_single);
+        assert!(decoded_single.is_err());
+
+        let encoded_empty: Vec<u32> = vec![];
+        let decoded_empty = decode_zigzag_const_rle::<i32>(&encoded_empty);
+        assert!(decoded_empty.is_err());
+    }
+
+    #[test]
+    fn test_decode_unsigned_const_rle() {
+        let encoded: Vec<u32> = vec![0, 10];
+        let decoded = decode_unsigned_const_rle::<u32>(&encoded).unwrap();
+        assert_eq!(decoded, 10);
+
+        let encoded_extra: Vec<u32> = vec![0, 10, 20, 30];
+        let decoded_extra = decode_unsigned_const_rle::<u32>(&encoded_extra).unwrap();
+        assert_eq!(decoded_extra, 10);
+
+        let encoded_single: Vec<u32> = vec![0];
+        let decoded_single = decode_unsigned_const_rle::<u32>(&encoded_single);
+        assert!(decoded_single.is_err());
+
+        let encoded_empty: Vec<u32> = vec![];
+        let decoded_empty = decode_unsigned_const_rle::<u32>(&encoded_empty);
+        assert!(decoded_empty.is_err());
+    }
+
+    #[test]
+    fn test_decode_const_int_stream_signed() {
+        // Single value, Varint bytes: [0x01] → values = [1] → ZigZag(1) = -1
+        let mut single_bytes: TrackedBytes = vec![0x01u8].into();
+        let single_meta = generate_metadata(
+            LogicalLevelTechnique::Delta,
+            LogicalLevelTechnique::Delta,
+            None,
+            1,
+        );
+        let decoded_single =
+            decode_const_int_stream_signed(&mut single_bytes, &single_meta).unwrap();
+        assert_eq!(decoded_single, -1);
+
+        // RLE-const, Varint bytes: [0x00, 0x0A] → values = [0, 10]
+        // decode_zigzag_const_rle takes index 1 → 10 → ZigZag(10) = 5
+        let mut rle_bytes: TrackedBytes = vec![0x00u8, 0x0A].into();
+        let rle_meta = generate_metadata(
+            LogicalLevelTechnique::Delta,
+            LogicalLevelTechnique::Delta,
+            None,
+            2,
+        );
+        let decoded_rle = decode_const_int_stream_signed(&mut rle_bytes, &rle_meta).unwrap();
+        assert_eq!(decoded_rle, 5);
+    }
+
+    #[test]
+    fn test_decode_const_int_stream_unsigned() {
+        // Single value, Varint bytes: [0x02] → values = [2]
+        let mut single_bytes: TrackedBytes = vec![0x02u8].into();
+        let single_meta = generate_metadata(
+            LogicalLevelTechnique::None,
+            LogicalLevelTechnique::None,
+            None,
+            1,
+        );
+        let decoded_single =
+            decode_const_int_stream_unsigned(&mut single_bytes, &single_meta).unwrap();
+        assert_eq!(decoded_single, 2);
+
+        // RLE-const, Varint bytes: [0x00, 0x0A] → values = [0, 10]
+        // decode_unsigned_const_rle takes index 1 → 10
+        let mut rle_bytes: TrackedBytes = vec![0x00u8, 0x0A].into();
+        let rle_meta = generate_metadata(
+            LogicalLevelTechnique::None,
+            LogicalLevelTechnique::None,
+            None,
+            2,
+        );
+        let decoded_rle = decode_const_int_stream_unsigned(&mut rle_bytes, &rle_meta).unwrap();
+        assert_eq!(decoded_rle, 10);
     }
 }

--- a/rust/mlt/src/encoder/integer.rs
+++ b/rust/mlt/src/encoder/integer.rs
@@ -1,5 +1,5 @@
 /// Converts a slice of u32 integers into a vector of bytes in little-endian (LE) order.
-pub fn encoded_u32s_to_le_bytes(encoded: &[u32]) -> Vec<u8> {
+pub fn u32s_to_le_bytes(encoded: &[u32]) -> Vec<u8> {
     let mut encoded_bytes: Vec<u8> = Vec::with_capacity(size_of_val(encoded));
     for val in encoded {
         encoded_bytes.extend(&val.to_le_bytes());
@@ -12,9 +12,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_encoded_u32s_to_le_bytes() {
+    fn test_u32s_to_le_bytes() {
         let input: Vec<u32> = vec![0x1234_5678, 0x90ab_cdef];
-        let result: Vec<u8> = encoded_u32s_to_le_bytes(&input);
+        let result: Vec<u8> = u32s_to_le_bytes(&input);
         assert_eq!(result, vec![0x78, 0x56, 0x34, 0x12, 0xef, 0xcd, 0xab, 0x90]);
     }
 }


### PR DESCRIPTION
- [x] Implement `decode_const_int_stream_signed`, `decode_const_int_stream_unsigned`, and required functions
- [x] Add required unit tests
- [x] Move `decode_componentwise_delta_vec2s` to `integer_stream.rs` module
- [x] Fix a Clippy warning on `decode_physical`