### PR TITLE
Add encoding server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.class
 *.log
+.DS_Store
 .idea/
 .vscode/
 bazel-*

--- a/java/encoding-server/.gitignore
+++ b/java/encoding-server/.gitignore
@@ -1,0 +1,2 @@
+cache/
+node_modules/

--- a/java/encoding-server/README.md
+++ b/java/encoding-server/README.md
@@ -1,0 +1,37 @@
+# MVT to MLT Development Server
+This Node.js-based application serves as a **development and testing server** for converting **MVT** to **MLT** in realtime.
+The server acts as a proxy for style, source, and tile endpoints, enabling seamless on-demand transformation of vector tile data.
+> Most of the arguments supported by the java encoder are also available as Node.js arguments or through `config.json` file.
+---
+
+## Prerequisites
+
+- Node.js
+- npm (Node package manager)
+- Java MLT encoder
+
+## Running the Server
+
+```bash
+cd encoding-server
+npm install
+npm start
+```
+
+## Requests
+
+In most cases, the initial style request is sufficient to initiate the process, with all subsequent source and tile requests automatically redirected back to the server.
+
+```bash
+## style - http://<server_ip>/style?url=<style_url>
+curl http://0.0.0.0/style?url=https://demotiles.maplibre.org/style.json ## default
+curl http://localhost/style?url=https://demotiles.maplibre.org/style.json
+curl http://10.0.2.2/style?url=https://demotiles.maplibre.org/style.json ## Android emulator bridge to 0.0.0.0
+
+## source - http://<server_ip>/style?url=<source_url>
+curl http://0.0.0.0/source?url=https://demotiles.maplibre.org/tiles/tiles.json
+
+## tile - http://<server_ip>/tile?url=<tile_url>
+curl http://0.0.0.0/tile?url=https://demotiles.maplibre.org/tiles/{z}/{x}/{y}.pbf
+
+```

--- a/java/encoding-server/config.json
+++ b/java/encoding-server/config.json
@@ -1,0 +1,13 @@
+{
+    "host": "0.0.0.0",
+    "port": 80,
+    "verbose": true,
+
+    "input": "mvt",
+    "noids": false,
+    "advanced": false,
+    "nomorton": false,
+    "outlines": "",
+    "timer": false,
+    "compare": false
+}

--- a/java/encoding-server/config.mjs
+++ b/java/encoding-server/config.mjs
@@ -1,0 +1,69 @@
+import yargs from 'yargs';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const configFile = JSON.parse(fs.readFileSync(path.join(__dirname, 'config.json')));
+
+const config = yargs(process.argv.slice(2))
+  .option('host', {
+    type: 'string',
+    default: (configFile && configFile.host) ? configFile.host : '0.0.0.0'
+  })
+  .option('port', {
+    type: 'number',
+    default: (configFile && configFile.port) ? configFile.port : 80
+  })
+  .option('verbose', {
+    type: 'boolean',
+    default: (configFile && configFile.verbose) ? configFile.verbose : true
+  })
+  .option('keep_files', {
+    type: 'boolean',
+    default: (configFile && configFile.keep_files) ? configFile.keep_files : false
+  })
+  .option('noencodingserver', {
+    type: 'boolean',
+    default: (configFile && configFile.noencodingserver) ? configFile.noencodingserver : false
+  })
+
+  // encoding params
+  .option('input', {
+    type: 'string',
+    choices: [ 'mvt', 'pmtiles' ],
+    default: (configFile && configFile.input) ? configFile.input : 'mvt'
+  })
+  .option('noids', {
+    type: 'boolean',
+    default: (configFile && configFile.noids) ? configFile.noids : false
+  })
+  .option('advanced', {
+    type: 'boolean',
+    default: (configFile && configFile.advanced) ? configFile.advanced : false
+  })
+  .option('nomorton', {
+    type: 'boolean',
+    default: (configFile && configFile.nomorton) ? configFile.nomorton : false
+  })
+  .option('outlines', {
+    type: 'string',
+    default: (configFile && configFile.outlines) ? configFile.outlines : ''
+  })
+  .option('timer', {
+    type: 'boolean',
+    default: (configFile && configFile.timer) ? configFile.timer : false
+  })
+  .option('compare', {
+    type: 'boolean',
+    default: (configFile && configFile.compare) ? configFile.compare : false
+  })
+  .argv;
+
+
+config.cachePath = path.join(__dirname, 'cache');
+config.cliToolsPath = path.join(__dirname, '../');
+config.encoderPath = path.join(config.cliToolsPath, 'build/libs/encode.jar');
+config.encoderPort = 3001;
+
+export default config;

