### PR TITLE
Fix several bugs, improve error message on type mismatch

### DIFF
--- a/java/src/main/java/org/maplibre/mlt/converter/encodings/MltTypeMap.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/encodings/MltTypeMap.java
@@ -102,7 +102,7 @@ public class MltTypeMap {
     }
 
     public static boolean columnTypeHasName(int typeCode) {
-      return (typeCode < 10);
+      return (10 <= typeCode);
     }
 
     public static boolean columnTypeHasChildren(int typeCode) {

--- a/java/src/main/java/org/maplibre/mlt/converter/encodings/PropertyEncoder.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/encodings/PropertyEncoder.java
@@ -212,7 +212,7 @@ public class PropertyEncoder {
       boolean coercePropertyValues,
       @Nullable Map<String, Triple<byte[], byte[], String>> rawStreamData)
       throws IOException {
-    var scalarType = columnMetadata.getScalarType().getPhysicalType();
+    final var scalarType = columnMetadata.getScalarType().getPhysicalType();
     switch (scalarType) {
       case BOOLEAN:
         {

--- a/java/src/main/java/org/maplibre/mlt/converter/geometry/SpaceFillingCurve.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/geometry/SpaceFillingCurve.java
@@ -27,7 +27,6 @@ public abstract class SpaceFillingCurve {
         || vertex.y() < minBound
         || vertex.x() > maxBound
         || vertex.y() > maxBound) {
-      // System.err.println("The specified tile buffer size is currently not supported.");
       throw new IllegalArgumentException(
           "The specified tile buffer size is currently not supported.");
     }

--- a/java/src/main/java/org/maplibre/mlt/decoder/MltDecoder.java
+++ b/java/src/main/java/org/maplibre/mlt/decoder/MltDecoder.java
@@ -24,7 +24,7 @@ public class MltDecoder {
       final var metadata = parseEmbeddedMetadata(countStream);
       final var tileExtent = DecodingUtils.decodeVarint(countStream);
       final var bodySize = layerSize - countStream.getCount();
-      return decodeMltLayer(stream.readNBytes((int) bodySize), metadata, tileExtent);
+      return decodeMltLayer(countStream.readNBytes((int) bodySize), metadata, tileExtent);
     }
   }
 


### PR DESCRIPTION
- ID columns were being written as signed ints.
- Type code check was inverted.
- Layer code was still reading to the end of the buffer it was given, leading to only one layer being decoded.
- Tag size was not correctly deducted from layer size.
- Layer metadata/header size was not correctly deducted from the layer body size.
- Type mismatch error now contains the layer name and the feature index as well as the property key.