### PR TITLE
Allow coercion or elision of mismatched property types

### DIFF
--- a/java/src/jmh/java/org/maplibre/mlt/BenchmarkUtils.java
+++ b/java/src/jmh/java/org/maplibre/mlt/BenchmarkUtils.java
@@ -36,8 +36,9 @@ public class BenchmarkUtils {
 
     var columnMapping = new ColumnMapping("name", ":", true);
     var columnMappings = List.of(columnMapping);
+    final var isIdPresent = true;
     var metadata =
-        MltConverter.createTilesetMetadata(encodedMvtTile.getRight(), columnMappings, true);
+        MltConverter.createTilesetMetadata(encodedMvtTile.getRight(), columnMappings, isIdPresent);
 
     var allowIdRegeneration = true;
     var allowSorting = true;

--- a/java/src/main/java/org/maplibre/mlt/converter/ConversionConfig.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/ConversionConfig.java
@@ -7,6 +7,7 @@ import java.util.Map;
 public class ConversionConfig {
   private final boolean includeIds;
   private final boolean useAdvancedEncodingSchemes;
+  private final boolean coercePropertyValues;
   private final boolean useMortonEncoding;
   private final boolean preTessellatePolygons;
   private final Map<String, FeatureTableOptimizations> optimizations;
@@ -22,12 +23,14 @@ public class ConversionConfig {
   public ConversionConfig(
       boolean includeIds,
       boolean useAdvancedEncodingSchemes,
+      boolean coercePropertyValues,
       Map<String, FeatureTableOptimizations> optimizations,
       boolean preTessellatePolygons,
       boolean useMortonEncoding,
       List<String> outlineFeatureTableNames) {
     this.includeIds = includeIds;
     this.useAdvancedEncodingSchemes = useAdvancedEncodingSchemes;
+    this.coercePropertyValues = coercePropertyValues;
     this.preTessellatePolygons = preTessellatePolygons;
     this.useMortonEncoding = useMortonEncoding;
     this.optimizations = (optimizations != null) ? optimizations : new HashMap<>();
@@ -44,6 +47,7 @@ public class ConversionConfig {
     this(
         includeIds,
         useAdvancedEncodingSchemes,
+        /* coercePropertyValues= */ false,
         optimizations,
         preTessellatePolygons,
         useMortonEncoding,
@@ -58,6 +62,7 @@ public class ConversionConfig {
     this(
         includeIds,
         useAdvancedEncodingSchemes,
+        /* coercePropertyValues= */ false,
         null,
         preTessellatePolygons,
         /* useMortonEncoding= */ true,
@@ -71,6 +76,7 @@ public class ConversionConfig {
     this(
         includeIds,
         useAdvancedEncodingSchemes,
+        /* coercePropertyValues= */ false,
         optimizations,
         /* preTessellatePolygons= */ false,
         /* useMortonEncoding= */ true,
@@ -81,6 +87,7 @@ public class ConversionConfig {
     this(
         includeIds,
         useAdvancedEncodingSchemes,
+        /* coercePropertyValues= */ false,
         /* optimizations= */ null,
         /* preTessellatePolygons= */ false,
         /* useMortonEncoding= */ true,
@@ -91,6 +98,7 @@ public class ConversionConfig {
     this(
         includeIds,
         /* useAdvancedEncodingSchemes= */ false,
+        /* coercePropertyValues= */ false,
         /* optimizations= */ null,
         /* preTessellatePolygons= */ false,
         /* useMortonEncoding= */ true,
@@ -101,6 +109,7 @@ public class ConversionConfig {
     this(
         /* includeIds= */ true,
         /* useAdvancedEncodingSchemes= */ false,
+        /* coercePropertyValues= */ false,
         /* optimizations= */ null,
         /* preTessellatePolygons= */ false,
         /* useMortonEncoding= */ true,
@@ -113,6 +122,10 @@ public class ConversionConfig {
 
   public boolean getUseAdvancedEncodingSchemes() {
     return this.useAdvancedEncodingSchemes;
+  }
+
+  public boolean getCoercePropertyValues() {
+    return this.coercePropertyValues;
   }
 
   public Map<String, FeatureTableOptimizations> getOptimizations() {

--- a/java/src/test/java/org/maplibre/mlt/MltGenerator.java
+++ b/java/src/test/java/org/maplibre/mlt/MltGenerator.java
@@ -69,9 +69,10 @@ public class MltGenerator {
       for (var mvTile : repo) {
         final var tileId = mvTile.tileId();
         try {
+          final var isIdPresent = false;
           final var tileMetadata =
               writeTileSetMetadata(
-                  MltConverter.createTilesetMetadata(mvTile, COLUMN_MAPPINGS, true),
+                  MltConverter.createTilesetMetadata(mvTile, COLUMN_MAPPINGS, isIdPresent),
                   MLT_OUTPUT_DIR);
 
           final var mlTile = convertMvtToMlt(optimizations, true, mvTile, tileMetadata);
@@ -121,9 +122,10 @@ public class MltGenerator {
       var mvt = Files.readAllBytes(Path.of(MVT_SPECIFIC_TILES_SOURCE_DIR, tileName.toString()));
       var mvTile = MvtUtils.decodeMvt(mvt, COLUMN_MAPPINGS);
       try {
-        var tileMetadata =
+        final var isIdPresent = false;
+        final var tileMetadata =
             writeTileSetMetadata(
-                MltConverter.createTilesetMetadata(mvTile, COLUMN_MAPPINGS, true),
+                MltConverter.createTilesetMetadata(mvTile, COLUMN_MAPPINGS, isIdPresent),
                 MLT_SPECIFIC_TILES_OUTPUT_DIR);
 
         var mlTile = convertMvtToMlt(optimizations, USE_POLYGON_TESSELLATION, mvTile, tileMetadata);
@@ -147,9 +149,11 @@ public class MltGenerator {
       var optimizations = getOptimizations();
       for (var mvTile : mvTiles) {
         try {
-          var tileMetadata =
+          final var isIdPresent = false;
+          final var tileMetadata =
               writeTileSetMetadata(
-                  MltConverter.createTilesetMetadata(mvTile.getMiddle(), COLUMN_MAPPINGS, true),
+                  MltConverter.createTilesetMetadata(
+                      mvTile.getMiddle(), COLUMN_MAPPINGS, isIdPresent),
                   MLT_SPECIFIC_TILES_OUTPUT_DIR);
 
           var mlTile =
@@ -196,6 +200,7 @@ public class MltGenerator {
         new ConversionConfig(
             /* includeIds= */ true,
             USE_ADVANCED_ENCODINGS,
+            /* coercePropertyValues= */ false,
             optimizations,
             USE_POLYGON_TESSELLATION,
             USE_MORTON_ENCODING,

--- a/java/src/test/java/org/maplibre/mlt/benchmarks/CompressionBenchmarks.java
+++ b/java/src/test/java/org/maplibre/mlt/benchmarks/CompressionBenchmarks.java
@@ -130,7 +130,8 @@ public class CompressionBenchmarks {
 
     var columnMapping = new ColumnMapping("name", ":", true);
     var columnMappings = List.of(columnMapping);
-    var tileMetadata = MltConverter.createTilesetMetadata(mvTile, columnMappings, true);
+    final var isIdPresent = true;
+    var tileMetadata = MltConverter.createTilesetMetadata(mvTile, columnMappings, isIdPresent);
 
     var optimization = new FeatureTableOptimizations(allowSorting, false, columnMappings);
     var optimizations =

--- a/java/src/test/java/org/maplibre/mlt/decoder/MltDecoderTest.java
+++ b/java/src/test/java/org/maplibre/mlt/decoder/MltDecoderTest.java
@@ -97,7 +97,8 @@ public class MltDecoderTest {
 
     var columnMapping = new ColumnMapping("name", ":", true);
     var columnMappings = List.of(columnMapping);
-    var tileMetadata = MltConverter.createTilesetMetadata(mvTile, columnMappings, true);
+    final var isIdPresent = true;
+    var tileMetadata = MltConverter.createTilesetMetadata(mvTile, columnMappings, isIdPresent);
 
     var allowSorting = optimization == TestUtils.Optimization.SORTED;
     var featureTableOptimization =


### PR DESCRIPTION
Add command-line options to `Encode` which allow layers with heterogeneous properties to be converted without exceptions.  Specifically, the MVTs in `test/fixtures/amazon_here`.  Such properties may be coerced or elided.  Coerced properties will be forced to a string type, elided values will become null.

This could be improved by:
- Selecting a type other than string when, e.g., all the values could be coerced to a better type.
- When eliding, selecting the type with the most values rather than the first one seen.
- Silently allow a limited set of coercions, e.g., `uint` to `sint`

