### PR TITLE
Fix GitHub Pages deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,4 +25,3 @@ jobs:
         with:
           branch: gh-pages
           folder: mkdocs/site
-          target-folder: maplibre-tile-spec

--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: MapLibre Tile Specification
 site_url: https://www.maplibre.org/maplibre-tile-spec
 repo_url: https://github.com/maplibre/maplibre-tile-spec
 site_description: MapLibre Tile Specification
-edit_uri: edit/mkdocs/docs
+edit_uri: edit/main/mkdocs/docs
 extra_css:
   - assets/extra.css
 theme:


### PR DESCRIPTION
Fixes 'edit' link and puts the site on https://maplibre.org/maplibre-tile-spec/ instead of https://maplibre.org/maplibre-tile-spec/maplibre-tile-spec