### PR TITLE
Make the compare option more useful

### DIFF
--- a/java/src/main/java/org/maplibre/mlt/cli/CliUtil.java
+++ b/java/src/main/java/org/maplibre/mlt/cli/CliUtil.java
@@ -11,6 +11,8 @@ public class CliUtil {
 
   private CliUtil() {}
 
+  // The method calls below are used to trigger lazy decoding of features, and their return values
+  // are intentionally ignored.
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public static void decodeFeatureTables(FeatureTable[] featureTables) {
     for (FeatureTable featureTable : featureTables) {

--- a/java/src/main/java/org/maplibre/mlt/cli/Encode.java
+++ b/java/src/main/java/org/maplibre/mlt/cli/Encode.java
@@ -771,18 +771,17 @@ public class Encode {
         if (compareProp) {
           final var mltProperties = mltFeature.properties();
           final var mvtProperties = mvtFeature.properties();
-          final var nonNullMLTProperties =
-              mltProperties.entrySet().stream().filter(entry -> entry.getValue() != null).toList();
-          if (mvtProperties.size() != nonNullMLTProperties.size()) {
+          final var nonNullMLTKeys =
+              mltProperties.entrySet().stream()
+                  .filter(entry -> entry.getValue() != null)
+                  .map(Map.Entry::getKey)
+                  .collect(Collectors.toUnmodifiableSet());
+          if (mvtProperties.size() != nonNullMLTKeys.size()) {
             throw new RuntimeException("Number of properties in MLT and MVT features do not match");
           }
           final var mvtPropertyKeys = mvtProperties.keySet();
-          final var nonNullMLTPropertyKeys =
-              nonNullMLTProperties.stream()
-                  .map(Map.Entry::getKey)
-                  .collect(Collectors.toUnmodifiableSet());
           // compare keys
-          if (!mvtPropertyKeys.equals(nonNullMLTPropertyKeys)) {
+          if (!mvtPropertyKeys.equals(nonNullMLTKeys)) {
             throw new RuntimeException("Property keys in MLT and MVT features do not match");
           }
           // compare values
@@ -1069,7 +1068,7 @@ public class Encode {
               .longOpt(COMPARE_GEOM_OPTION)
               .hasArg(false)
               .desc(
-                  "Assert that geometry in the the decoded tile is the same as the input tile. "
+                  "Assert that geometry in the decoded tile is the same as the input tile. "
                       + "Only applies with --"
                       + INPUT_TILE_ARG
                       + ".")
@@ -1080,7 +1079,7 @@ public class Encode {
               .longOpt(COMPARE_PROP_OPTION)
               .hasArg(false)
               .desc(
-                  "Assert that properties in the the decoded tile is the same as the input tile. "
+                  "Assert that properties in the decoded tile is the same as the input tile. "
                       + "Only applies with --"
                       + INPUT_TILE_ARG
                       + ".")

--- a/java/src/main/java/org/maplibre/mlt/cli/Encode.java
+++ b/java/src/main/java/org/maplibre/mlt/cli/Encode.java
@@ -804,7 +804,7 @@ public class Encode {
                                 + "\n")
                     .toList();
             throw new RuntimeException(
-                "Property values in MLT and MVT features do not match: \n" + unequalValues);
+                "Property values in MLT and MVT features do not match: \n" + String.join("", unequalValues));
           }
         }
       }


### PR DESCRIPTION
- When using the `--printmlt` or `--printmvt` options, print the property values in key order and omit null values from the MLT, so that the outputs can be usefully diff-ed.
- Split the compare option into `--compare-geom` and `--compare-prop`.
- Disregard null properties when comparing property collections.
- Consider identical values of different types to be equivalent.
- Show the differences in a more useful format, each on a new line so that they align.
