### PR TITLE
refactor: reorganize decode vectorized code

### DIFF
--- a/rust/mlt/src/decoder/integer.rs
+++ b/rust/mlt/src/decoder/integer.rs
@@ -1,7 +1,7 @@
 use crate::MltError;
+use crate::decoder::helpers::decode_componentwise_delta_vec2s;
 use crate::decoder::tracked_bytes::TrackedBytes;
 use crate::decoder::varint;
-use crate::decoder::vectorized::helpers::decode_componentwise_delta_vec2s;
 use crate::encoder::integer::encoded_u32s_to_bytes;
 use crate::metadata::stream::{Morton, Rle, StreamMetadata};
 use crate::metadata::stream_encoding::{

--- a/rust/mlt/src/decoder/integer_stream.rs
+++ b/rust/mlt/src/decoder/integer_stream.rs
@@ -1,40 +1,6 @@
-use crate::MltError;
 use crate::metadata::stream::StreamMetadata;
 use crate::metadata::stream_encoding::LogicalLevelTechnique;
 use crate::vector::types::VectorType;
-
-use zigzag::ZigZag;
-
-/// Decode ([`ZigZag`] + delta) for Vec2s
-// TODO: The encoded process is (delta + ZigZag) for each component
-pub fn decode_componentwise_delta_vec2s<T: ZigZag>(data: &[T::UInt]) -> Result<Vec<T>, MltError> {
-    let len = data.len();
-    if len < 2 {
-        return Err(MltError::MinLength {
-            ctx: "vec2 delta stream",
-            min: 2,
-            got: len,
-        });
-    }
-    if len % 2 != 0 {
-        return Err(MltError::InvalidValueMultiple {
-            ctx: "vec2 delta stream length",
-            multiple_of: 2,
-            got: len,
-        });
-    }
-
-    let mut result = Vec::with_capacity(len);
-    result.push(T::decode(data[0]));
-    result.push(T::decode(data[1]));
-
-    for i in (2..len).step_by(2) {
-        result.push(T::decode(data[i]) + result[i - 2]);
-        result.push(T::decode(data[i + 1]) + result[i - 1]);
-    }
-
-    Ok(result)
-}
 
 pub fn get_vector_type_int_stream(metadata: &StreamMetadata) -> VectorType {
     let tech1 = metadata.logical.technique1;
@@ -66,23 +32,6 @@ mod tests {
         Logical, LogicalLevelTechnique, LogicalStreamType, Physical, PhysicalLevelTechnique,
         PhysicalStreamType,
     };
-
-    #[test]
-    fn test_decode_componentwise_delta_vec2s() {
-        // original Vec2s: [(3, 5), (7, 6), (12, 4)]
-        // delta:          [3, 5, 4, 1, 5, -2]
-        // ZigZag:         [6, 10, 8, 2, 10, 3]
-        let encoded_from_positives: Vec<u32> = vec![6, 10, 8, 2, 10, 3];
-        let decoded = decode_componentwise_delta_vec2s::<i32>(&encoded_from_positives).unwrap();
-        assert_eq!(decoded, vec![3, 5, 7, 6, 12, 4]);
-
-        // original Vec2s: [(3, 5), (-1, 6), (4, -4)]
-        // delta:          [3, 5, -4, 1, 5, -10]
-        // ZigZag:         [6, 10, 7, 2, 10, 19]
-        let encoded_from_negatives: Vec<u32> = vec![6, 10, 7, 2, 10, 19];
-        let decoded = decode_componentwise_delta_vec2s::<i32>(&encoded_from_negatives).unwrap();
-        assert_eq!(decoded, vec![3, 5, -1, 6, 4, -4]);
-    }
 
     fn generate_metadata(
         t1: LogicalLevelTechnique,

--- a/rust/mlt/src/decoder/mod.rs
+++ b/rust/mlt/src/decoder/mod.rs
@@ -1,6 +1,6 @@
 mod decode;
 mod helpers;
 pub mod integer;
+pub mod integer_stream;
 pub mod tracked_bytes;
 pub mod varint;
-pub mod vectorized;

--- a/rust/mlt/src/decoder/vectorized/mod.rs
+++ b/rust/mlt/src/decoder/vectorized/mod.rs
@@ -1,1 +1,0 @@
-pub mod helpers;


### PR DESCRIPTION
As I began working on the decode_const_int_stream function, I referred to the TypeScript implementation. Instead of moving the stream-related code into the vectorized folder, I placed it in integer_stream.rs, which I find more structured and better organized.