### PR TITLE
Reduce encoded size of column metadata

### DIFF
--- a/java/src/main/java/org/maplibre/mlt/converter/MltConverter.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/MltConverter.java
@@ -646,7 +646,7 @@ public class MltConverter {
       String columnName, MltTilesetMetadata.ComplexColumn complexColumn) {
     return MltTilesetMetadata.Column.newBuilder()
         .setName(columnName)
-        .setNullable(true)
+        .setNullable(false) // See `PropertyDecoder.decodePropertyColumn()`
         .setColumnScope(MltTilesetMetadata.ColumnScope.FEATURE)
         .setComplexType(complexColumn)
         .build();

--- a/java/src/main/java/org/maplibre/mlt/converter/encodings/MltTypeMap.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/encodings/MltTypeMap.java
@@ -1,0 +1,201 @@
+package org.maplibre.mlt.converter.encodings;
+
+import java.util.Optional;
+import javax.annotation.Nullable;
+import org.maplibre.mlt.metadata.tileset.MltTilesetMetadata;
+
+public class MltTypeMap {
+  public static class Tag0x01 {
+    /// Produces the unique type encoding for a `Column` or `Field`
+    public static Optional<Integer> encodeColumnType(
+        @Nullable MltTilesetMetadata.ScalarType physicalScalarType,
+        @Nullable MltTilesetMetadata.LogicalScalarType logicalScalarType,
+        @Nullable MltTilesetMetadata.ComplexType physicalComplexType,
+        @Nullable MltTilesetMetadata.LogicalComplexType ignoredLogicalComplexType,
+        boolean isNullable,
+        boolean hasChildren,
+        boolean hasLongIDs) {
+      if (physicalScalarType != null) {
+        if (!hasChildren) {
+          return switch (physicalScalarType) {
+            case BOOLEAN -> Optional.of(isNullable ? 0 : 1);
+            case INT_8 -> Optional.of(isNullable ? 2 : 3);
+            case UINT_8 -> Optional.of(isNullable ? 4 : 5);
+            case INT_32 -> Optional.of(isNullable ? 6 : 7);
+            case UINT_32 -> Optional.of(isNullable ? 8 : 9);
+            case INT_64 -> Optional.of(isNullable ? 10 : 11);
+            case UINT_64 -> Optional.of(isNullable ? 12 : 13);
+            case FLOAT -> Optional.of(isNullable ? 14 : 15);
+            case DOUBLE -> Optional.of(isNullable ? 16 : 17);
+            case STRING -> Optional.of(isNullable ? 18 : 19);
+            default -> Optional.empty();
+          };
+        }
+      } else if (logicalScalarType != null) {
+        if (logicalScalarType == MltTilesetMetadata.LogicalScalarType.ID) {
+          return Optional.of(isNullable ? (hasLongIDs ? 20 : 21) : (hasLongIDs ? 22 : 23));
+        }
+      } else if (physicalComplexType != null) {
+        if (physicalComplexType == MltTilesetMetadata.ComplexType.GEOMETRY) {
+          if (!isNullable && !hasChildren) {
+            return Optional.of(24);
+          }
+        } else if (physicalComplexType == MltTilesetMetadata.ComplexType.STRUCT) {
+          if (!isNullable && hasChildren) {
+            return Optional.of(25);
+          }
+        }
+      }
+      return Optional.empty();
+    }
+
+    /// Re-create a `Column` from the unique type code.
+    /// The inverse of `getTag1TypeEncoding``
+    public static MltTilesetMetadata.Column.Builder decodeColumnType(int typeCode) {
+      final var builder = MltTilesetMetadata.Column.newBuilder();
+      if (0 <= typeCode && typeCode <= 19) {
+        return MltTilesetMetadata.Column.newBuilder()
+            .setNullable((typeCode & 1) == 0)
+            .setScalarType(
+                MltTilesetMetadata.ScalarColumn.newBuilder()
+                    .setPhysicalType(
+                        switch (typeCode) {
+                          case 0, 1 -> MltTilesetMetadata.ScalarType.BOOLEAN;
+                          case 2, 3 -> MltTilesetMetadata.ScalarType.INT_8;
+                          case 4, 5 -> MltTilesetMetadata.ScalarType.UINT_8;
+                          case 6, 7 -> MltTilesetMetadata.ScalarType.INT_32;
+                          case 8, 9 -> MltTilesetMetadata.ScalarType.UINT_32;
+                          case 10, 11 -> MltTilesetMetadata.ScalarType.INT_64;
+                          case 12, 13 -> MltTilesetMetadata.ScalarType.UINT_64;
+                          case 14, 15 -> MltTilesetMetadata.ScalarType.FLOAT;
+                          case 16, 17 -> MltTilesetMetadata.ScalarType.DOUBLE;
+                          case 18, 19 -> MltTilesetMetadata.ScalarType.STRING;
+                          default -> {
+                            // Should be impossible due to the containing `if`
+                            throw new IllegalStateException("Unsupported Type");
+                          }
+                        }));
+      } else if (20 <= typeCode && typeCode <= 23) {
+        return builder
+            .setNullable(typeCode < 22)
+            .setName(PropertyEncoder.ID_COLUMN_NAME)
+            .setScalarType(
+                MltTilesetMetadata.ScalarColumn.newBuilder()
+                    .setLongID((typeCode & 1) == 0)
+                    .setLogicalType(MltTilesetMetadata.LogicalScalarType.ID));
+      } else if (24 == typeCode) {
+        return builder
+            .setNullable(false)
+            .setName(PropertyEncoder.GEOMETRY_COLUMN_NAME)
+            .setComplexType(
+                MltTilesetMetadata.ComplexColumn.newBuilder()
+                    .setPhysicalType(MltTilesetMetadata.ComplexType.GEOMETRY));
+      } else if (25 == typeCode) {
+        return builder
+            .setNullable(false)
+            .setComplexType(
+                MltTilesetMetadata.ComplexColumn.newBuilder()
+                    .setPhysicalType(MltTilesetMetadata.ComplexType.STRUCT));
+      } else {
+        throw new IllegalStateException("Unsupported Type " + typeCode);
+      }
+    }
+
+    public static boolean columnTypeHasName(int typeCode) {
+      return (typeCode < 20 || typeCode > 24);
+    }
+
+    public static boolean columnTypeHasChildren(int typeCode) {
+      return (typeCode == 25);
+    }
+
+    public static boolean isID(MltTilesetMetadata.Column column) {
+      return column.hasScalarType()
+          && column.getScalarType().hasLogicalType()
+          && column.getScalarType().getLogicalType() == MltTilesetMetadata.LogicalScalarType.ID;
+    }
+
+    public static boolean isGeometry(MltTilesetMetadata.Column column) {
+      return column.hasComplexType()
+          && column.getComplexType().hasPhysicalType()
+          && column.getComplexType().getPhysicalType() == MltTilesetMetadata.ComplexType.GEOMETRY;
+    }
+
+    static boolean isStruct(MltTilesetMetadata.Column column) {
+      return column.hasComplexType()
+          && column.getComplexType().hasPhysicalType()
+          && column.getComplexType().getPhysicalType() == MltTilesetMetadata.ComplexType.STRUCT;
+    }
+
+    public static boolean hasStreamCount(MltTilesetMetadata.Column column) {
+      if (column.hasScalarType()) {
+        final var scalar = column.getScalarType();
+        if (scalar.hasPhysicalType()) {
+          switch (scalar.getPhysicalType()) {
+            case BOOLEAN:
+            case INT_8:
+            case UINT_8:
+            case INT_32:
+            case UINT_32:
+            case INT_64:
+            case UINT_64:
+            case FLOAT:
+            case DOUBLE:
+              return false;
+            case STRING:
+              return true;
+            default:
+          }
+        } else if (scalar.hasLogicalType()) {
+          if (scalar.getLogicalType() == MltTilesetMetadata.LogicalScalarType.ID) {
+            return false;
+          }
+        }
+      } else if (column.hasComplexType()) {
+        final var complex = column.getComplexType();
+        if (complex.hasPhysicalType()) {
+          switch (complex.getPhysicalType()) {
+            case GEOMETRY:
+            case STRUCT:
+              return true;
+            default:
+          }
+        }
+        // Complex/Logical not currently used
+      }
+      assert false;
+      return false;
+    }
+
+    ///  Convert a decoded `Column` into `Field` for child types
+    public static MltTilesetMetadata.Field toField(MltTilesetMetadata.Column column) {
+      var field =
+          MltTilesetMetadata.Field.newBuilder()
+              .setNullable(column.getNullable())
+              .setName(column.getName());
+      if (column.hasScalarType()) {
+        final var builder = MltTilesetMetadata.ScalarField.newBuilder();
+        if (column.getScalarType().hasPhysicalType()) {
+          field.setScalarField(builder.setPhysicalType(column.getScalarType().getPhysicalType()));
+        } else if (column.getScalarType().hasLogicalType()) {
+          field.setScalarField(builder.setLogicalType(column.getScalarType().getLogicalType()));
+        } else {
+          throw new RuntimeException("Unsupported Field Type");
+        }
+      } else if (column.hasComplexType()) {
+        final var builder = MltTilesetMetadata.ComplexField.newBuilder();
+        if (column.getComplexType().hasPhysicalType()) {
+          field.setComplexField(builder.setPhysicalType(column.getComplexType().getPhysicalType()));
+        } else if (column.getComplexType().hasLogicalType()) {
+          field.setComplexField(
+              builder.setLogicalType(column.getComplexTypeOrBuilder().getLogicalType()));
+        } else {
+          throw new RuntimeException("Unsupported Field Type");
+        }
+      } else {
+        throw new RuntimeException("Unsupported Field Type");
+      }
+      return field.build();
+    }
+  }
+}

--- a/java/src/main/java/org/maplibre/mlt/converter/encodings/MltTypeMap.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/encodings/MltTypeMap.java
@@ -18,31 +18,31 @@ public class MltTypeMap {
       if (physicalScalarType != null) {
         if (!hasChildren) {
           return switch (physicalScalarType) {
-            case BOOLEAN -> Optional.of(isNullable ? 0 : 1);
-            case INT_8 -> Optional.of(isNullable ? 2 : 3);
-            case UINT_8 -> Optional.of(isNullable ? 4 : 5);
-            case INT_32 -> Optional.of(isNullable ? 6 : 7);
-            case UINT_32 -> Optional.of(isNullable ? 8 : 9);
-            case INT_64 -> Optional.of(isNullable ? 10 : 11);
-            case UINT_64 -> Optional.of(isNullable ? 12 : 13);
-            case FLOAT -> Optional.of(isNullable ? 14 : 15);
-            case DOUBLE -> Optional.of(isNullable ? 16 : 17);
-            case STRING -> Optional.of(isNullable ? 18 : 19);
+            case BOOLEAN -> Optional.of(isNullable ? 11 : 10);
+            case INT_8 -> Optional.of(isNullable ? 13 : 12);
+            case UINT_8 -> Optional.of(isNullable ? 15 : 14);
+            case INT_32 -> Optional.of(isNullable ? 17 : 16);
+            case UINT_32 -> Optional.of(isNullable ? 19 : 18);
+            case INT_64 -> Optional.of(isNullable ? 21 : 20);
+            case UINT_64 -> Optional.of(isNullable ? 23 : 22);
+            case FLOAT -> Optional.of(isNullable ? 25 : 24);
+            case DOUBLE -> Optional.of(isNullable ? 27 : 26);
+            case STRING -> Optional.of(isNullable ? 29 : 28);
             default -> Optional.empty();
           };
         }
       } else if (logicalScalarType != null) {
         if (logicalScalarType == MltTilesetMetadata.LogicalScalarType.ID) {
-          return Optional.of(isNullable ? (hasLongIDs ? 20 : 21) : (hasLongIDs ? 22 : 23));
+          return Optional.of(isNullable ? (hasLongIDs ? 3 : 2) : (hasLongIDs ? 1 : 0));
         }
       } else if (physicalComplexType != null) {
         if (physicalComplexType == MltTilesetMetadata.ComplexType.GEOMETRY) {
           if (!isNullable && !hasChildren) {
-            return Optional.of(24);
+            return Optional.of(4);
           }
         } else if (physicalComplexType == MltTilesetMetadata.ComplexType.STRUCT) {
           if (!isNullable && hasChildren) {
-            return Optional.of(25);
+            return Optional.of(30);
           }
         }
       }
@@ -53,44 +53,44 @@ public class MltTypeMap {
     /// The inverse of `getTag1TypeEncoding``
     public static MltTilesetMetadata.Column.Builder decodeColumnType(int typeCode) {
       final var builder = MltTilesetMetadata.Column.newBuilder();
-      if (0 <= typeCode && typeCode <= 19) {
+      if (10 <= typeCode && typeCode <= 29) {
         return MltTilesetMetadata.Column.newBuilder()
-            .setNullable((typeCode & 1) == 0)
+            .setNullable((typeCode & 1) != 0)
             .setScalarType(
                 MltTilesetMetadata.ScalarColumn.newBuilder()
                     .setPhysicalType(
                         switch (typeCode) {
-                          case 0, 1 -> MltTilesetMetadata.ScalarType.BOOLEAN;
-                          case 2, 3 -> MltTilesetMetadata.ScalarType.INT_8;
-                          case 4, 5 -> MltTilesetMetadata.ScalarType.UINT_8;
-                          case 6, 7 -> MltTilesetMetadata.ScalarType.INT_32;
-                          case 8, 9 -> MltTilesetMetadata.ScalarType.UINT_32;
-                          case 10, 11 -> MltTilesetMetadata.ScalarType.INT_64;
-                          case 12, 13 -> MltTilesetMetadata.ScalarType.UINT_64;
-                          case 14, 15 -> MltTilesetMetadata.ScalarType.FLOAT;
-                          case 16, 17 -> MltTilesetMetadata.ScalarType.DOUBLE;
-                          case 18, 19 -> MltTilesetMetadata.ScalarType.STRING;
+                          case 10, 11 -> MltTilesetMetadata.ScalarType.BOOLEAN;
+                          case 12, 13 -> MltTilesetMetadata.ScalarType.INT_8;
+                          case 14, 15 -> MltTilesetMetadata.ScalarType.UINT_8;
+                          case 16, 17 -> MltTilesetMetadata.ScalarType.INT_32;
+                          case 18, 19 -> MltTilesetMetadata.ScalarType.UINT_32;
+                          case 20, 21 -> MltTilesetMetadata.ScalarType.INT_64;
+                          case 22, 23 -> MltTilesetMetadata.ScalarType.UINT_64;
+                          case 24, 25 -> MltTilesetMetadata.ScalarType.FLOAT;
+                          case 26, 27 -> MltTilesetMetadata.ScalarType.DOUBLE;
+                          case 28, 29 -> MltTilesetMetadata.ScalarType.STRING;
                           default -> {
                             // Should be impossible due to the containing `if`
                             throw new IllegalStateException("Unsupported Type");
                           }
                         }));
-      } else if (20 <= typeCode && typeCode <= 23) {
+      } else if (0 <= typeCode && typeCode <= 3) {
         return builder
-            .setNullable(typeCode < 22)
+            .setNullable(1 < typeCode)
             .setName(PropertyEncoder.ID_COLUMN_NAME)
             .setScalarType(
                 MltTilesetMetadata.ScalarColumn.newBuilder()
-                    .setLongID((typeCode & 1) == 0)
+                    .setLongID((typeCode & 1) != 0)
                     .setLogicalType(MltTilesetMetadata.LogicalScalarType.ID));
-      } else if (24 == typeCode) {
+      } else if (4 == typeCode) {
         return builder
             .setNullable(false)
             .setName(PropertyEncoder.GEOMETRY_COLUMN_NAME)
             .setComplexType(
                 MltTilesetMetadata.ComplexColumn.newBuilder()
                     .setPhysicalType(MltTilesetMetadata.ComplexType.GEOMETRY));
-      } else if (25 == typeCode) {
+      } else if (30 == typeCode) {
         return builder
             .setNullable(false)
             .setComplexType(
@@ -102,11 +102,11 @@ public class MltTypeMap {
     }
 
     public static boolean columnTypeHasName(int typeCode) {
-      return (typeCode < 20 || typeCode > 24);
+      return (typeCode < 10);
     }
 
     public static boolean columnTypeHasChildren(int typeCode) {
-      return (typeCode == 25);
+      return (typeCode == 30);
     }
 
     public static boolean isID(MltTilesetMetadata.Column column) {

--- a/java/src/main/java/org/maplibre/mlt/converter/encodings/PropertyEncoder.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/encodings/PropertyEncoder.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.Triple;
 import org.maplibre.mlt.converter.CollectionUtils;
+import org.maplibre.mlt.converter.MltConverter;
 import org.maplibre.mlt.converter.Settings;
 import org.maplibre.mlt.converter.mvt.ColumnMapping;
 import org.maplibre.mlt.data.Feature;
@@ -57,9 +58,7 @@ public class PropertyEncoder {
         featureScopedPropertyColumns =
             CollectionUtils.concatByteArrays(
                 featureScopedPropertyColumns, encodedScalarPropertyColumn);
-      } else if (columnMetadata.hasComplexType()
-          && columnMetadata.getComplexType().getPhysicalType()
-              == MltTilesetMetadata.ComplexType.STRUCT) {
+      } else if (MltConverter.isStruct(columnMetadata)) {
         if (columnMappings.isEmpty()) {
           throw new IllegalArgumentException(
               "Column mappings are required for nested property column "

--- a/java/src/main/java/org/maplibre/mlt/converter/encodings/StringEncoder.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/encodings/StringEncoder.java
@@ -60,8 +60,6 @@ public class StringEncoder {
 
           if (!dictionary.contains(value)) {
             dictionary.add(value);
-            var utf8EncodedData = value.getBytes(StandardCharsets.UTF_8);
-            // lengthStream.add(utf8EncodedData.length);
             var index = dictionary.size() - 1;
             dataStream.add(index);
           } else {
@@ -128,7 +126,7 @@ public class StringEncoder {
     }
 
     // TODO: make present stream optional
-    var numStreams =
+    final var numStreams =
         (encodedSharedFsstDictionary != null
                     && encodedSharedFsstDictionary.length < encodedSharedDictionary.length
                 ? 5

--- a/java/src/main/java/org/maplibre/mlt/decoder/DecodingUtils.java
+++ b/java/src/main/java/org/maplibre/mlt/decoder/DecodingUtils.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 import me.lemire.integercompression.*;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.orc.impl.BufferChunk;
 import org.apache.orc.impl.InStream;
 import org.apache.orc.impl.RunLengthByteReader;
@@ -135,22 +136,31 @@ public class DecodingUtils {
     return offset;
   }
 
-  public static int decodeVarint(InputStream stream) throws IOException {
+  public static Pair<Integer, Integer> decodeVarintWithLength(InputStream stream)
+      throws IOException {
     var b = (byte) stream.read();
+    var bytesRead = 1;
     var value = b & 0x7f;
     if ((b & 0x80) != 0) {
       b = (byte) stream.read();
+      bytesRead++;
       value |= (b & 0x7f) << 7;
       if ((b & 0x80) != 0) {
         b = (byte) stream.read();
+        bytesRead++;
         value |= (b & 0x7f) << 14;
         if ((b & 0x80) != 0) {
           b = (byte) stream.read();
+          bytesRead++;
           value |= (b & 0x7f) << 21;
         }
       }
     }
-    return value;
+    return Pair.of(value, bytesRead);
+  }
+
+  public static int decodeVarint(InputStream stream) throws IOException {
+    return decodeVarintWithLength(stream).getLeft();
   }
 
   public static String decodeString(InputStream stream) throws IOException {

--- a/java/src/main/java/org/maplibre/mlt/decoder/MltDecoder.java
+++ b/java/src/main/java/org/maplibre/mlt/decoder/MltDecoder.java
@@ -7,7 +7,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import me.lemire.integercompression.IntWrapper;
 import org.locationtech.jts.geom.Geometry;
-import org.maplibre.mlt.converter.MltConverter;
+import org.maplibre.mlt.converter.encodings.MltTypeMap;
 import org.maplibre.mlt.data.Feature;
 import org.maplibre.mlt.data.Layer;
 import org.maplibre.mlt.data.MapLibreTile;
@@ -15,60 +15,7 @@ import org.maplibre.mlt.metadata.stream.StreamMetadataDecoder;
 import org.maplibre.mlt.metadata.tileset.MltTilesetMetadata;
 
 public class MltDecoder {
-  private static final String ID_COLUMN_NAME = "id";
-  private static final String GEOMETRY_COLUMN_NAME = "geometry";
-
   private MltDecoder() {}
-
-  private static MltTilesetMetadata.Column.Builder decodeType(int typeCode) {
-    final var builder = MltTilesetMetadata.Column.newBuilder();
-    if (0 <= typeCode && typeCode <= 19) {
-      return MltTilesetMetadata.Column.newBuilder()
-          .setNullable((typeCode & 1) == 0)
-          .setScalarType(
-              MltTilesetMetadata.ScalarColumn.newBuilder()
-                  .setPhysicalType(
-                      switch (typeCode) {
-                        case 0, 1 -> MltTilesetMetadata.ScalarType.BOOLEAN;
-                        case 2, 3 -> MltTilesetMetadata.ScalarType.INT_8;
-                        case 4, 5 -> MltTilesetMetadata.ScalarType.UINT_8;
-                        case 6, 7 -> MltTilesetMetadata.ScalarType.INT_32;
-                        case 8, 9 -> MltTilesetMetadata.ScalarType.UINT_32;
-                        case 10, 11 -> MltTilesetMetadata.ScalarType.INT_64;
-                        case 12, 13 -> MltTilesetMetadata.ScalarType.UINT_64;
-                        case 14, 15 -> MltTilesetMetadata.ScalarType.FLOAT;
-                        case 16, 17 -> MltTilesetMetadata.ScalarType.DOUBLE;
-                        case 18, 19 -> MltTilesetMetadata.ScalarType.STRING;
-                        default -> {
-                          // Should be impossible due to the containing `if`
-                          throw new IllegalStateException("Unsupported Type");
-                        }
-                      }));
-    } else if (20 <= typeCode && typeCode <= 23) {
-      return builder
-          .setNullable(typeCode < 22)
-          .setName(ID_COLUMN_NAME)
-          .setScalarType(
-              MltTilesetMetadata.ScalarColumn.newBuilder()
-                  .setLongID((typeCode & 1) == 0)
-                  .setLogicalType(MltTilesetMetadata.LogicalScalarType.ID));
-    } else if (24 == typeCode) {
-      return builder
-          .setNullable(false)
-          .setName(GEOMETRY_COLUMN_NAME)
-          .setComplexType(
-              MltTilesetMetadata.ComplexColumn.newBuilder()
-                  .setPhysicalType(MltTilesetMetadata.ComplexType.GEOMETRY));
-    } else if (25 == typeCode) {
-      return builder
-          .setNullable(false)
-          .setComplexType(
-              MltTilesetMetadata.ComplexColumn.newBuilder()
-                  .setPhysicalType(MltTilesetMetadata.ComplexType.STRUCT));
-    } else {
-      throw new IllegalStateException("Unsupported Type " + typeCode);
-    }
-  }
 
   private static Layer parseBasicMVTEquivalent(int tag, InputStream stream) throws IOException {
     final var metadata = parseEmbeddedMetadata(stream);
@@ -101,28 +48,24 @@ public class MltDecoder {
   public static Layer decodeMltLayer(
       byte[] tile, MltTilesetMetadata.FeatureTableSchema layerMetadata, int tileExtent)
       throws IOException {
-    var offset = new IntWrapper(0);
+    final var offset = new IntWrapper(0);
     List<Long> ids = null;
     Geometry[] geometries = null;
-    var properties = new HashMap<String, List<Object>>();
+    final var properties = new HashMap<String, List<Object>>();
     for (var columnMetadata : layerMetadata.getColumnsList()) {
       final var columnName = columnMetadata.getName();
-      final var numStreams = DecodingUtils.decodeVarint(tile, offset, 1)[0];
+      final var hasStreamCount = MltTypeMap.Tag0x01.hasStreamCount(columnMetadata);
+      final var numStreams = hasStreamCount ? DecodingUtils.decodeVarint(tile, offset, 1)[0] : 0;
       // TODO: add decoding of vector type to be compliant with the spec
       // TODO: compare based on ids
-      if (MltConverter.isID(columnMetadata)) {
-        if (numStreams == 2) {
-          var presentStreamMetadata = StreamMetadataDecoder.decode(tile, offset);
+      if (MltTypeMap.Tag0x01.isID(columnMetadata)) {
+        if (columnMetadata.getNullable()) {
+          final var presentStreamMetadata = StreamMetadataDecoder.decode(tile, offset);
           // TODO: handle present stream -> should a id column even be nullable?
-          var presentStream =
-              DecodingUtils.decodeBooleanRle(
-                  tile,
-                  presentStreamMetadata.numValues(),
-                  presentStreamMetadata.byteLength(),
-                  offset);
+          offset.add(presentStreamMetadata.byteLength());
         }
 
-        var idDataStreamMetadata = StreamMetadataDecoder.decode(tile, offset);
+        final var idDataStreamMetadata = StreamMetadataDecoder.decode(tile, offset);
         if (columnMetadata.getScalarType().getLongID()) {
           ids = IntegerDecoder.decodeLongStream(tile, offset, idDataStreamMetadata, false);
         } else {
@@ -132,11 +75,12 @@ public class MltDecoder {
                   .boxed()
                   .collect(Collectors.toList());
         }
-      } else if (MltConverter.isGeometry(columnMetadata)) {
-        var geometryColumn = GeometryDecoder.decodeGeometryColumn(tile, numStreams, offset);
+      } else if (MltTypeMap.Tag0x01.isGeometry(columnMetadata)) {
+        assert hasStreamCount;
+        final var geometryColumn = GeometryDecoder.decodeGeometryColumn(tile, numStreams, offset);
         geometries = GeometryDecoder.decodeGeometry(geometryColumn);
       } else {
-        var propertyColumn =
+        final var propertyColumn =
             PropertyDecoder.decodePropertyColumn(tile, offset, columnMetadata, numStreams);
         if (propertyColumn instanceof HashMap<?, ?>) {
           @SuppressWarnings("unchecked")
@@ -152,6 +96,8 @@ public class MltDecoder {
           @SuppressWarnings("unchecked")
           var list = (List<Object>) propertyColumn;
           properties.put(columnName, list);
+        } else {
+          throw new RuntimeException("Unexpected property result");
         }
       }
     }
@@ -197,52 +143,22 @@ public class MltDecoder {
 
   private static MltTilesetMetadata.Column decodeColumn(InputStream stream) throws IOException {
     final var typeCode = DecodingUtils.decodeVarint(stream);
-    final var column = decodeType(typeCode);
+    final var column = MltTypeMap.Tag0x01.decodeColumnType(typeCode);
 
-    if (MltConverter.typeCodeHasName(typeCode)) {
+    if (MltTypeMap.Tag0x01.columnTypeHasName(typeCode)) {
       column.setName(DecodingUtils.decodeString(stream));
     }
 
-    if (MltConverter.typeCodeHasChildren(typeCode)) {
+    if (MltTypeMap.Tag0x01.columnTypeHasChildren(typeCode)) {
       final var childCount = DecodingUtils.decodeVarint(stream);
       for (var i = 0; i < childCount; ++i) {
         column.setComplexType(
             MltTilesetMetadata.ComplexColumn.newBuilder(column.getComplexType())
-                .addChildren(toField(decodeColumn(stream))));
+                .addChildren(MltTypeMap.Tag0x01.toField(decodeColumn(stream))));
       }
     }
 
     return column.build();
-  }
-
-  private static MltTilesetMetadata.Field toField(MltTilesetMetadata.Column column) {
-    var field =
-        MltTilesetMetadata.Field.newBuilder()
-            .setNullable(column.getNullable())
-            .setName(column.getName());
-    if (column.hasScalarType()) {
-      final var builder = MltTilesetMetadata.ScalarField.newBuilder();
-      if (column.getScalarType().hasPhysicalType()) {
-        field.setScalarField(builder.setPhysicalType(column.getScalarType().getPhysicalType()));
-      } else if (column.getScalarType().hasLogicalType()) {
-        field.setScalarField(builder.setLogicalType(column.getScalarType().getLogicalType()));
-      } else {
-        throw new RuntimeException("Unsupported Field Type");
-      }
-    } else if (column.hasComplexType()) {
-      final var builder = MltTilesetMetadata.ComplexField.newBuilder();
-      if (column.getComplexType().hasPhysicalType()) {
-        field.setComplexField(builder.setPhysicalType(column.getComplexType().getPhysicalType()));
-      } else if (column.getComplexType().hasLogicalType()) {
-        field.setComplexField(
-            builder.setLogicalType(column.getComplexTypeOrBuilder().getLogicalType()));
-      } else {
-        throw new RuntimeException("Unsupported Field Type");
-      }
-    } else {
-      throw new RuntimeException("Unsupported Field Type");
-    }
-    return field.build();
   }
 
   public static MltTilesetMetadata.FeatureTableSchema parseEmbeddedMetadata(InputStream stream)

--- a/java/src/main/java/org/maplibre/mlt/decoder/PropertyDecoder.java
+++ b/java/src/main/java/org/maplibre/mlt/decoder/PropertyDecoder.java
@@ -2,8 +2,8 @@ package org.maplibre.mlt.decoder;
 
 import java.io.IOException;
 import java.util.*;
+import javax.annotation.Nullable;
 import me.lemire.integercompression.IntWrapper;
-import org.maplibre.mlt.metadata.stream.StreamMetadata;
 import org.maplibre.mlt.metadata.stream.StreamMetadataDecoder;
 import org.maplibre.mlt.metadata.tileset.MltTilesetMetadata;
 
@@ -11,126 +11,137 @@ public class PropertyDecoder {
 
   private PropertyDecoder() {}
 
+  /// Use present bits to reconstitute the original list with null values, if appropriate
+  private static <T> List<T> unpack(
+      List<T> dataStream, @Nullable BitSet presentBits, int numPresentBits) {
+    if (presentBits == null) {
+      return dataStream;
+    }
+    final ArrayList<T> outValues = new ArrayList<>(presentBits.size());
+    var counter = 0;
+    for (var i = 0; i < numPresentBits; i++) {
+      outValues.add(presentBits.get(i) ? dataStream.get(counter++) : null);
+    }
+    return outValues;
+  }
+
+  ///  Special case for boolean columns because `BitSet` is not compatible with `List`
+  private static List<Boolean> unpack(
+      BitSet dataStream, int dataStreamSize, @Nullable BitSet presentBits, int numPresentBits) {
+    final var numValues = (presentBits != null) ? numPresentBits : dataStreamSize;
+    final ArrayList<Boolean> booleanValues = new ArrayList<>(numValues);
+    var counter = 0;
+    for (var i = 0; i < numValues; i++) {
+      booleanValues.add(
+          (presentBits == null || presentBits.get(i)) ? dataStream.get(counter++) : null);
+    }
+    return booleanValues;
+  }
+
+  private static Object decodeScalarPropertyColumn(
+      byte[] data,
+      IntWrapper offset,
+      MltTilesetMetadata.ScalarColumn scalarType,
+      boolean nullable,
+      int numStreams)
+      throws IOException {
+    final BitSet presentStream;
+    final int presentStreamSize;
+    if (nullable) {
+      final var presentStreamMetadata = StreamMetadataDecoder.decode(data, offset);
+      presentStream =
+          DecodingUtils.decodeBooleanRle(
+              data, presentStreamMetadata.numValues(), presentStreamMetadata.byteLength(), offset);
+      presentStreamSize = presentStreamMetadata.numValues();
+    } else {
+      presentStream = null;
+      presentStreamSize = 0;
+    }
+
+    switch (scalarType.getPhysicalType()) {
+      case BOOLEAN:
+        {
+          final var dataStreamMetadata = StreamMetadataDecoder.decode(data, offset);
+          final var dataStream =
+              DecodingUtils.decodeBooleanRle(
+                  data, dataStreamMetadata.numValues(), dataStreamMetadata.byteLength(), offset);
+          return unpack(
+              dataStream, dataStreamMetadata.numValues(), presentStream, presentStreamSize);
+        }
+      case UINT_32:
+      case INT_32:
+        {
+          final var dataStreamMetadata = StreamMetadataDecoder.decode(data, offset);
+          final var dataStream =
+              IntegerDecoder.decodeIntStream(
+                  data,
+                  offset,
+                  dataStreamMetadata,
+                  scalarType.getPhysicalType() == MltTilesetMetadata.ScalarType.INT_32);
+          return unpack(dataStream, presentStream, presentStreamSize);
+        }
+      case FLOAT:
+        {
+          final var dataStreamMetadata = StreamMetadataDecoder.decode(data, offset);
+          final var dataStream = FloatDecoder.decodeFloatStream(data, offset, dataStreamMetadata);
+          return unpack(dataStream, presentStream, presentStreamSize);
+        }
+      case DOUBLE:
+        {
+          {
+            final var dataStreamMetadata = StreamMetadataDecoder.decode(data, offset);
+            final var dataStream = FloatDecoder.decodeFloatStream(data, offset, dataStreamMetadata);
+            return unpack(dataStream, presentStream, presentStreamSize);
+          }
+        }
+      case UINT_64:
+      case INT_64:
+        {
+          final var dataStreamMetadata = StreamMetadataDecoder.decode(data, offset);
+          final var dataStream =
+              IntegerDecoder.decodeLongStream(
+                  data,
+                  offset,
+                  dataStreamMetadata,
+                  scalarType.getPhysicalType() == MltTilesetMetadata.ScalarType.INT_64);
+          return unpack(dataStream, presentStream, presentStreamSize);
+        }
+      case STRING:
+        {
+          if (presentStream == null) {
+            throw new RuntimeException("Non-nullable string columns not currently supported");
+          }
+
+          // The present stream has already been decoded
+          final var strValues =
+              StringDecoder.decode(data, offset, numStreams - 1, presentStream, presentStreamSize);
+          return strValues.getRight();
+        }
+      default:
+        throw new IllegalArgumentException(
+            "The specified data type for the field is currently not supported: " + scalarType);
+    }
+  }
+
   public static Object decodePropertyColumn(
       byte[] data, IntWrapper offset, MltTilesetMetadata.Column column, int numStreams)
       throws IOException {
-    StreamMetadata presentStreamMetadata = null;
 
     if (column.hasScalarType()) {
-      BitSet presentStream = null;
-      var numValues = 0;
-      if (numStreams > 1) {
-        presentStreamMetadata = StreamMetadataDecoder.decode(data, offset);
-        numValues = presentStreamMetadata.numValues();
-        presentStream =
-            DecodingUtils.decodeBooleanRle(
-                data,
-                presentStreamMetadata.numValues(),
-                presentStreamMetadata.byteLength(),
-                offset);
-      }
-
-      var scalarType = column.getScalarType();
-      switch (scalarType.getPhysicalType()) {
-        case BOOLEAN:
-          {
-            var dataStreamMetadata = StreamMetadataDecoder.decode(data, offset);
-            var dataStream =
-                DecodingUtils.decodeBooleanRle(
-                    data, dataStreamMetadata.numValues(), dataStreamMetadata.byteLength(), offset);
-            var booleanValues = new ArrayList<Boolean>(presentStreamMetadata.numValues());
-            var counter = 0;
-            for (var i = 0; i < presentStreamMetadata.numValues(); i++) {
-              var value = presentStream.get(i) ? dataStream.get(counter++) : null;
-              booleanValues.add(value);
-            }
-            return booleanValues;
-          }
-        case UINT_32:
-        case INT_32:
-          {
-            var dataStreamMetadata = StreamMetadataDecoder.decode(data, offset);
-            var dataStream =
-                IntegerDecoder.decodeIntStream(
-                    data,
-                    offset,
-                    dataStreamMetadata,
-                    scalarType.getPhysicalType() == MltTilesetMetadata.ScalarType.INT_32);
-            var counter = 0;
-            var values = new ArrayList<Integer>();
-            for (var i = 0; i < presentStreamMetadata.numValues(); i++) {
-              var value = presentStream.get(i) ? dataStream.get(counter++) : null;
-              values.add(value);
-            }
-            return values;
-          }
-        case FLOAT:
-          {
-            var dataStreamMetadata = StreamMetadataDecoder.decode(data, offset);
-            var dataStream = FloatDecoder.decodeFloatStream(data, offset, dataStreamMetadata);
-            var values = new ArrayList<Float>();
-            var counter = 0;
-            for (var i = 0; i < presentStreamMetadata.numValues(); i++) {
-              var value = presentStream.get(i) ? dataStream.get(counter++) : null;
-              values.add(value);
-            }
-            return values;
-          }
-        case DOUBLE:
-          {
-            {
-              var dataStreamMetadata = StreamMetadataDecoder.decode(data, offset);
-              var dataStream = FloatDecoder.decodeFloatStream(data, offset, dataStreamMetadata);
-              var values = new ArrayList<Float>();
-              var counter = 0;
-              for (var i = 0; i < presentStreamMetadata.numValues(); i++) {
-                var value = presentStream.get(i) ? dataStream.get(counter++) : null;
-                values.add(value);
-              }
-              return values;
-            }
-          }
-        case UINT_64:
-        case INT_64:
-          {
-            var dataStreamMetadata = StreamMetadataDecoder.decode(data, offset);
-            var dataStream =
-                IntegerDecoder.decodeLongStream(
-                    data,
-                    offset,
-                    dataStreamMetadata,
-                    scalarType.getPhysicalType() == MltTilesetMetadata.ScalarType.INT_64);
-            var values = new ArrayList<Long>();
-            var counter = 0;
-            for (var i = 0; i < presentStreamMetadata.numValues(); i++) {
-              var value = presentStream.get(i) ? dataStream.get(counter++) : null;
-              values.add(value);
-            }
-            return values;
-          }
-        case STRING:
-          {
-            var strValues =
-                StringDecoder.decode(data, offset, numStreams - 1, presentStream, numValues);
-            return strValues.getRight();
-          }
-        default:
-          throw new IllegalArgumentException(
-              "The specified data type for the field is currently not supported: " + scalarType);
-      }
+      return decodeScalarPropertyColumn(
+          data, offset, column.getScalarType(), column.getNullable(), numStreams);
     }
 
     /* Handle struct which currently only supports strings as nested fields for supporting shared dictionary encoding */
-    if (numStreams == 1) {
-      // var presentStreamMetadata = StreamMetadata.decode(data, offset);
-      // var presentStream = DecodingUtils.decodeBooleanRle(data, presentStreamMetadata.numValues(),
-      // presentStreamMetadata.byteLength(), offset);
-      // TODO: process present stream
-      // var values = StringDecoder.decodeSharedDictionary(data, offset, fieldMetadata);
-      throw new IllegalArgumentException("Present stream currently not supported for Structs.");
-    } else {
-      var result = StringDecoder.decodeSharedDictionary(data, offset, column);
-      return result.getRight();
+    if (numStreams > 1) {
+      return StringDecoder.decodeSharedDictionary(data, offset, column).getRight();
     }
+
+    // var presentStreamMetadata = StreamMetadata.decode(data, offset);
+    // var presentStream = DecodingUtils.decodeBooleanRle(data, presentStreamMetadata.numValues(),
+    // presentStreamMetadata.byteLength(), offset);
+    // TODO: process present stream
+    // var values = StringDecoder.decodeSharedDictionary(data, offset, fieldMetadata);
+    throw new IllegalArgumentException("Present stream currently not supported for Structs.");
   }
 }

--- a/java/src/main/java/org/maplibre/mlt/decoder/StringDecoder.java
+++ b/java/src/main/java/org/maplibre/mlt/decoder/StringDecoder.java
@@ -170,7 +170,6 @@ public class StringDecoder {
      * -> fsst dictionary -> symbolTable, symbolLength, dictionary, length, present, data
      * */
 
-    // BitSet presentStream = null;
     List<Integer> dictionaryLengthStream = null;
     List<Integer> offsetStream = null;
     byte[] dataStream = null;
@@ -178,15 +177,8 @@ public class StringDecoder {
     List<Integer> symbolLengthStream = null;
     byte[] symbolTableStream = null;
     for (var i = 0; i < numStreams; i++) {
-      var streamMetadata = StreamMetadataDecoder.decode(data, offset);
+      final var streamMetadata = StreamMetadataDecoder.decode(data, offset);
       switch (streamMetadata.physicalStreamType()) {
-          /*case PRESENT: {
-              //var presentStreamMetadata = StreamMetadata.decode(data, offset);
-              //TODO: set numValues in different stream if present stream is nullable
-              numValues = streamMetadata.numValues();
-              presentStream = DecodingUtils.decodeBooleanRle(data, streamMetadata.numValues(), streamMetadata.byteLength(), offset);
-              break;
-          }*/
         case OFFSET:
           {
             offsetStream = IntegerDecoder.decodeIntStream(data, offset, streamMetadata, false);
@@ -218,8 +210,7 @@ public class StringDecoder {
       }
     }
 
-    if (symbolTableStream != null && dictionaryLengthStream != null) {
-      @SuppressWarnings("deprecation")
+    if (symbolTableStream != null && symbolLengthStream != null && dictionaryLengthStream != null) {
       var utf8Values =
           FsstEncoder.decode(
               symbolTableStream,

--- a/java/src/main/java/org/maplibre/mlt/metadata/tileset/ColumnOptions.java
+++ b/java/src/main/java/org/maplibre/mlt/metadata/tileset/ColumnOptions.java
@@ -1,5 +1,0 @@
-package org.maplibre.mlt.metadata.tileset;
-
-public class ColumnOptions extends FieldOptions {
-  public static final int VERTEX_SCOPE = (1 << 4);
-}

--- a/java/src/main/java/org/maplibre/mlt/metadata/tileset/FieldOptions.java
+++ b/java/src/main/java/org/maplibre/mlt/metadata/tileset/FieldOptions.java
@@ -1,8 +1,0 @@
-package org.maplibre.mlt.metadata.tileset;
-
-public class FieldOptions {
-  public static final int NULLABLE = 1;
-  public static final int COMPLEX_TYPE = (1 << 1);
-  public static final int LOGICAL_TYPE = (1 << 2);
-  public static final int HAS_CHILDREN = (1 << 3);
-}

--- a/java/src/main/java/org/maplibre/mlt/metadata/tileset/MltTilesetMetadata.java
+++ b/java/src/main/java/org/maplibre/mlt/metadata/tileset/MltTilesetMetadata.java
@@ -5272,6 +5272,19 @@ public final class MltTilesetMetadata extends com.google.protobuf.GeneratedFile 
       com.google.protobuf.MessageOrBuilder {
 
     /**
+     *
+     *
+     * <pre>
+     * this belongs elsewhere, but is here for now
+     * </pre>
+     *
+     * <code>bool longID = 1;</code>
+     *
+     * @return The longID.
+     */
+    boolean getLongID();
+
+    /**
      * <code>.mlt.ScalarType physicalType = 4;</code>
      *
      * @return Whether the physicalType field is set.
@@ -5405,6 +5418,25 @@ public final class MltTilesetMetadata extends com.google.protobuf.GeneratedFile 
       return TypeCase.forNumber(typeCase_);
     }
 
+    public static final int LONGID_FIELD_NUMBER = 1;
+    private boolean longID_ = false;
+
+    /**
+     *
+     *
+     * <pre>
+     * this belongs elsewhere, but is here for now
+     * </pre>
+     *
+     * <code>bool longID = 1;</code>
+     *
+     * @return The longID.
+     */
+    @java.lang.Override
+    public boolean getLongID() {
+      return longID_;
+    }
+
     public static final int PHYSICALTYPE_FIELD_NUMBER = 4;
 
     /**
@@ -5499,6 +5531,9 @@ public final class MltTilesetMetadata extends com.google.protobuf.GeneratedFile 
 
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
+      if (longID_ != false) {
+        output.writeBool(1, longID_);
+      }
       if (typeCase_ == 4) {
         output.writeEnum(4, ((java.lang.Integer) type_));
       }
@@ -5514,6 +5549,9 @@ public final class MltTilesetMetadata extends com.google.protobuf.GeneratedFile 
       if (size != -1) return size;
 
       size = 0;
+      if (longID_ != false) {
+        size += com.google.protobuf.CodedOutputStream.computeBoolSize(1, longID_);
+      }
       if (typeCase_ == 4) {
         size +=
             com.google.protobuf.CodedOutputStream.computeEnumSize(4, ((java.lang.Integer) type_));
@@ -5538,6 +5576,7 @@ public final class MltTilesetMetadata extends com.google.protobuf.GeneratedFile 
       org.maplibre.mlt.metadata.tileset.MltTilesetMetadata.ScalarColumn other =
           (org.maplibre.mlt.metadata.tileset.MltTilesetMetadata.ScalarColumn) obj;
 
+      if (getLongID() != other.getLongID()) return false;
       if (!getTypeCase().equals(other.getTypeCase())) return false;
       switch (typeCase_) {
         case 4:
@@ -5560,6 +5599,8 @@ public final class MltTilesetMetadata extends com.google.protobuf.GeneratedFile 
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + LONGID_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(getLongID());
       switch (typeCase_) {
         case 4:
           hash = (37 * hash) + PHYSICALTYPE_FIELD_NUMBER;
@@ -5707,6 +5748,7 @@ public final class MltTilesetMetadata extends com.google.protobuf.GeneratedFile 
       public Builder clear() {
         super.clear();
         bitField0_ = 0;
+        longID_ = false;
         typeCase_ = 0;
         type_ = null;
         return this;
@@ -5749,6 +5791,9 @@ public final class MltTilesetMetadata extends com.google.protobuf.GeneratedFile 
       private void buildPartial0(
           org.maplibre.mlt.metadata.tileset.MltTilesetMetadata.ScalarColumn result) {
         int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.longID_ = longID_;
+        }
       }
 
       private void buildPartialOneofs(
@@ -5773,6 +5818,9 @@ public final class MltTilesetMetadata extends com.google.protobuf.GeneratedFile 
         if (other
             == org.maplibre.mlt.metadata.tileset.MltTilesetMetadata.ScalarColumn
                 .getDefaultInstance()) return this;
+        if (other.getLongID() != false) {
+          setLongID(other.getLongID());
+        }
         switch (other.getTypeCase()) {
           case PHYSICALTYPE:
             {
@@ -5815,6 +5863,12 @@ public final class MltTilesetMetadata extends com.google.protobuf.GeneratedFile 
               case 0:
                 done = true;
                 break;
+              case 8:
+                {
+                  longID_ = input.readBool();
+                  bitField0_ |= 0x00000001;
+                  break;
+                } // case 8
               case 32:
                 {
                   int rawValue = input.readEnum();
@@ -5861,6 +5915,62 @@ public final class MltTilesetMetadata extends com.google.protobuf.GeneratedFile 
       }
 
       private int bitField0_;
+
+      private boolean longID_;
+
+      /**
+       *
+       *
+       * <pre>
+       * this belongs elsewhere, but is here for now
+       * </pre>
+       *
+       * <code>bool longID = 1;</code>
+       *
+       * @return The longID.
+       */
+      @java.lang.Override
+      public boolean getLongID() {
+        return longID_;
+      }
+
+      /**
+       *
+       *
+       * <pre>
+       * this belongs elsewhere, but is here for now
+       * </pre>
+       *
+       * <code>bool longID = 1;</code>
+       *
+       * @param value The longID to set.
+       * @return This builder for chaining.
+       */
+      public Builder setLongID(boolean value) {
+
+        longID_ = value;
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+
+      /**
+       *
+       *
+       * <pre>
+       * this belongs elsewhere, but is here for now
+       * </pre>
+       *
+       * <code>bool longID = 1;</code>
+       *
+       * @return This builder for chaining.
+       */
+      public Builder clearLongID() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        longID_ = false;
+        onChanged();
+        return this;
+      }
 
       /**
        * <code>.mlt.ScalarType physicalType = 4;</code>
@@ -10999,33 +11109,33 @@ public final class MltTilesetMetadata extends com.google.protobuf.GeneratedFile 
           + "lable\030\002 \001(\010\022%\n\013columnScope\030\003 \001(\0162\020.mlt.C"
           + "olumnScope\022\'\n\nscalarType\030\004 \001(\0132\021.mlt.Sca"
           + "larColumnH\000\022)\n\013complexType\030\005 \001(\0132\022.mlt.C"
-          + "omplexColumnH\000B\006\n\004type\"n\n\014ScalarColumn\022\'"
-          + "\n\014physicalType\030\004 \001(\0162\017.mlt.ScalarTypeH\000\022"
-          + "-\n\013logicalType\030\005 \001(\0162\026.mlt.LogicalScalar"
-          + "TypeH\000B\006\n\004type\"\217\001\n\rComplexColumn\022(\n\014phys"
-          + "icalType\030\004 \001(\0162\020.mlt.ComplexTypeH\000\022.\n\013lo"
-          + "gicalType\030\005 \001(\0162\027.mlt.LogicalComplexType"
-          + "H\000\022\034\n\010children\030\006 \003(\0132\n.mlt.FieldB\006\n\004type"
-          + "\"\243\001\n\005Field\022\021\n\004name\030\001 \001(\tH\001\210\001\001\022\025\n\010nullabl"
-          + "e\030\002 \001(\010H\002\210\001\001\022\'\n\013scalarField\030\003 \001(\0132\020.mlt."
-          + "ScalarFieldH\000\022)\n\014complexField\030\004 \001(\0132\021.ml"
-          + "t.ComplexFieldH\000B\006\n\004typeB\007\n\005_nameB\013\n\t_nu"
-          + "llable\"m\n\013ScalarField\022\'\n\014physicalType\030\001 "
-          + "\001(\0162\017.mlt.ScalarTypeH\000\022-\n\013logicalType\030\002 "
-          + "\001(\0162\026.mlt.LogicalScalarTypeH\000B\006\n\004type\"\216\001"
-          + "\n\014ComplexField\022(\n\014physicalType\030\001 \001(\0162\020.m"
-          + "lt.ComplexTypeH\000\022.\n\013logicalType\030\002 \001(\0162\027."
-          + "mlt.LogicalComplexTypeH\000\022\034\n\010children\030\003 \003"
-          + "(\0132\n.mlt.FieldB\006\n\004type*&\n\013ColumnScope\022\013\n"
-          + "\007FEATURE\020\000\022\n\n\006VERTEX\020\001*\205\001\n\nScalarType\022\013\n"
-          + "\007BOOLEAN\020\000\022\t\n\005INT_8\020\001\022\n\n\006UINT_8\020\002\022\n\n\006INT"
-          + "_32\020\003\022\013\n\007UINT_32\020\004\022\n\n\006INT_64\020\005\022\013\n\007UINT_6"
-          + "4\020\006\022\t\n\005FLOAT\020\007\022\n\n\006DOUBLE\020\010\022\n\n\006STRING\020\t*\'"
-          + "\n\013ComplexType\022\014\n\010GEOMETRY\020\000\022\n\n\006STRUCT\020\001*"
-          + "\033\n\021LogicalScalarType\022\006\n\002ID\020\000*/\n\022LogicalC"
-          + "omplexType\022\n\n\006BINARY\020\000\022\r\n\tRANGE_MAP\020\001B#\n"
-          + "!org.maplibre.mlt.metadata.tilesetb\006prot"
-          + "o3"
+          + "omplexColumnH\000B\006\n\004type\"~\n\014ScalarColumn\022\016"
+          + "\n\006longID\030\001 \001(\010\022\'\n\014physicalType\030\004 \001(\0162\017.m"
+          + "lt.ScalarTypeH\000\022-\n\013logicalType\030\005 \001(\0162\026.m"
+          + "lt.LogicalScalarTypeH\000B\006\n\004type\"\217\001\n\rCompl"
+          + "exColumn\022(\n\014physicalType\030\004 \001(\0162\020.mlt.Com"
+          + "plexTypeH\000\022.\n\013logicalType\030\005 \001(\0162\027.mlt.Lo"
+          + "gicalComplexTypeH\000\022\034\n\010children\030\006 \003(\0132\n.m"
+          + "lt.FieldB\006\n\004type\"\243\001\n\005Field\022\021\n\004name\030\001 \001(\t"
+          + "H\001\210\001\001\022\025\n\010nullable\030\002 \001(\010H\002\210\001\001\022\'\n\013scalarFi"
+          + "eld\030\003 \001(\0132\020.mlt.ScalarFieldH\000\022)\n\014complex"
+          + "Field\030\004 \001(\0132\021.mlt.ComplexFieldH\000B\006\n\004type"
+          + "B\007\n\005_nameB\013\n\t_nullable\"m\n\013ScalarField\022\'\n"
+          + "\014physicalType\030\001 \001(\0162\017.mlt.ScalarTypeH\000\022-"
+          + "\n\013logicalType\030\002 \001(\0162\026.mlt.LogicalScalarT"
+          + "ypeH\000B\006\n\004type\"\216\001\n\014ComplexField\022(\n\014physic"
+          + "alType\030\001 \001(\0162\020.mlt.ComplexTypeH\000\022.\n\013logi"
+          + "calType\030\002 \001(\0162\027.mlt.LogicalComplexTypeH\000"
+          + "\022\034\n\010children\030\003 \003(\0132\n.mlt.FieldB\006\n\004type*&"
+          + "\n\013ColumnScope\022\013\n\007FEATURE\020\000\022\n\n\006VERTEX\020\001*\205"
+          + "\001\n\nScalarType\022\013\n\007BOOLEAN\020\000\022\t\n\005INT_8\020\001\022\n\n"
+          + "\006UINT_8\020\002\022\n\n\006INT_32\020\003\022\013\n\007UINT_32\020\004\022\n\n\006IN"
+          + "T_64\020\005\022\013\n\007UINT_64\020\006\022\t\n\005FLOAT\020\007\022\n\n\006DOUBLE"
+          + "\020\010\022\n\n\006STRING\020\t*\'\n\013ComplexType\022\014\n\010GEOMETR"
+          + "Y\020\000\022\n\n\006STRUCT\020\001*\033\n\021LogicalScalarType\022\006\n\002"
+          + "ID\020\000*/\n\022LogicalComplexType\022\n\n\006BINARY\020\000\022\r"
+          + "\n\tRANGE_MAP\020\001B#\n!org.maplibre.mlt.metada"
+          + "ta.tilesetb\006proto3"
     };
     descriptor =
         com.google.protobuf.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
@@ -11064,7 +11174,7 @@ public final class MltTilesetMetadata extends com.google.protobuf.GeneratedFile 
         new com.google.protobuf.GeneratedMessage.FieldAccessorTable(
             internal_static_mlt_ScalarColumn_descriptor,
             new java.lang.String[] {
-              "PhysicalType", "LogicalType", "Type",
+              "LongID", "PhysicalType", "LogicalType", "Type",
             });
     internal_static_mlt_ComplexColumn_descriptor = getDescriptor().getMessageTypes().get(4);
     internal_static_mlt_ComplexColumn_fieldAccessorTable =

--- a/java/src/test/java/org/maplibre/mlt/converter/encodings/MltTypeMapTest.java
+++ b/java/src/test/java/org/maplibre/mlt/converter/encodings/MltTypeMapTest.java
@@ -1,0 +1,62 @@
+package org.maplibre.mlt.converter.encodings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.maplibre.mlt.metadata.tileset.MltTilesetMetadata;
+
+public class MltTypeMapTest {
+  @Test
+  public void roundTrips() {
+    final var valid =
+        Set.of(
+            0, 1, 2, 3, 4, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
+            28, 29, 30);
+
+    for (var i = 0; i < 100; ++i) {
+      final MltTilesetMetadata.Column.Builder[] columns =
+          new MltTilesetMetadata.Column.Builder[] {null};
+      if (valid.contains(i)) {
+        final var typeCode = i;
+        Assertions.assertDoesNotThrow(
+            () -> columns[0] = MltTypeMap.Tag0x01.decodeColumnType(typeCode));
+      } else {
+        final var typeCode = i;
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> {
+              columns[0] = MltTypeMap.Tag0x01.decodeColumnType(typeCode);
+            });
+        continue;
+      }
+
+      final var column = columns[0];
+
+      // STRUCT must have children before being re-encoded
+      if (MltTypeMap.Tag0x01.columnTypeHasChildren(i)) {
+        column.setComplexType(
+            MltTilesetMetadata.ComplexColumn.newBuilder(column.getComplexType())
+                .addChildren(MltTilesetMetadata.Field.newBuilder()));
+      }
+
+      final boolean complex = column.hasComplexType();
+      final boolean logical =
+          (complex && column.getComplexType().hasLogicalType())
+              || (!complex && column.getScalarType().hasLogicalType());
+
+      final var typeCode =
+          MltTypeMap.Tag0x01.encodeColumnType(
+                  (!complex && !logical) ? column.getScalarType().getPhysicalType() : null,
+                  (!complex && logical) ? column.getScalarType().getLogicalType() : null,
+                  (complex && !logical) ? column.getComplexType().getPhysicalType() : null,
+                  (complex && logical) ? column.getComplexType().getLogicalType() : null,
+                  column.getNullable(),
+                  complex && !column.getComplexType().getChildrenList().isEmpty(),
+                  !complex && column.getScalarType().getLongID())
+              .or(Assertions::fail);
+      assertEquals(typeCode.get(), i);
+    }
+  }
+}

--- a/rust/mlt/src/converter/mlt.rs
+++ b/rust/mlt/src/converter/mlt.rs
@@ -81,12 +81,14 @@ pub fn create_tileset_metadata(
                 r#type: {
                     if layer.features.iter().all(|f| f.id <= i64::from(i32::MAX)) {
                         Some(column::Type::ScalarType(ScalarColumn {
+                            long_id: false,
                             r#type: Some(scalar_column::Type::PhysicalType(
                                 ScalarType::Uint32 as i32,
                             )),
                         }))
                     } else {
                         Some(column::Type::ScalarType(ScalarColumn {
+                            long_id: true,
                             r#type: Some(scalar_column::Type::PhysicalType(
                                 ScalarType::Uint64 as i32,
                             )),
@@ -238,6 +240,7 @@ pub fn create_tileset_metadata(
                     nullable: true,
                     column_scope: ColumnScope::Feature.into(),
                     r#type: Some(column::Type::ScalarType(ScalarColumn {
+                        long_id: false, // fixme: not sure if this is correct
                         r#type: Some(scalar_column::Type::PhysicalType(scalar_type as i32)),
                     })),
                 };

--- a/rust/mlt/src/decoder/helpers.rs
+++ b/rust/mlt/src/decoder/helpers.rs
@@ -87,6 +87,7 @@ mod tests {
             nullable: false,
             column_scope: 0,
             r#type: Some(column::Type::ScalarType(ScalarColumn {
+                long_id: false,
                 r#type: Some(scalar_column::Type::PhysicalType(ScalarType::Uint32 as i32)),
             })),
         };

--- a/rust/mlt/src/metadata/proto_tileset.rs
+++ b/rust/mlt/src/metadata/proto_tileset.rs
@@ -54,6 +54,9 @@ pub mod column {
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ScalarColumn {
+    /// this belongs elsewhere, but is here for now
+    #[prost(bool, tag = "1")]
+    pub long_id: bool,
     #[prost(oneof = "scalar_column::Type", tags = "4, 5")]
     pub r#type: ::core::option::Option<scalar_column::Type>,
 }

--- a/spec/schema/mlt_tileset_metadata.proto
+++ b/spec/schema/mlt_tileset_metadata.proto
@@ -36,6 +36,8 @@ message Column {
 }
 
 message ScalarColumn {
+  // this belongs elsewhere, but is here for now
+  bool longID = 1;
   oneof type {
     ScalarType physicalType = 4;
     LogicalScalarType logicalType = 5;


### PR DESCRIPTION
- Collapses the encoding of physical/logical,scalar/complex types into a single value range.
- Eliminates stream counts from scalar property columns other than string
- Eliminates present streams from non-nullable columns