--- a/java/encoding-server/convert.mjs
+++ b/java/encoding-server/convert.mjs
@@ -1,0 +1,314 @@
+import { get } from 'https';
+import { unlink, existsSync, mkdirSync, createWriteStream } from 'fs';
+import { join } from 'path';
+import { randomUUID } from 'crypto';
+import { exec, execSync, spawn } from 'child_process';
+import net from 'net';
+
+import config from './config.mjs'
+
+function convertRequest(convertResponse) {
+  return (req, res, next) => {
+    if (config.verbose) {
+      console.log(req.originalUrl);
+    }
+
+    if (!req.query.url) {
+      if (config.verbose) {
+        console.error('Missing `url` parameter');
+      }
+
+      res.status(400).send('Missing `url` parameter');
+      return;
+    }
+
+    let url;
+    try {
+      url = new URL(req.query.url)
+    } catch {
+      if (config.verbose) {
+        console.error(`Invalid url ${req.query.url}`);
+      }
+
+      res.status(400).send(`Invalid url: ${req.query.url}`);
+      return;
+    }
+
+    get(url, (stypeResponse) => {
+      let data = ''
+
+      stypeResponse.on('data', (chunk) => {
+        data += chunk;
+      });
+
+      stypeResponse.on('end', () => {
+        convertResponse(req, data, res);
+      });
+    }).on('error', (error) => {
+      if (config.verbose) {
+        console.error(`Request failed: ${req.query.url} - ${error}`);
+      }
+      res.status(500).send(`Request failed: ${req.query.url} - ${error}`);
+    });
+  };
+}
+
+function convertURL(urlString, type, req) {
+  try {
+    const url = new URL(urlString);
+              
+    if (url.protocol != 'https:' && url.protocol != 'http:') {
+      return urlString;
+    }
+  } catch (error) {
+    if (config.verbose) {
+      console.error(`URL (${urlString}) parse error: ${error}`);
+    }
+    return urlString;
+  }
+
+  return `${req.protocol}://${req.get('host')}/${type}?url=${urlString}`;
+}
+
+function convertStyleResponse(req, data, res) {
+  try {
+    const json = JSON.parse(data);
+
+    if (json.sources) {
+      for (let key in json.sources) {
+        if (!json.sources.hasOwnProperty(key)) {
+          continue;
+        }
+
+        var source = json.sources[key];
+
+        if (!source || source.type != 'vector') {
+          continue;
+        }
+
+        source.encoding = 'mlt';
+
+        if (source.url) {
+          source.url = convertURL(source.url, 'source', req);
+        }
+
+        if (source.tiles) {
+          source.tiles.forEach(tile => {
+            tile = convertURL(tile, 'tile', req);
+          });
+        }
+      }
+    }
+
+    res.status(200).json(json);
+  } catch (error) {
+    if (config.verbose) {
+      console.error(`Failed to parse style response: ${error}`);
+    }
+    res.status(400).send(`Failed to parse style response: ${error}`);
+  }
+}
+
+function convertSourceResponse(req, data, res) {
+  try {
+    const json = JSON.parse(data);
+
+    json.encoding = 'mlt';
+
+    if (json.tiles) {
+      for (let key in json.tiles) {
+        if (!json.tiles.hasOwnProperty(key)) {
+          continue;
+        }
+
+        json.tiles[key] = convertURL(json.tiles[key], 'tile', req);
+      }
+    }
+
+    res.status(200).json(json);
+  } catch (error) {
+    if (config.verbose) {
+      console.error(`Failed to parse style response: ${error}`);
+    }
+    res.status(400).send(`Failed to parse style response: ${error}`);
+  }
+}
+
+const convertStyleRequest = convertRequest(convertStyleResponse);
+const convertSourceRequest = convertRequest(convertSourceResponse);
+
+function convertTileResponse(filePath, res) {
+  const mltPath = filePath + '.mlt';
+  const args = 
+    ' --' + config.input + ' ' + filePath +
+    ' --mlt ' + mltPath +
+    (config.noids ? ' --noids' : '') +
+    (config.advanced ? ' --advanced' : '') +
+    (config.nomorton ? ' --nomorton' : '') +
+    (config.outlines ? ' --outlines \\*' : '') +
+    (config.timer ? ' --timer' : '') +
+    (config.compare ? ' --compare' : '');
+
+  const callback = (error, stdout, stderr) => {
+    if (config.verbose) {
+      if (stdout) {
+        console.log(`Encoder output: ${stderr}`);
+      }
+
+      if (stderr) {
+        console.error(`Encoder error: ${stderr}`);
+      }
+    }
+
+    if (!config.keep_files) {
+      unlink(filePath, (fileErr) => {
+        if (fileErr && config.verbose) {
+          console.error(`Failed to delete input file: ${filePath} - ${fileErr}`);
+        }
+      });
+    }
+
+    if (error) {
+      if (config.verbose) {
+        console.error(`Tile encoding failed: ${error}`);
+      }
+
+      res.status(500).send(`Tile encoding failed: ${error}`);
+      return;
+    }
+
+    res.on('finish', (error) => {
+      if (!config.keep_files) {
+        unlink(mltPath, (fileErr) => {
+          if (fileErr && config.verbose) {
+            console.error(`Failed to delete output file: ${mltPath} - ${fileErr}`);
+          }
+        });
+      }
+    });
+
+    res.status(200).sendFile(mltPath);
+  }
+
+  if (config.noencodingserver) {
+    convertTileCLI(args, callback);
+  } else {
+    convertTileCLIServer(args, callback);
+  }
+}
+
+function convertTileCLI(args, callback) {
+  const command = `java -jar ${config.encoderPath} ${args}`;
+  exec(command, callback);
+}
+
+function convertTileCLIServer(args, callback) {
+  const command = `${args}\n`;
+  const response = '';
+  const socket = new net.Socket();
+
+  socket.connect(config.encoderPort, 'localhost', () => {
+    socket.write(command);
+  });
+
+  socket.on('data', (data) => {
+    response += data;
+  });
+
+  socket.on('close', () => {
+    callback(null, response.length > 0 ? response : null, null)
+  });
+
+  socket.on('error', (error) => {
+    console.error(`Encoder error: ${error}`);
+  })
+}
+
+function convertTileRequest(req, res, next) {
+  if (config.verbose) {
+    console.log(req.originalUrl);
+  }
+
+  if (!req.query.url) {
+    if (config.verbose) {
+      console.error('Missing `url` parameter');
+    }
+
+    res.status(400).send('Missing `url` parameter');
+    return;
+  }
+
+  let url;
+  try {
+    url = new URL(req.query.url)
+  } catch {
+    if (config.verbose) {
+      console.error(`Invalid url: ${req.query.url}`);
+    }
+
+    res.status(400).send(`Invalid url: ${req.query.url}`);
+    return;
+  }
+
+  get(url, (tileResponse) => {
+    if (tileResponse.statusCode !== 200) {
+      res.status(tileResponse.statusCode).send(`Tile request error: ${req.query.url} - ${tileResponse.statusMessage}`);
+      return;
+    }
+
+    if (!existsSync(config.cachePath)) {
+      mkdirSync(config.cachePath, { recursive: true });
+    }
+
+    const file = createWriteStream(join(config.cachePath, randomUUID()));
+
+    tileResponse.pipe(file);
+
+    file.on('error', (error) => {
+      if (config.verbose) {
+        console.error(`Tile download failed: ${req.query.url} - ${error}`);
+      }
+      res.status(500).send(`Tile download failed: ${req.query.url} - ${error}`);
+    });
+
+    file.on('finish', () => {
+      file.close();
+      convertTileResponse(file.path, res);
+    });
+  }).on('error', (error) => {
+    if (config.verbose) {
+      console.error(`Request failed: ${req.query.url} - ${error}`);
+    }
+    res.status(500).send(`Request failed: ${req.query.url} - ${error}`);
+  });
+}
+
+function runCLISetup() {
+  console.log(`Building CLI tools at ${config.cliToolsPath}`);
+  execSync(`./gradlew cli`, { cwd: config.cliToolsPath });
+
+  if (config.noencodingserver) {
+    return;
+  }
+
+  const server = spawn(`java`, [
+    '-jar', `${config.encoderPath}`,
+    '--server', `${config.encoderPort}`,
+  ]);
+
+  if (config.verbose) {
+    server.stdout.on('data', (data) => {
+      console.log(`Encoder: ${data}`);
+    });
+
+    server.stderr.on('data', (data) => {
+      console.error(`Encoder: ${data}`);
+    });
+  }
+
+  server.on('close', (code) => {
+    console.log(`Encoder closed: ${code}`);
+  });
+}
+
+export { convertStyleRequest, convertSourceRequest, convertTileRequest, runCLISetup };

