### PR TITLE
Add test case for 5-byte varint case

### DIFF
--- a/java/src/main/java/org/maplibre/mlt/converter/MltConverter.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/MltConverter.java
@@ -486,7 +486,8 @@ public class MltConverter {
           PhysicalLevelTechnique physicalLevelTechnique,
           boolean encodePolygonOutlines,
           @Nullable URI tessellateSource,
-          @Nullable HashMap<String, Triple<byte[], byte[], String>> rawStreamData) {
+          @Nullable HashMap<String, Triple<byte[], byte[], String>> rawStreamData)
+          throws IOException {
     /*
      * Following simple strategy is currently used for ordering the features when sorting is enabled:
      * - if id column is present and ids should not be reassigned -> sort id column

--- a/java/src/main/java/org/maplibre/mlt/converter/encodings/FloatEncoder.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/encodings/FloatEncoder.java
@@ -1,6 +1,7 @@
 package org.maplibre.mlt.converter.encodings;
 
 import jakarta.annotation.Nullable;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -15,7 +16,8 @@ public class FloatEncoder {
   public static byte[] encodeFloatStream(
       List<Float> values,
       @Nullable Map<String, Triple<byte[], byte[], String>> rawStreamData,
-      @Nullable String streamName) {
+      @Nullable String streamName)
+      throws IOException {
     // TODO: add encodings -> RLE, Dictionary, PDE, ALP
     float[] floatArray = new float[values.size()];
     for (int i = 0; i < values.size(); i++) {

--- a/java/src/main/java/org/maplibre/mlt/converter/encodings/GeometryEncoder.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/encodings/GeometryEncoder.java
@@ -5,6 +5,7 @@ import static org.maplibre.mlt.converter.encodings.IntegerEncoder.encodeVarint;
 
 import com.google.gson.Gson;
 import jakarta.annotation.Nullable;
+import java.io.IOException;
 import java.net.URI;
 import java.util.*;
 import java.util.function.Function;
@@ -53,7 +54,8 @@ public class GeometryEncoder {
       boolean useMortonEncoding,
       boolean encodePolygonOutlines,
       @Nullable URI tessellateSource,
-      @Nullable Map<String, Triple<byte[], byte[], String>> rawStreamData) {
+      @Nullable Map<String, Triple<byte[], byte[], String>> rawStreamData)
+      throws IOException {
     var geometryTypes = new ArrayList<Integer>();
     var numGeometries = new ArrayList<Integer>();
     var numParts = new ArrayList<Integer>();
@@ -426,7 +428,8 @@ public class GeometryEncoder {
       PhysicalLevelTechnique physicalLevelTechnique,
       ArrayList<Integer> numTriangles,
       ArrayList<Integer> indexBuffer,
-      @Nullable Map<String, Triple<byte[], byte[], String>> rawStreamData) {
+      @Nullable Map<String, Triple<byte[], byte[], String>> rawStreamData)
+      throws IOException {
     var encodedNumTrianglesBuffer =
         IntegerEncoder.encodeIntStream(
             numTriangles,
@@ -456,7 +459,8 @@ public class GeometryEncoder {
       ArrayList<Integer> numRings,
       ArrayList<Integer> numTriangles,
       ArrayList<Integer> indexBuffer,
-      @Nullable Map<String, Triple<byte[], byte[], String>> rawStreamData) {
+      @Nullable Map<String, Triple<byte[], byte[], String>> rawStreamData)
+      throws IOException {
     var encodedNumGeometries =
         IntegerEncoder.encodeIntStream(
             numGeometries,
@@ -526,7 +530,8 @@ public class GeometryEncoder {
       PhysicalLevelTechnique physicalLevelTechnique,
       SortSettings sortSettings,
       boolean useMortonEncoding,
-      @Nullable Map<String, Triple<byte[], byte[], String>> rawStreamData) {
+      @Nullable Map<String, Triple<byte[], byte[], String>> rawStreamData)
+      throws IOException {
     var geometryTypes = new ArrayList<Integer>();
     var numGeometries = new ArrayList<Integer>();
     var numParts = new ArrayList<Integer>();
@@ -985,7 +990,8 @@ public class GeometryEncoder {
       List<Integer> values,
       Collection<Vertex> vertices,
       PhysicalLevelTechnique physicalLevelTechnique,
-      @Nullable Map<String, Triple<byte[], byte[], String>> rawStreamData) {
+      @Nullable Map<String, Triple<byte[], byte[], String>> rawStreamData)
+      throws IOException {
     var encodedValues =
         physicalLevelTechnique == PhysicalLevelTechnique.FAST_PFOR
             ? encodeFastPfor(values, false)

--- a/java/src/main/java/org/maplibre/mlt/converter/encodings/IntegerEncoder.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/encodings/IntegerEncoder.java
@@ -2,6 +2,7 @@ package org.maplibre.mlt.converter.encodings;
 
 import com.google.common.collect.Lists;
 import jakarta.annotation.Nullable;
+import java.io.IOException;
 import java.util.*;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -42,7 +43,8 @@ public class IntegerEncoder {
       List<Integer> values,
       int numBits,
       int coordinateShift,
-      PhysicalLevelTechnique physicalLevelTechnique) {
+      PhysicalLevelTechnique physicalLevelTechnique)
+      throws IOException {
     var encodedValueStream = encodeMortonCodes(values, physicalLevelTechnique);
     var valuesMetadata =
         new MortonEncodedStreamMetadata(
@@ -64,7 +66,8 @@ public class IntegerEncoder {
       PhysicalLevelTechnique physicalLevelTechnique,
       boolean isSigned,
       PhysicalStreamType streamType,
-      LogicalStreamType logicalStreamType) {
+      LogicalStreamType logicalStreamType)
+      throws IOException {
     return encodeIntStream(
         values, physicalLevelTechnique, isSigned, streamType, logicalStreamType, null, null);
   }
@@ -76,7 +79,8 @@ public class IntegerEncoder {
       PhysicalStreamType streamType,
       LogicalStreamType logicalStreamType,
       @Nullable Map<String, Triple<byte[], byte[], String>> rawStreamData,
-      @Nullable String streamName) {
+      @Nullable String streamName)
+      throws IOException {
     var encodedValueStream = IntegerEncoder.encodeInt(values, physicalLevelTechnique, isSigned);
 
     // TODO: refactor -> also allow the use of none null suppression techniques
@@ -111,7 +115,8 @@ public class IntegerEncoder {
       List<Long> values,
       boolean isSigned,
       PhysicalStreamType streamType,
-      LogicalStreamType logicalStreamType) {
+      LogicalStreamType logicalStreamType)
+      throws IOException {
     return encodeLongStream(values, isSigned, streamType, logicalStreamType, null, null);
   }
 
@@ -121,7 +126,8 @@ public class IntegerEncoder {
       PhysicalStreamType streamType,
       LogicalStreamType logicalStreamType,
       @Nullable Map<String, Triple<byte[], byte[], String>> rawStreamData,
-      @Nullable String streamName) {
+      @Nullable String streamName)
+      throws IOException {
     var encodedValueStream = IntegerEncoder.encodeLong(values, isSigned);
 
     /* Currently FastPfor is only supported with 32 bit so for long we always have to fallback to Varint encoding */

--- a/java/src/main/java/org/maplibre/mlt/converter/encodings/StringEncoder.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/encodings/StringEncoder.java
@@ -179,7 +179,8 @@ public class StringEncoder {
       boolean encodeDataStream,
       boolean isSharedDictionary,
       @Nullable Map<String, Triple<byte[], byte[], String>> rawStreamData,
-      String fieldName) {
+      String fieldName)
+      throws IOException {
     var dataStream = new ArrayList<Integer>(values.size());
     // var lengthStream = new ArrayList<Integer>();
     var dictionary = new ArrayList<String>();
@@ -220,7 +221,8 @@ public class StringEncoder {
       PhysicalLevelTechnique physicalLevelTechnique,
       boolean isSharedDictionary,
       @Nullable Map<String, Triple<byte[], byte[], String>> rawStreamData,
-      @Nullable String fieldName) {
+      @Nullable String fieldName)
+      throws IOException {
     var joinedValues = String.join("", values).getBytes(StandardCharsets.UTF_8);
     var symbolTable = FsstEncoder.encode(joinedValues);
 
@@ -299,7 +301,8 @@ public class StringEncoder {
       boolean encodeOffsetStream,
       boolean isSharedDictionary,
       @Nullable Map<String, Triple<byte[], byte[], String>> rawStreamData,
-      String fieldName) {
+      String fieldName)
+      throws IOException {
     var offsetStream = new ArrayList<Integer>(values.size());
     var lengthStream = new ArrayList<Integer>();
     var dictionary = new ArrayList<String>();

--- a/java/src/main/java/org/maplibre/mlt/decoder/GeometryDecoder.java
+++ b/java/src/main/java/org/maplibre/mlt/decoder/GeometryDecoder.java
@@ -1,5 +1,6 @@
 package org.maplibre.mlt.decoder;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,8 +24,8 @@ public class GeometryDecoder {
 
   private GeometryDecoder() {}
 
-  public static GeometryColumn decodeGeometryColumn(
-      byte[] tile, int numStreams, IntWrapper offset) {
+  public static GeometryColumn decodeGeometryColumn(byte[] tile, int numStreams, IntWrapper offset)
+      throws IOException {
     var geometryTypeMetadata = StreamMetadataDecoder.decode(tile, offset);
     var geometryTypes = IntegerDecoder.decodeIntStream(tile, offset, geometryTypeMetadata, false);
 

--- a/java/src/main/java/org/maplibre/mlt/decoder/IntegerDecoder.java
+++ b/java/src/main/java/org/maplibre/mlt/decoder/IntegerDecoder.java
@@ -1,5 +1,6 @@
 package org.maplibre.mlt.decoder;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -13,7 +14,8 @@ public class IntegerDecoder {
   private IntegerDecoder() {}
 
   public static List<Integer> decodeMortonStream(
-      byte[] data, IntWrapper offset, MortonEncodedStreamMetadata streamMetadata) {
+      byte[] data, IntWrapper offset, MortonEncodedStreamMetadata streamMetadata)
+      throws IOException {
     int[] values;
     if (streamMetadata.physicalLevelTechnique() == PhysicalLevelTechnique.FAST_PFOR) {
       // TODO: numValues is not right if rle or delta rle is used -> add separate flag in
@@ -72,7 +74,8 @@ public class IntegerDecoder {
   }
 
   public static List<Integer> decodeIntStream(
-      byte[] data, IntWrapper offset, StreamMetadata streamMetadata, boolean isSigned) {
+      byte[] data, IntWrapper offset, StreamMetadata streamMetadata, boolean isSigned)
+      throws IOException {
     int[] values = null;
     if (streamMetadata.physicalLevelTechnique() == PhysicalLevelTechnique.FAST_PFOR) {
       values =

--- a/java/src/main/java/org/maplibre/mlt/decoder/StreamDecoder.java
+++ b/java/src/main/java/org/maplibre/mlt/decoder/StreamDecoder.java
@@ -1,11 +1,12 @@
 package org.maplibre.mlt.decoder;
 
+import java.io.IOException;
 import me.lemire.integercompression.IntWrapper;
 import org.maplibre.mlt.metadata.stream.*;
 
 public class StreamDecoder {
 
-  public static StreamMetadata decode(byte[] tile, IntWrapper offset) {
+  public static StreamMetadata decode(byte[] tile, IntWrapper offset) throws IOException {
     var streamMetadata = StreamMetadata.decode(tile, offset);
 
     if (LogicalLevelTechnique.RLE.equals(streamMetadata.logicalLevelTechnique1())

--- a/java/src/main/java/org/maplibre/mlt/decoder/vectorized/VectorizedStringDecoder.java
+++ b/java/src/main/java/org/maplibre/mlt/decoder/vectorized/VectorizedStringDecoder.java
@@ -99,7 +99,8 @@ public class VectorizedStringDecoder {
       IntWrapper offset,
       int numStreams,
       BitVector bitVector,
-      int numFeatures) {
+      int numFeatures)
+      throws IOException {
     // TODO: handle ConstVector
     IntBuffer dictionaryLengthStream = null;
     IntBuffer offsetStream = null;
@@ -178,7 +179,7 @@ public class VectorizedStringDecoder {
   /** Not optimized for random access only for sequential iteration */
   @SuppressWarnings("rawtypes")
   public static Vector decodeSharedDictionary(
-      byte[] data, IntWrapper offset, MltTilesetMetadata.Column column) {
+      byte[] data, IntWrapper offset, MltTilesetMetadata.Column column) throws IOException {
     IntBuffer dictionaryLengthBuffer = null;
     ByteBuffer dictionaryBuffer = null;
     IntBuffer symbolLengthBuffer = null;
@@ -272,7 +273,8 @@ public class VectorizedStringDecoder {
 
   @SuppressWarnings("rawtypes")
   public static Vector decodeSharedDictionaryToRandomAccessFormat(
-      byte[] data, IntWrapper offset, MltTilesetMetadata.Column column, int numFeatures) {
+      byte[] data, IntWrapper offset, MltTilesetMetadata.Column column, int numFeatures)
+      throws IOException {
     IntBuffer dictionaryOffsetBuffer = null;
     ByteBuffer dictionaryBuffer = null;
     IntBuffer symbolOffsetBuffer = null;

--- a/java/src/main/java/org/maplibre/mlt/metadata/stream/MortonEncodedStreamMetadata.java
+++ b/java/src/main/java/org/maplibre/mlt/metadata/stream/MortonEncodedStreamMetadata.java
@@ -1,5 +1,6 @@
 package org.maplibre.mlt.metadata.stream;
 
+import java.io.IOException;
 import me.lemire.integercompression.IntWrapper;
 import org.apache.commons.lang3.ArrayUtils;
 import org.maplibre.mlt.converter.encodings.EncodingUtils;
@@ -32,13 +33,14 @@ public class MortonEncodedStreamMetadata extends StreamMetadata {
     this.coordinateShift = coordinateShift;
   }
 
-  public byte[] encode() {
+  public byte[] encode() throws IOException {
     var mortonInfos =
         EncodingUtils.encodeVarints(new long[] {numBits, coordinateShift}, false, false);
     return ArrayUtils.addAll(super.encode(), mortonInfos);
   }
 
-  public static MortonEncodedStreamMetadata decode(byte[] tile, IntWrapper offset) {
+  public static MortonEncodedStreamMetadata decode(byte[] tile, IntWrapper offset)
+      throws IOException {
     var streamMetadata = StreamMetadata.decode(tile, offset);
     var mortonInfo = DecodingUtils.decodeVarint(tile, offset, 2);
     return new MortonEncodedStreamMetadata(
@@ -54,7 +56,7 @@ public class MortonEncodedStreamMetadata extends StreamMetadata {
   }
 
   public static MortonEncodedStreamMetadata decodePartial(
-      StreamMetadata streamMetadata, byte[] tile, IntWrapper offset) {
+      StreamMetadata streamMetadata, byte[] tile, IntWrapper offset) throws IOException {
     var mortonInfo = DecodingUtils.decodeVarint(tile, offset, 2);
     return new MortonEncodedStreamMetadata(
         streamMetadata.physicalStreamType(),

--- a/java/src/main/java/org/maplibre/mlt/metadata/stream/RleEncodedStreamMetadata.java
+++ b/java/src/main/java/org/maplibre/mlt/metadata/stream/RleEncodedStreamMetadata.java
@@ -1,5 +1,6 @@
 package org.maplibre.mlt.metadata.stream;
 
+import java.io.IOException;
 import me.lemire.integercompression.IntWrapper;
 import org.apache.commons.lang3.ArrayUtils;
 import org.maplibre.mlt.converter.encodings.EncodingUtils;
@@ -40,12 +41,12 @@ public class RleEncodedStreamMetadata extends StreamMetadata {
     this.numRleValues = numRleValues;
   }
 
-  public byte[] encode() {
+  public byte[] encode() throws IOException {
     var encodedRleInfo = EncodingUtils.encodeVarints(new long[] {runs, numRleValues}, false, false);
     return ArrayUtils.addAll(super.encode(), encodedRleInfo);
   }
 
-  public static RleEncodedStreamMetadata decode(byte[] tile, IntWrapper offset) {
+  public static RleEncodedStreamMetadata decode(byte[] tile, IntWrapper offset) throws IOException {
     var streamMetadata = StreamMetadata.decode(tile, offset);
     var rleInfo = DecodingUtils.decodeVarint(tile, offset, 2);
     return new RleEncodedStreamMetadata(
@@ -61,7 +62,7 @@ public class RleEncodedStreamMetadata extends StreamMetadata {
   }
 
   public static RleEncodedStreamMetadata decodePartial(
-      StreamMetadata streamMetadata, byte[] tile, IntWrapper offset) {
+      StreamMetadata streamMetadata, byte[] tile, IntWrapper offset) throws IOException {
     var rleInfo = DecodingUtils.decodeVarint(tile, offset, 2);
     return new RleEncodedStreamMetadata(
         streamMetadata.physicalStreamType(),

--- a/java/src/main/java/org/maplibre/mlt/metadata/stream/StreamMetadata.java
+++ b/java/src/main/java/org/maplibre/mlt/metadata/stream/StreamMetadata.java
@@ -1,6 +1,7 @@
 package org.maplibre.mlt.metadata.stream;
 
 import com.google.common.primitives.Bytes;
+import java.io.IOException;
 import me.lemire.integercompression.IntWrapper;
 import org.maplibre.mlt.converter.encodings.EncodingUtils;
 import org.maplibre.mlt.decoder.DecodingUtils;
@@ -49,7 +50,7 @@ public class StreamMetadata {
     return logicalStreamType.offsetType().ordinal();
   }
 
-  public byte[] encode() {
+  public byte[] encode() throws IOException {
     var encodedStreamType = (byte) ((physicalStreamType.ordinal()) << 4 | getLogicalType());
     var encodedEncodingScheme =
         (byte)
@@ -61,7 +62,7 @@ public class StreamMetadata {
     return Bytes.concat(new byte[] {encodedStreamType, encodedEncodingScheme}, encodedLengthInfo);
   }
 
-  public static StreamMetadata decode(byte[] tile, IntWrapper offset) {
+  public static StreamMetadata decode(byte[] tile, IntWrapper offset) throws IOException {
     var streamType = tile[offset.get()];
     var physicalStreamType = PhysicalStreamType.values()[streamType >> 4];
     LogicalStreamType logicalStreamType = null;

--- a/java/src/main/java/org/maplibre/mlt/metadata/stream/StreamMetadataDecoder.java
+++ b/java/src/main/java/org/maplibre/mlt/metadata/stream/StreamMetadataDecoder.java
@@ -1,10 +1,11 @@
 package org.maplibre.mlt.metadata.stream;
 
+import java.io.IOException;
 import me.lemire.integercompression.IntWrapper;
 
 public class StreamMetadataDecoder {
 
-  public static StreamMetadata decode(byte[] tile, IntWrapper offset) {
+  public static StreamMetadata decode(byte[] tile, IntWrapper offset) throws IOException {
     var streamMetadata = StreamMetadata.decode(tile, offset);
     /* Currently morton can't be combined with RLE only with delta */
     if (streamMetadata.logicalLevelTechnique1().equals(LogicalLevelTechnique.MORTON)) {

--- a/java/src/test/java/org/maplibre/mlt/decoder/IntegerDecoderTest.java
+++ b/java/src/test/java/org/maplibre/mlt/decoder/IntegerDecoderTest.java
@@ -1,5 +1,6 @@
 package org.maplibre.mlt.decoder;
 
+import java.io.IOException;
 import java.util.List;
 import me.lemire.integercompression.IntWrapper;
 import org.junit.jupiter.api.Disabled;
@@ -11,7 +12,7 @@ import org.maplibre.mlt.metadata.stream.*;
 public class IntegerDecoderTest {
 
   @Test
-  public void decodeIntStream_SignedIntegerValues_PlainFastPforEncode() {
+  public void decodeIntStream_SignedIntegerValues_PlainFastPforEncode() throws IOException {
     var values = List.of(1, 2, 7, 3, -4, 5, 1, -8);
     var encodedStream =
         IntegerEncoder.encodeIntStream(
@@ -26,7 +27,7 @@ public class IntegerDecoderTest {
   }
 
   @Test
-  public void decodeIntStream_SignedIntegerValues_PlainVarintEncode() {
+  public void decodeIntStream_SignedIntegerValues_PlainVarintEncode() throws IOException {
     var values = List.of(1, 2, 7, 3, -4, 5, 1, -8);
     var encodedStream =
         IntegerEncoder.encodeIntStream(
@@ -41,11 +42,11 @@ public class IntegerDecoderTest {
   }
 
   @Test
-  public void decodeIntStream_SignedIntegerValues_PlainVarintEncode2() {
+  public void decodeIntStream_SignedIntegerValues_PlainVarintEncode2() throws IOException {
     var values = List.of(1523632385);
     var encodedStream =
-            IntegerEncoder.encodeIntStream(
-                    values, PhysicalLevelTechnique.VARINT, true, PhysicalStreamType.DATA, null);
+        IntegerEncoder.encodeIntStream(
+            values, PhysicalLevelTechnique.VARINT, true, PhysicalStreamType.DATA, null);
 
     var offset = new IntWrapper(0);
     var streamMetadata = StreamMetadata.decode(encodedStream, offset);
@@ -57,7 +58,7 @@ public class IntegerDecoderTest {
 
   @Test
   @Disabled
-  public void decodeIntStream_SignedIntegerValues_FastPforDeltaRleEncode() {
+  public void decodeIntStream_SignedIntegerValues_FastPforDeltaRleEncode() throws IOException {
     var values = List.of(-1, -2, -3, -4, -5, -6, -7, 8);
     var encodedStream =
         IntegerEncoder.encodeIntStream(
@@ -72,7 +73,7 @@ public class IntegerDecoderTest {
 
   @Test
   @Disabled
-  public void decodeIntStream_SignedIntegerValues_VarintDeltaRleEncode() {
+  public void decodeIntStream_SignedIntegerValues_VarintDeltaRleEncode() throws IOException {
     var values = List.of(-1, -2, -3, -4, -5, -6, -7, 8);
     var encodedStream =
         IntegerEncoder.encodeIntStream(
@@ -87,7 +88,7 @@ public class IntegerDecoderTest {
 
   @Test
   @Disabled
-  public void decodeIntStream_SignedIntegerValues_FastPforRleEncode() {
+  public void decodeIntStream_SignedIntegerValues_FastPforRleEncode() throws IOException {
     var values = List.of(-1, -1, -1, -1, -1, -1, -2, -2);
     var encodedStream =
         IntegerEncoder.encodeIntStream(
@@ -103,7 +104,7 @@ public class IntegerDecoderTest {
 
   @Test
   @Disabled
-  public void decodeIntStream_SignedIntegerValues_VarintRleEncode() {
+  public void decodeIntStream_SignedIntegerValues_VarintRleEncode() throws IOException {
     var values = List.of(-1, -1, -1, -1, -1, -1, -2, -2);
     var encodedStream =
         IntegerEncoder.encodeIntStream(
@@ -119,7 +120,7 @@ public class IntegerDecoderTest {
 
   @Test
   @Disabled
-  public void decodeIntStream_UnsignedIntegerValues_VarintRleEncode() {
+  public void decodeIntStream_UnsignedIntegerValues_VarintRleEncode() throws IOException {
     var values = List.of(1, 1, 1, 1, 1, 1, 2, 2);
     var encodedStream =
         IntegerEncoder.encodeIntStream(
@@ -135,7 +136,7 @@ public class IntegerDecoderTest {
 
   @Test
   @Disabled
-  public void decodeLongStream_SignedIntegerValues_PlainEncode() {
+  public void decodeLongStream_SignedIntegerValues_PlainEncode() throws IOException {
     var values = List.of(1l, 2l, 7l, 3l, -4l, 5l, 1l, -8l);
     var encodedStream =
         IntegerEncoder.encodeLongStream(values, true, PhysicalStreamType.DATA, null);
@@ -151,7 +152,7 @@ public class IntegerDecoderTest {
 
   @Test
   @Disabled
-  public void decodeLongStream_SignedIntegerValues_DeltaRleEncode() {
+  public void decodeLongStream_SignedIntegerValues_DeltaRleEncode() throws IOException {
     var values = List.of(-1l, -2l, -3l, -4l, -5l, -6l, -7l, 8l);
     var encodedStream =
         IntegerEncoder.encodeLongStream(values, true, PhysicalStreamType.DATA, null);
@@ -166,7 +167,7 @@ public class IntegerDecoderTest {
 
   @Test
   @Disabled
-  public void decodeLongStream_SignedIntegerValues_RleEncode() {
+  public void decodeLongStream_SignedIntegerValues_RleEncode() throws IOException {
     var values = List.of(-1l, -1l, -1l, -1l, -1l, -1l, -2l, -2l);
     var encodedStream =
         IntegerEncoder.encodeLongStream(values, true, PhysicalStreamType.DATA, null);

--- a/java/src/test/java/org/maplibre/mlt/decoder/IntegerDecoderTest.java
+++ b/java/src/test/java/org/maplibre/mlt/decoder/IntegerDecoderTest.java
@@ -41,6 +41,21 @@ public class IntegerDecoderTest {
   }
 
   @Test
+  public void decodeIntStream_SignedIntegerValues_PlainVarintEncode2() {
+    var values = List.of(1523632385);
+    var encodedStream =
+            IntegerEncoder.encodeIntStream(
+                    values, PhysicalLevelTechnique.VARINT, true, PhysicalStreamType.DATA, null);
+
+    var offset = new IntWrapper(0);
+    var streamMetadata = StreamMetadata.decode(encodedStream, offset);
+    var decodedValues = IntegerDecoder.decodeIntStream(encodedStream, offset, streamMetadata, true);
+
+    Assert.equals(values, decodedValues);
+    Assert.equals(LogicalLevelTechnique.NONE, streamMetadata.logicalLevelTechnique1());
+  }
+
+  @Test
   @Disabled
   public void decodeIntStream_SignedIntegerValues_FastPforDeltaRleEncode() {
     var values = List.of(-1, -2, -3, -4, -5, -6, -7, 8);


### PR DESCRIPTION
Maybe I'm missing something here, but there seems to be a problem with the varint decoding, though it's surprising that we didn't run into it yet.  This is the failing test case based on troubleshooting an error I got on a real tile.

@mactrem Is there a canonical set of test cases for the varint encoding we're using?  ~~There seem to be several slightly different variations on it.~~

I found the link to [Bazel](https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/util/VarInt.java).  There doesn't seem to be any testing of that varint code in the [test tree](http://github.com/bazelbuild/bazel/tree/master/src/test/java/com/google/devtools/build/lib/util).

But the decode implementation isn't quite the same, so I'll consider that confirmation.
