### PR TITLE
refactor(rust): improves boolean decoder organization

### DIFF
--- a/rust/mlt/src/decoder/boolean.rs
+++ b/rust/mlt/src/decoder/boolean.rs
@@ -1,0 +1,62 @@
+use bytes::Buf;
+
+use crate::decoder::tracked_bytes::TrackedBytes;
+
+/// Decodes boolean RLE from the buffer.
+/// - `num_booleans` is the total number of booleans (bits).
+/// - `byte_size` is inferred as `ceil(num_booleans / 8)`.
+pub fn decode_boolean_rle(tile: &mut TrackedBytes, num_booleans: usize) -> Vec<u8> {
+    let num_bytes = num_booleans.div_ceil(8);
+    decode_byte_rle(tile, num_bytes)
+}
+
+/// Decodes byte RLE from the buffer.
+/// - `num_bytes` is how many decoded bytes we expect.
+pub fn decode_byte_rle(tile: &mut TrackedBytes, num_bytes: usize) -> Vec<u8> {
+    let mut result = Vec::with_capacity(num_bytes);
+    let mut value_offset = 0;
+
+    while value_offset < num_bytes {
+        let header = tile.get_u8();
+
+        if header <= 0x7F {
+            // Runs
+            let num_runs = header as usize + 3;
+            let value = tile.get_u8();
+            let end_value_offset = value_offset + num_runs;
+            result.resize(end_value_offset.min(num_bytes), value);
+            value_offset = end_value_offset.min(num_bytes);
+        } else {
+            // Literals
+            let num_literals = 256 - header as usize;
+            for _ in 0..num_literals {
+                if value_offset >= num_bytes {
+                    break;
+                }
+                result.push(tile.get_u8());
+                value_offset += 1;
+            }
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decode_byte_rle() {
+        let mut tile: TrackedBytes = [0x03, 0x01].as_slice().into();
+        let result = decode_byte_rle(&mut tile, 5);
+        assert_eq!(result, vec![1, 1, 1, 1, 1]);
+    }
+
+    #[test]
+    fn test_decode_boolean_rle() {
+        let mut tile: TrackedBytes = [0x03, 0x01].as_slice().into();
+        let result = decode_boolean_rle(&mut tile, 5);
+        assert_eq!(result, vec![1]);
+    }
+}

--- a/rust/mlt/src/decoder/decode.rs
+++ b/rust/mlt/src/decoder/decode.rs
@@ -5,7 +5,8 @@ use bytes::Buf;
 use zigzag::ZigZag;
 
 use crate::data::MapLibreTile;
-use crate::decoder::helpers::{decode_boolean_rle, get_data_type_from_column};
+use crate::decoder::boolean::decode_boolean_rle;
+use crate::decoder::helpers::get_data_type_from_column;
 use crate::decoder::tracked_bytes::TrackedBytes;
 use crate::encoder::geometry::GeometryScaling;
 use crate::metadata::proto_tileset::{Column, ScalarType, TileSetMetadata};

--- a/rust/mlt/src/decoder/helpers.rs
+++ b/rust/mlt/src/decoder/helpers.rs
@@ -1,48 +1,5 @@
-use bytes::Buf;
-
-use crate::decoder::tracked_bytes::TrackedBytes;
 use crate::metadata::proto_tileset::{Column, ScalarType, column, scalar_column};
 use crate::{MltError, MltResult};
-
-/// Decodes boolean RLE from the buffer.
-/// - `num_booleans` is the total number of booleans (bits).
-/// - `byte_size` is inferred as `ceil(num_booleans / 8)`.
-pub fn decode_boolean_rle(tile: &mut TrackedBytes, num_booleans: usize) -> Vec<u8> {
-    let num_bytes = num_booleans.div_ceil(8);
-    decode_byte_rle(tile, num_bytes)
-}
-
-/// Decodes byte RLE from the buffer.
-/// - `num_bytes` is how many decoded bytes we expect.
-pub fn decode_byte_rle(tile: &mut TrackedBytes, num_bytes: usize) -> Vec<u8> {
-    let mut result = Vec::with_capacity(num_bytes);
-    let mut value_offset = 0;
-
-    while value_offset < num_bytes {
-        let header = tile.get_u8();
-
-        if header <= 0x7F {
-            // Runs
-            let num_runs = header as usize + 3;
-            let value = tile.get_u8();
-            let end_value_offset = value_offset + num_runs;
-            result.resize(end_value_offset.min(num_bytes), value);
-            value_offset = end_value_offset.min(num_bytes);
-        } else {
-            // Literals
-            let num_literals = 256 - header as usize;
-            for _ in 0..num_literals {
-                if value_offset >= num_bytes {
-                    break;
-                }
-                result.push(tile.get_u8());
-                value_offset += 1;
-            }
-        }
-    }
-
-    result
-}
 
 /// Get the physical scalarType from a Column metadata.
 pub fn get_data_type_from_column(column_metadata: &Column) -> MltResult<ScalarType> {
@@ -63,22 +20,7 @@ pub fn get_data_type_from_column(column_metadata: &Column) -> MltResult<ScalarTy
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::decoder::integer_stream::decode_componentwise_delta_vec2s;
     use crate::metadata::proto_tileset::ScalarColumn;
-
-    #[test]
-    fn test_decode_byte_rle() {
-        let mut tile: TrackedBytes = [0x03, 0x01].as_slice().into();
-        let result = decode_byte_rle(&mut tile, 5);
-        assert_eq!(result, vec![1, 1, 1, 1, 1]);
-    }
-
-    #[test]
-    fn test_decode_boolean_rle() {
-        let mut tile: TrackedBytes = [0x03, 0x01].as_slice().into();
-        let result = decode_boolean_rle(&mut tile, 5);
-        assert_eq!(result, vec![1]);
-    }
 
     #[test]
     fn test_get_data_type_from_column() {
@@ -94,22 +36,5 @@ mod tests {
         let data_type =
             get_data_type_from_column(&column_metadata).expect("should parse ScalarType");
         assert_eq!(data_type, ScalarType::Uint32);
-    }
-
-    #[test]
-    fn test_decode_componentwise_delta_vec2s() {
-        // original Vec2s: [(3, 5), (7, 6), (12, 4)]
-        // delta:          [3, 5, 4, 1, 5, -2]
-        // ZigZag:         [6, 10, 8, 2, 10, 3]
-        let encoded_from_positives: Vec<u32> = vec![6, 10, 8, 2, 10, 3];
-        let decoded = decode_componentwise_delta_vec2s::<i32>(&encoded_from_positives).unwrap();
-        assert_eq!(decoded, vec![3, 5, 7, 6, 12, 4]);
-
-        // original Vec2s: [(3, 5), (-1, 6), (4, -4)]
-        // delta:          [3, 5, -4, 1, 5, -10]
-        // ZigZag:         [6, 10, 7, 2, 10, 19]
-        let encoded_from_negatives: Vec<u32> = vec![6, 10, 7, 2, 10, 19];
-        let decoded = decode_componentwise_delta_vec2s::<i32>(&encoded_from_negatives).unwrap();
-        assert_eq!(decoded, vec![3, 5, -1, 6, 4, -4]);
     }
 }

--- a/rust/mlt/src/decoder/integer_stream.rs
+++ b/rust/mlt/src/decoder/integer_stream.rs
@@ -166,6 +166,23 @@ mod tests {
     }
 
     #[test]
+    fn test_decode_componentwise_delta_vec2s() {
+        // original Vec2s: [(3, 5), (7, 6), (12, 4)]
+        // delta:          [3, 5, 4, 1, 5, -2]
+        // ZigZag:         [6, 10, 8, 2, 10, 3]
+        let encoded_from_positives: Vec<u32> = vec![6, 10, 8, 2, 10, 3];
+        let decoded = decode_componentwise_delta_vec2s::<i32>(&encoded_from_positives).unwrap();
+        assert_eq!(decoded, vec![3, 5, 7, 6, 12, 4]);
+
+        // original Vec2s: [(3, 5), (-1, 6), (4, -4)]
+        // delta:          [3, 5, -4, 1, 5, -10]
+        // ZigZag:         [6, 10, 7, 2, 10, 19]
+        let encoded_from_negatives: Vec<u32> = vec![6, 10, 7, 2, 10, 19];
+        let decoded = decode_componentwise_delta_vec2s::<i32>(&encoded_from_negatives).unwrap();
+        assert_eq!(decoded, vec![3, 5, -1, 6, 4, -4]);
+    }
+
+    #[test]
     fn test_decode_zigzag_const_rle() {
         let encoded: Vec<u32> = vec![0, 10];
         let decoded = decode_zigzag_const_rle::<i32>(&encoded).unwrap();

--- a/rust/mlt/src/decoder/mod.rs
+++ b/rust/mlt/src/decoder/mod.rs
@@ -1,3 +1,4 @@
+pub mod boolean;
 mod decode;
 mod helpers;
 pub mod integer;
@@ -77,7 +78,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "not all parsing has been implemented yet"]
+    #[ignore = "not all parsing has been implemented yet - some boolean test fixtures have incorrect JSON output due to Java encoder bug (see issue #569)"]
     fn test_decode_fixtures() {
         for (name, path) in &get_bin_fixtures() {
             let meta = fs::read(path.with_extension("meta.bin")).expect(name);
@@ -98,6 +99,8 @@ mod tests {
             // eprintln!("{name} => result {result:?}");
 
             let expected = fs::read_to_string(path.with_extension("json")).expect(name);
+            // Note: Some boolean test fixtures may have incorrect JSON output due to Java encoder bug
+            // where JSON is truncated at the last true bit (issue #569). The binary data is correct.
             assert_eq!(
                 serde_json::to_string(&result).expect(name),
                 expected,


### PR DESCRIPTION
Context
- The PR was originally intended to enable the `test_decode_fixtures` unit test, but this was not possible at the current stage. As the work progressed, it became apparent that separating the boolean decoder would help with future enabling efforts.

Changes
- Separated the boolean decoder from the helper function
- Update result type for int_decoder
- Relocated unit tests accordingly

Related Issues
- References issue #569 regarding Java encoder boolean truncation bug