### PR TITLE
refactor: switch integer encoder/decoder from BE to LE

### DIFF
--- a/rust/mlt/src/decoder/integer.rs
+++ b/rust/mlt/src/decoder/integer.rs
@@ -2,7 +2,7 @@ use crate::MltError;
 use crate::decoder::helpers::decode_componentwise_delta_vec2s;
 use crate::decoder::tracked_bytes::TrackedBytes;
 use crate::decoder::varint;
-use crate::encoder::integer::encoded_u32s_to_bytes;
+use crate::encoder::integer::encoded_u32s_to_le_bytes;
 use crate::metadata::stream::{Morton, Rle, StreamMetadata};
 use crate::metadata::stream_encoding::{
     Logical, LogicalLevelTechnique, LogicalStreamType, Physical, PhysicalLevelTechnique,
@@ -112,7 +112,7 @@ fn decode_fast_pfor(
     let expected_len = metadata.num_values as usize;
     let mut decoded = vec![0; expected_len];
     // Regardless of u32 or u64 fastpfor, the encoded data is always u32
-    let encoded_u32s: Vec<u32> = bytes_to_encoded_u32s(tile, metadata.byte_length as usize)?;
+    let encoded_u32s: Vec<u32> = le_bytes_to_encoded_u32s(tile, metadata.byte_length as usize)?;
     let decoded_slice = codec.decode32(&encoded_u32s, &mut decoded)?;
     let actual_len = decoded_slice.len();
     if actual_len != expected_len {
@@ -124,7 +124,11 @@ fn decode_fast_pfor(
     Ok(decoded)
 }
 
-fn bytes_to_encoded_u32s(tile: &mut TrackedBytes, num_bytes: usize) -> Result<Vec<u32>, MltError> {
+/// Convert a byte stream (little-endian, LE) to a vector of u32 integers.
+fn le_bytes_to_encoded_u32s(
+    tile: &mut TrackedBytes,
+    num_bytes: usize,
+) -> Result<Vec<u32>, MltError> {
     if num_bytes % 4 != 0 {
         return Err(MltError::InvalidByteMultiple {
             ctx: "bytes-to-be-encoded-u32 stream",
@@ -146,7 +150,7 @@ fn bytes_to_encoded_u32s(tile: &mut TrackedBytes, num_bytes: usize) -> Result<Ve
             let b2 = tile.get_u8();
             let b3 = tile.get_u8();
             let b4 = tile.get_u8();
-            u32::from_be_bytes([b1, b2, b3, b4])
+            u32::from_le_bytes([b1, b2, b3, b4])
         })
         .collect();
     Ok(encoded_u32s)
@@ -254,7 +258,7 @@ fn generate_physical_decode_cases() -> Vec<PhysicalDecodeCase> {
     let codec = FastPFor128Codec::new();
     let mut tmp = vec![0; input.len()];
     let encoded = codec.encode32(&input, &mut tmp).unwrap();
-    let encoded_bytes = encoded_u32s_to_bytes(encoded);
+    let encoded_bytes = encoded_u32s_to_le_bytes(encoded);
 
     vec![
         // FastPFor-encoded example
@@ -524,7 +528,7 @@ mod tests {
         let num_values = input.len() as u32;
 
         // Prepare the tile as a TrackedBytes instance
-        let encoded_bytes: Vec<u8> = encoded_u32s_to_bytes(encoded);
+        let encoded_bytes: Vec<u8> = encoded_u32s_to_le_bytes(encoded);
         let mut tile: TrackedBytes = encoded_bytes.into();
 
         // Create a StreamMetadata instance
@@ -549,11 +553,11 @@ mod tests {
     }
 
     #[test]
-    fn test_bytes_to_encoded_u32s() {
-        let mut tile: TrackedBytes = [0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef]
+    fn test_le_bytes_to_encoded_u32s() {
+        let mut tile: TrackedBytes = [0x78, 0x56, 0x34, 0x12, 0xef, 0xcd, 0xab, 0x90]
             .as_slice()
             .into();
-        let result = bytes_to_encoded_u32s(&mut tile, 8).unwrap();
+        let result = le_bytes_to_encoded_u32s(&mut tile, 8).unwrap();
         assert_eq!(result, [0x1234_5678, 0x90ab_cdef]);
     }
 

--- a/rust/mlt/src/encoder/integer.rs
+++ b/rust/mlt/src/encoder/integer.rs
@@ -1,7 +1,8 @@
-pub fn encoded_u32s_to_bytes(encoded: &[u32]) -> Vec<u8> {
+/// Converts a slice of u32 integers into a vector of bytes in little-endian (LE) order.
+pub fn encoded_u32s_to_le_bytes(encoded: &[u32]) -> Vec<u8> {
     let mut encoded_bytes: Vec<u8> = Vec::with_capacity(size_of_val(encoded));
     for val in encoded {
-        encoded_bytes.extend(&val.to_be_bytes());
+        encoded_bytes.extend(&val.to_le_bytes());
     }
     encoded_bytes
 }
@@ -11,9 +12,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_encoded_u32s_to_bytes() {
+    fn test_encoded_u32s_to_le_bytes() {
         let input: Vec<u32> = vec![0x1234_5678, 0x90ab_cdef];
-        let result: Vec<u8> = encoded_u32s_to_bytes(&input);
-        assert_eq!(result, vec![0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef]);
+        let result: Vec<u8> = encoded_u32s_to_le_bytes(&input);
+        assert_eq!(result, vec![0x78, 0x56, 0x34, 0x12, 0xef, 0xcd, 0xab, 0x90]);
     }
 }


### PR DESCRIPTION
The initial implementation used big-endian (BE) byte order for both the encoder and decoder. 
Other language implementations use little-endian (LE), and LE is generally preferred for 
performance reasons. This PR updates the code to align with that choice.

Changes:
- [x] Use LE byte order for integer encoder and decoder
- [x] Update unit tests to match LE encoding/decoding