### PR TITLE
Fix handling of negative values in 32-bit int decoding

### DIFF
--- a/java/src/main/java/org/maplibre/mlt/converter/MltConverter.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/MltConverter.java
@@ -525,13 +525,17 @@ public class MltConverter {
       FeatureTableOptimizations featureTableOptimizations,
       @Nullable HashMap<String, Triple<byte[], byte[], String>> rawStreamData)
       throws IOException {
-    var propertyColumns = filterPropertyColumns(featureTableMetadata);
+    final var propertyColumns = filterPropertyColumns(featureTableMetadata);
+    final List<ColumnMapping> columnMappings =
+        (featureTableOptimizations != null)
+            ? featureTableOptimizations.columnMappings()
+            : List.of();
     return PropertyEncoder.encodePropertyColumns(
         propertyColumns,
         sortedFeatures,
         config.getUseAdvancedEncodingSchemes(),
         config.getCoercePropertyValues(),
-        featureTableOptimizations != null ? featureTableOptimizations.columnMappings() : List.of(),
+        columnMappings,
         rawStreamData);
   }
 

--- a/java/src/main/java/org/maplibre/mlt/converter/encodings/GeometryEncoder.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/encodings/GeometryEncoder.java
@@ -995,8 +995,7 @@ public class GeometryEncoder {
     var encodedValues =
         physicalLevelTechnique == PhysicalLevelTechnique.FAST_PFOR
             ? encodeFastPfor(values, false)
-            : encodeVarint(
-                values.stream().mapToLong(i -> i).boxed().collect(Collectors.toList()), false);
+            : encodeVarint(values, false);
 
     var encodedMetadata =
         new StreamMetadata(

--- a/java/src/main/java/org/maplibre/mlt/converter/encodings/PropertyEncoder.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/encodings/PropertyEncoder.java
@@ -40,16 +40,17 @@ public class PropertyEncoder {
     var i = 0;
     for (var columnMetadata : propertyColumns) {
       if (columnMetadata.hasScalarType()) {
-        if (features.stream()
-            .noneMatch(f -> f.properties().containsKey(columnMetadata.getName()))) {
+        if (MltTypeMap.Tag0x01.hasStreamCount(columnMetadata)
+            && features.stream()
+                .noneMatch(f -> f.properties().containsKey(columnMetadata.getName()))) {
           /* Indicate a missing property column in the tile with a zero for the number of streams */
-          var encodedFieldMetadata = EncodingUtils.encodeVarints(new long[] {0}, false, false);
+          final var encodedFieldMetadata = EncodingUtils.encodeVarint(0, false);
           featureScopedPropertyColumns =
               CollectionUtils.concatByteArrays(featureScopedPropertyColumns, encodedFieldMetadata);
           continue;
         }
 
-        var encodedScalarPropertyColumn =
+        final var encodedScalarPropertyColumn =
             encodeScalarPropertyColumn(
                 columnMetadata,
                 features,
@@ -113,7 +114,7 @@ public class PropertyEncoder {
 
         if (sharedDictionary.stream().allMatch(List::isEmpty)) {
           /* Set number of streams to zero if no columns are present in this tile */
-          var encodedFieldMetadata = EncodingUtils.encodeVarints(new long[] {0}, false, false);
+          final var encodedFieldMetadata = EncodingUtils.encodeVarint(0, false);
           return CollectionUtils.concatByteArrays(
               featureScopedPropertyColumns, encodedFieldMetadata);
         }
@@ -126,10 +127,9 @@ public class PropertyEncoder {
                 rawStreamData,
                 columnMetadata.getName());
         // TODO: fix -> ony quick and dirty fix
-        var numStreams = nestedColumns.getLeft() == 0 ? 0 : 1;
+        final var numStreams = nestedColumns.getLeft() == 0 ? 0 : 1;
         /* Set number of streams to zero if no columns are present in this tile */
-        var encodedFieldMetadata =
-            EncodingUtils.encodeVarints(new long[] {numStreams}, false, false);
+        final var encodedFieldMetadata = EncodingUtils.encodeVarint(numStreams, false);
 
         // TODO: add present stream and present stream metadata for struct column in addition
         // to the FieldMetadata to be compliant with the specification

--- a/java/src/main/java/org/maplibre/mlt/converter/encodings/StringEncoder.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/encodings/StringEncoder.java
@@ -98,20 +98,20 @@ public class StringEncoder {
 
       if (dataStream.isEmpty()) {
         /* If no values are present in this column add zero for number of streams */
-        var encodedFieldMetadata = EncodingUtils.encodeVarints(new long[] {0}, false, false);
+        final var encodedFieldMetadata = EncodingUtils.encodeVarint(0, false);
         sharedDictionary = CollectionUtils.concatByteArrays(sharedDictionary, encodedFieldMetadata);
         continue;
       }
 
-      var encodedFieldMetadata = EncodingUtils.encodeVarints(new long[] {2}, false, false);
-      var encodedPresentStream =
+      final var encodedFieldMetadata = EncodingUtils.encodeVarints(new int[] {2}, false, false);
+      final var encodedPresentStream =
           BooleanEncoder.encodeBooleanStream(
               presentStream,
               PhysicalStreamType.PRESENT,
               rawStreamData,
               fieldName + "_present_" + i);
 
-      var encodedDataStream =
+      final var encodedDataStream =
           IntegerEncoder.encodeIntStream(
               dataStream,
               physicalLevelTechnique,

--- a/java/src/main/java/org/maplibre/mlt/decoder/IntegerDecoder.java
+++ b/java/src/main/java/org/maplibre/mlt/decoder/IntegerDecoder.java
@@ -24,7 +24,7 @@ public class IntegerDecoder {
           DecodingUtils.decodeFastPfor(
               data, streamMetadata.numValues(), streamMetadata.byteLength(), offset);
     } else if (streamMetadata.physicalLevelTechnique() == PhysicalLevelTechnique.VARINT) {
-      values = DecodingUtils.decodeVarint(data, offset, streamMetadata.numValues());
+      values = DecodingUtils.decodeVarints(data, offset, streamMetadata.numValues());
     } else {
       throw new IllegalArgumentException(
           "Specified physical level technique not yet supported: "
@@ -82,7 +82,7 @@ public class IntegerDecoder {
           DecodingUtils.decodeFastPfor(
               data, streamMetadata.numValues(), streamMetadata.byteLength(), offset);
     } else if (streamMetadata.physicalLevelTechnique() == PhysicalLevelTechnique.VARINT) {
-      values = DecodingUtils.decodeVarint(data, offset, streamMetadata.numValues());
+      values = DecodingUtils.decodeVarints(data, offset, streamMetadata.numValues());
     } else {
       throw new IllegalArgumentException(
           "Specified physical level technique not yet supported: "
@@ -93,7 +93,7 @@ public class IntegerDecoder {
   }
 
   private static List<Integer> decodeIntArray(
-      int[] values, StreamMetadata streamMetadata, boolean isSigned) {
+      int[] values, StreamMetadata streamMetadata, boolean isSigned) throws IOException {
     switch (streamMetadata.logicalLevelTechnique1()) {
       case DELTA:
         if (streamMetadata.logicalLevelTechnique2().equals(LogicalLevelTechnique.RLE)) {
@@ -137,7 +137,7 @@ public class IntegerDecoder {
 
   public static List<Long> decodeLongStream(
       byte[] data, IntWrapper offset, StreamMetadata streamMetadata, boolean isSigned) {
-    var values = DecodingUtils.decodeLongVarint(data, offset, streamMetadata.numValues());
+    var values = DecodingUtils.decodeLongVarints(data, offset, streamMetadata.numValues());
     return decodeLongArray(values, streamMetadata, isSigned);
   }
 

--- a/java/src/main/java/org/maplibre/mlt/decoder/MltDecoder.java
+++ b/java/src/main/java/org/maplibre/mlt/decoder/MltDecoder.java
@@ -61,7 +61,7 @@ public class MltDecoder {
     for (var columnMetadata : layerMetadata.getColumnsList()) {
       final var columnName = columnMetadata.getName();
       final var hasStreamCount = MltTypeMap.Tag0x01.hasStreamCount(columnMetadata);
-      final var numStreams = hasStreamCount ? DecodingUtils.decodeVarint(tile, offset, 1)[0] : 0;
+      final var numStreams = hasStreamCount ? DecodingUtils.decodeVarints(tile, offset, 1)[0] : 0;
       // TODO: add decoding of vector type to be compliant with the spec
       // TODO: compare based on ids
       if (MltTypeMap.Tag0x01.isID(columnMetadata)) {

--- a/java/src/main/java/org/maplibre/mlt/decoder/StringDecoder.java
+++ b/java/src/main/java/org/maplibre/mlt/decoder/StringDecoder.java
@@ -102,7 +102,7 @@ public class StringDecoder {
     var numValues = new HashMap<String, Integer>();
     var values = new HashMap<String, List<String>>();
     for (var childField : column.getComplexType().getChildrenList()) {
-      var numStreams = DecodingUtils.decodeVarint(data, offset, 1)[0];
+      var numStreams = DecodingUtils.decodeVarints(data, offset, 1)[0];
       if (numStreams != 2
           || childField.hasComplexField()
           || childField.getScalarField().getPhysicalType()

--- a/java/src/main/java/org/maplibre/mlt/metadata/stream/MortonEncodedStreamMetadata.java
+++ b/java/src/main/java/org/maplibre/mlt/metadata/stream/MortonEncodedStreamMetadata.java
@@ -34,15 +34,15 @@ public class MortonEncodedStreamMetadata extends StreamMetadata {
   }
 
   public byte[] encode() throws IOException {
-    var mortonInfos =
-        EncodingUtils.encodeVarints(new long[] {numBits, coordinateShift}, false, false);
+    final var mortonInfos =
+        EncodingUtils.encodeVarints(new int[] {numBits, coordinateShift}, false, false);
     return ArrayUtils.addAll(super.encode(), mortonInfos);
   }
 
   public static MortonEncodedStreamMetadata decode(byte[] tile, IntWrapper offset)
       throws IOException {
     var streamMetadata = StreamMetadata.decode(tile, offset);
-    var mortonInfo = DecodingUtils.decodeVarint(tile, offset, 2);
+    var mortonInfo = DecodingUtils.decodeVarints(tile, offset, 2);
     return new MortonEncodedStreamMetadata(
         streamMetadata.physicalStreamType(),
         streamMetadata.logicalStreamType(),
@@ -57,7 +57,7 @@ public class MortonEncodedStreamMetadata extends StreamMetadata {
 
   public static MortonEncodedStreamMetadata decodePartial(
       StreamMetadata streamMetadata, byte[] tile, IntWrapper offset) throws IOException {
-    var mortonInfo = DecodingUtils.decodeVarint(tile, offset, 2);
+    var mortonInfo = DecodingUtils.decodeVarints(tile, offset, 2);
     return new MortonEncodedStreamMetadata(
         streamMetadata.physicalStreamType(),
         streamMetadata.logicalStreamType(),

--- a/java/src/main/java/org/maplibre/mlt/metadata/stream/RleEncodedStreamMetadata.java
+++ b/java/src/main/java/org/maplibre/mlt/metadata/stream/RleEncodedStreamMetadata.java
@@ -42,13 +42,14 @@ public class RleEncodedStreamMetadata extends StreamMetadata {
   }
 
   public byte[] encode() throws IOException {
-    var encodedRleInfo = EncodingUtils.encodeVarints(new long[] {runs, numRleValues}, false, false);
+    final var encodedRleInfo =
+        EncodingUtils.encodeVarints(new int[] {runs, numRleValues}, false, false);
     return ArrayUtils.addAll(super.encode(), encodedRleInfo);
   }
 
   public static RleEncodedStreamMetadata decode(byte[] tile, IntWrapper offset) throws IOException {
     var streamMetadata = StreamMetadata.decode(tile, offset);
-    var rleInfo = DecodingUtils.decodeVarint(tile, offset, 2);
+    var rleInfo = DecodingUtils.decodeVarints(tile, offset, 2);
     return new RleEncodedStreamMetadata(
         streamMetadata.physicalStreamType(),
         streamMetadata.logicalStreamType(),
@@ -63,7 +64,7 @@ public class RleEncodedStreamMetadata extends StreamMetadata {
 
   public static RleEncodedStreamMetadata decodePartial(
       StreamMetadata streamMetadata, byte[] tile, IntWrapper offset) throws IOException {
-    var rleInfo = DecodingUtils.decodeVarint(tile, offset, 2);
+    var rleInfo = DecodingUtils.decodeVarints(tile, offset, 2);
     return new RleEncodedStreamMetadata(
         streamMetadata.physicalStreamType(),
         streamMetadata.logicalStreamType(),

--- a/java/src/main/java/org/maplibre/mlt/metadata/stream/StreamMetadata.java
+++ b/java/src/main/java/org/maplibre/mlt/metadata/stream/StreamMetadata.java
@@ -51,14 +51,14 @@ public class StreamMetadata {
   }
 
   public byte[] encode() throws IOException {
-    var encodedStreamType = (byte) ((physicalStreamType.ordinal()) << 4 | getLogicalType());
-    var encodedEncodingScheme =
+    final var encodedStreamType = (byte) ((physicalStreamType.ordinal()) << 4 | getLogicalType());
+    final var encodedEncodingScheme =
         (byte)
             (logicalLevelTechnique1.ordinal() << 5
                 | logicalLevelTechnique2.ordinal() << 2
                 | physicalLevelTechnique.ordinal());
-    var encodedLengthInfo =
-        EncodingUtils.encodeVarints(new long[] {numValues, byteLength}, false, false);
+    final var encodedLengthInfo =
+        EncodingUtils.encodeVarints(new int[] {numValues, byteLength}, false, false);
     return Bytes.concat(new byte[] {encodedStreamType, encodedEncodingScheme}, encodedLengthInfo);
   }
 
@@ -84,7 +84,7 @@ public class StreamMetadata {
     var logicalLevelTechnique2 = LogicalLevelTechnique.values()[encodingsHeader >> 2 & 0x7];
     var physicalLevelTechnique = PhysicalLevelTechnique.values()[encodingsHeader & 0x3];
     offset.increment();
-    var sizeInfo = DecodingUtils.decodeVarint(tile, offset, 2);
+    var sizeInfo = DecodingUtils.decodeVarints(tile, offset, 2);
     var numValues = sizeInfo[0];
     var byteLength = sizeInfo[1];
 

--- a/java/src/test/java/org/maplibre/mlt/converter/encodings/EncodingUtilsTest.java
+++ b/java/src/test/java/org/maplibre/mlt/converter/encodings/EncodingUtilsTest.java
@@ -1,11 +1,11 @@
 package org.maplibre.mlt.converter.encodings;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 import me.lemire.integercompression.IntWrapper;
@@ -65,7 +65,7 @@ public class EncodingUtilsTest {
             encodedBooleans, numValues, encodedBooleans.length, new IntWrapper(0));
 
     for (var i = 0; i < numValues; i++) {
-      assertEquals(false, decodeBooleans.get(i));
+      assertFalse(decodeBooleans.get(i));
     }
   }
 
@@ -76,9 +76,8 @@ public class EncodingUtilsTest {
       data[i] = i;
     }
 
-    var fastPforCompressed = EncodingUtils.encodeFastPfor128(data, false, false);
-    var varintCompressed =
-        EncodingUtils.encodeVarints(Arrays.stream(data).asLongStream().toArray(), false, false);
+    final var fastPforCompressed = EncodingUtils.encodeFastPfor128(data, false, false);
+    final var varintCompressed = EncodingUtils.encodeVarints(data, false, false);
 
     Files.write(Paths.get("./250k_ascending_fastpfor.bin"), fastPforCompressed);
     Files.write(Paths.get("./250k_ascending_varint.bin"), varintCompressed);

--- a/java/src/test/java/org/maplibre/mlt/decoder/DecodingUtilsTest.java
+++ b/java/src/test/java/org/maplibre/mlt/decoder/DecodingUtilsTest.java
@@ -2,6 +2,7 @@ package org.maplibre.mlt.decoder;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import me.lemire.integercompression.IntWrapper;
 import org.apache.commons.lang3.ArrayUtils;
@@ -15,15 +16,15 @@ import org.maplibre.mlt.vector.BitVector;
 public class DecodingUtilsTest {
 
   @Test
-  public void decodeLongVarint() {
+  public void decodeLongVarints() throws IOException {
     var value = (long) Math.pow(2, 54);
     var value2 = (long) Math.pow(2, 17);
     var value3 = (long) Math.pow(2, 57);
     var encodedValues =
         EncodingUtils.encodeVarints(new long[] {value, value2, value3}, false, false);
 
-    var pos = new IntWrapper(0);
-    var decodedValue = DecodingUtils.decodeLongVarint(encodedValues, pos, 3);
+    final var pos = new IntWrapper(0);
+    final var decodedValue = DecodingUtils.decodeLongVarints(encodedValues, pos, 3);
 
     Assert.equals(value, decodedValue[0]);
     Assert.equals(value2, decodedValue[1]);

--- a/java/src/test/java/org/maplibre/mlt/decoder/IntegerDecoderTest.java
+++ b/java/src/test/java/org/maplibre/mlt/decoder/IntegerDecoderTest.java
@@ -10,6 +10,26 @@ import org.maplibre.mlt.converter.encodings.*;
 import org.maplibre.mlt.metadata.stream.*;
 
 public class IntegerDecoderTest {
+  @Test
+  public void encode_Int_Limits() throws IOException {
+    for (int v : new int[] {Integer.MIN_VALUE, -1, 0, 1, Integer.MAX_VALUE}) {
+      EncodingUtils.encodeVarint(v, true);
+      final var encoded = EncodingUtils.encodeVarint(v, false);
+      final var decoded = DecodingUtils.decodeVarints(encoded, new IntWrapper(0), 1)[0];
+      Assert.equals(decoded, v);
+    }
+  }
+
+  @Test
+  public void encode_Int_Limits_ZigZag() throws IOException {
+    for (int v : new int[] {Integer.MIN_VALUE, -1, 0, 1, Integer.MAX_VALUE}) {
+      EncodingUtils.encodeVarint(v, true);
+      final var encoded = EncodingUtils.encodeVarint(v, true);
+      final var zigzag = DecodingUtils.decodeVarints(encoded, new IntWrapper(0), 1)[0];
+      final var decoded = DecodingUtils.decodeZigZag(zigzag);
+      Assert.equals(decoded, v);
+    }
+  }
 
   @Test
   public void decodeIntStream_SignedIntegerValues_PlainFastPforEncode() throws IOException {
@@ -29,21 +49,6 @@ public class IntegerDecoderTest {
   @Test
   public void decodeIntStream_SignedIntegerValues_PlainVarintEncode() throws IOException {
     var values = List.of(1, 2, 7, 3, -4, 5, 1, -8);
-    var encodedStream =
-        IntegerEncoder.encodeIntStream(
-            values, PhysicalLevelTechnique.VARINT, true, PhysicalStreamType.DATA, null);
-
-    var offset = new IntWrapper(0);
-    var streamMetadata = StreamMetadata.decode(encodedStream, offset);
-    var decodedValues = IntegerDecoder.decodeIntStream(encodedStream, offset, streamMetadata, true);
-
-    Assert.equals(values, decodedValues);
-    Assert.equals(LogicalLevelTechnique.NONE, streamMetadata.logicalLevelTechnique1());
-  }
-
-  @Test
-  public void decodeIntStream_SignedIntegerValues_PlainVarintEncode2() throws IOException {
-    var values = List.of(1523632385);
     var encodedStream =
         IntegerEncoder.encodeIntStream(
             values, PhysicalLevelTechnique.VARINT, true, PhysicalStreamType.DATA, null);
@@ -137,7 +142,7 @@ public class IntegerDecoderTest {
   @Test
   @Disabled
   public void decodeLongStream_SignedIntegerValues_PlainEncode() throws IOException {
-    var values = List.of(1l, 2l, 7l, 3l, -4l, 5l, 1l, -8l);
+    final var values = List.of(1L, 2L, 7L, 3L, -4L, 5L, 1L, -8L);
     var encodedStream =
         IntegerEncoder.encodeLongStream(values, true, PhysicalStreamType.DATA, null);
 
@@ -153,7 +158,7 @@ public class IntegerDecoderTest {
   @Test
   @Disabled
   public void decodeLongStream_SignedIntegerValues_DeltaRleEncode() throws IOException {
-    var values = List.of(-1l, -2l, -3l, -4l, -5l, -6l, -7l, 8l);
+    final var values = List.of(-1L, -2L, -3L, -4L, -5L, -6L, -7L, 8L);
     var encodedStream =
         IntegerEncoder.encodeLongStream(values, true, PhysicalStreamType.DATA, null);
 
@@ -168,7 +173,7 @@ public class IntegerDecoderTest {
   @Test
   @Disabled
   public void decodeLongStream_SignedIntegerValues_RleEncode() throws IOException {
-    var values = List.of(-1l, -1l, -1l, -1l, -1l, -1l, -2l, -2l);
+    final var values = List.of(-1L, -1L, -1L, -1L, -1L, -1L, -2L, -2L);
     var encodedStream =
         IntegerEncoder.encodeLongStream(values, true, PhysicalStreamType.DATA, null);
 

--- a/java/src/test/java/org/maplibre/mlt/decoder/IntegerDecoderTest.java
+++ b/java/src/test/java/org/maplibre/mlt/decoder/IntegerDecoderTest.java
@@ -13,7 +13,6 @@ public class IntegerDecoderTest {
   @Test
   public void encode_Int_Limits() throws IOException {
     for (int v : new int[] {Integer.MIN_VALUE, -1, 0, 1, Integer.MAX_VALUE}) {
-      EncodingUtils.encodeVarint(v, true);
       final var encoded = EncodingUtils.encodeVarint(v, false);
       final var decoded = DecodingUtils.decodeVarints(encoded, new IntWrapper(0), 1)[0];
       Assert.equals(decoded, v);
@@ -23,7 +22,6 @@ public class IntegerDecoderTest {
   @Test
   public void encode_Int_Limits_ZigZag() throws IOException {
     for (int v : new int[] {Integer.MIN_VALUE, -1, 0, 1, Integer.MAX_VALUE}) {
-      EncodingUtils.encodeVarint(v, true);
       final var encoded = EncodingUtils.encodeVarint(v, true);
       final var zigzag = DecodingUtils.decodeVarints(encoded, new IntWrapper(0), 1)[0];
       final var decoded = DecodingUtils.decodeZigZag(zigzag);

--- a/java/src/test/java/org/maplibre/mlt/decoder/vectorized/VectorizedDecodingUtilsTest.java
+++ b/java/src/test/java/org/maplibre/mlt/decoder/vectorized/VectorizedDecodingUtilsTest.java
@@ -54,12 +54,13 @@ public class VectorizedDecodingUtilsTest {
   }
 
   @Test
-  void decodeLongVarint_UnsignedLong() {
+  void decodeLongVarint_UnsignedLong() throws IOException {
     var values = new long[] {0, 1, 127, 128, 255, 256, 555};
 
-    var encodedValues = EncodingUtils.encodeVarints(values, false, false);
-    var pos = new IntWrapper(0);
-    var decodedValues = VectorizedDecodingUtils.decodeLongVarint(encodedValues, pos, values.length);
+    final var encodedValues = EncodingUtils.encodeVarints(values, false, false);
+    final var pos = new IntWrapper(0);
+    final var decodedValues =
+        VectorizedDecodingUtils.decodeLongVarint(encodedValues, pos, values.length);
 
     assertEquals(values.length, decodedValues.capacity());
     assertEquals(pos.get(), encodedValues.length);


### PR DESCRIPTION
Large and negative `int` values are encoded with five bytes, and the decoder did not handle them correctly.  Those values encode differently when encoded as `long`, so care must be taken to encode and decode them the same way.