--- a/java/encoding-server/package.json
+++ b/java/encoding-server/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "encoding-server",
+  "version": "1.0.0",
+  "main": "server.mjs",
+  "scripts": {
+    "start": "node server.mjs"
+  },
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "express": "^5.1.0",
+    "https": "^1.0.0",
+    "yargs": "^18.0.0"
+  }
+}

--- a/java/encoding-server/server.mjs
+++ b/java/encoding-server/server.mjs
@@ -1,0 +1,16 @@
+import express from 'express';
+
+import config from './config.mjs'
+import { convertStyleRequest, convertSourceRequest, convertTileRequest, runCLISetup } from './convert.mjs'
+
+const app = express();
+
+app.use('/style', convertStyleRequest);
+app.use('/source', convertSourceRequest);
+app.use('/tile', convertTileRequest);
+
+app.listen(config.port, config.host, () => {
+  runCLISetup();
+
+  console.log(`Server started on port ${config.port}`);
+});

--- a/java/src/main/java/org/maplibre/mlt/cli/Server.java
+++ b/java/src/main/java/org/maplibre/mlt/cli/Server.java
@@ -1,0 +1,62 @@
+package org.maplibre.mlt.cli;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+public class Server {
+
+  public boolean run(int port) {
+    if (isRunning(port)) {
+      return true;
+    }
+
+    return startServer(port);
+  }
+
+  private boolean isRunning(int port) {
+    try (Socket client = new Socket("localhost", port)) {
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private boolean startServer(int port) {
+    try (ServerSocket server = new ServerSocket(port)) {
+      System.out.println("Server started on port " + port);
+
+      while (true) {
+        Socket client = server.accept();
+
+        new Thread(() -> handleClient(client)).start();
+      }
+    } catch(Exception e) {
+      System.err.println("Failed:");
+      e.printStackTrace(System.err);
+      return false;
+    }
+  }
+
+  private void handleClient(Socket socket) {
+    try (
+      BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+      PrintWriter out = new PrintWriter(socket.getOutputStream(), true);
+    ) {
+      try {
+        String command = in.readLine();
+
+        if (command != null) {
+          Encode.run(command.trim().split("\\s+"));
+        }
+      } catch(Exception e) {
+        e.printStackTrace(out);
+      }
+    } catch(Exception e) {
+      System.err.println("Failed:");
+      e.printStackTrace(System.err);
+    }
+  }
+}

--- a/java/src/main/java/org/maplibre/mlt/converter/encodings/GeometryEncoder.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/encodings/GeometryEncoder.java
@@ -618,10 +618,10 @@ public class GeometryEncoder {
     }
 
     // TODO: get rid of that separate calculation
-    var minVertexValue =
+    var minVertexValue = vertexBuffer.isEmpty() ? Integer.MAX_VALUE :
         Collections.min(
             vertexBuffer.stream().flatMapToInt(v -> IntStream.of(v.x(), v.y())).boxed().toList());
-    var maxVertexValue =
+    var maxVertexValue = vertexBuffer.isEmpty() ? -Integer.MAX_VALUE :
         Collections.max(
             vertexBuffer.stream().flatMapToInt(v -> IntStream.of(v.x(), v.y())).boxed().toList());
 


### PR DESCRIPTION
This PR adds a development server that acts as a proxy for style/source/tile requests and encodes tile responses to MLT.

- add server mode to the java cli encoder (avoid the jvm startup cost)
- tested with the native [implementation](https://github.com/maplibre/maplibre-native/pull/3246)
- fix exception in `GeometryEncoder.java`