### PR TITLE
Add implementation status page, deem MLT stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://maplibre.org/img/maplibre-logos/maplibre-logo-for-dark-bg.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://maplibre.org/img/maplibre-logos/maplibre-logo-for-light-bg.svg">
+    <img alt="MapLibre Logo" src="https://maplibre.org/img/maplibre-logos/maplibre-logo-for-light-bg.svg" width="200">
+  </picture>
+</p>
+
 # MapLibre Tiles (MLT)
+
+> [!NOTE]
+> [The specification](https://maplibre.org/maplibre-tile-spec/specification/) is deemed stable as of October 2025. However, as a living standard, experimental features may continue to evolve. Implementations and intergrations are being developed, refer to the [implementation status](https://maplibre.org/maplibre-tile-spec/implementation-status/) page for the current status.
 
 The MapLibre Tile specification is mainly inspired by the [Mapbox Vector Tile (MVT)](https://github.com/mapbox/vector-tile-spec) specification,
 but has been redesigned from the ground up to address the challenges of rapidly growing geospatial data volumes
@@ -15,12 +26,8 @@ large (planet-scale) 2D and 2.5 basemaps. In particular, MLT offers the followin
 allowing for efficient processing on both CPU and GPU. The formats are designed to be loaded into
 GPU buffers with little or no additional processing
 
-📝 For a more in-depth exploration of MLT have a look at the [following slides](https://github.com/mactrem/presentations/blob/main/FOSS4G_2024_Europe/FOSS4G_2024_Europe.pdf) or watch
-[this talk](https://www.youtube.com/watch?v=YHcoAFcsES0).
-
-
-> [!CAUTION]
-> This format is still in the active research and development phase and is not ready for production use.
+📝 For a more in-depth exploration of MLT have a look at the [following slides](https://github.com/mactrem/presentations/blob/main/FOSS4G_2024_Europe/FOSS4G_2024_Europe.pdf), watch
+[this talk](https://www.youtube.com/watch?v=YHcoAFcsES0) or read [this paper](https://www.arxiv.org/abs/2508.10791) by MLT inventor Markus Tremmel.
 
 ## Comparing with MVT
 
@@ -51,7 +58,7 @@ In the following, the size of MLT and MVT files are compared based on a selected
 
 ## Getting Involved
 
-Join the #maplibre-tile-format slack channel at OSMUS: get an invite at https://slack.openstreetmap.us/
+Join the `#maplibre-tile-format` Slack channel at OSM US: get an invite at https://slack.openstreetmap.us/
 
 ### Development
 

--- a/mkdocs/docs/implementation-status.md
+++ b/mkdocs/docs/implementation-status.md
@@ -1,0 +1,17 @@
+# Implementation Status
+
+## Intergrations
+
+| Integration | Status |
+|---|---|
+| MapLibre Native | PR: [maplibre-native#3246](https://github.com/maplibre/maplibre-native/pull/3246) |
+| MapLibre GL JS | Issue: [maplibre-gl-js#6258](https://github.com/maplibre/maplibre-gl-js/issues/6258) |
+
+## Implementations
+
+| Implementation | Language | Type | Notes |
+|---|---|---|---|
+| [maplibre-tile-spec/cpp](https://github.com/maplibre/maplibre-tile-spec/tree/main/cpp) | C++ | Decoder | Will be used by MapLibre Native |
+| [maplibre-tile-spec/js](https://github.com/maplibre/maplibre-tile-spec/tree/main/js) | TypeScript | Decoder | Will be used by MapLibre GL JS |
+| [maplibre-tile-spec/java](https://github.com/maplibre/maplibre-tile-spec/tree/main/java) | Java | Encoder | |
+| [maplibre-tile-spec/rust/mlt](https://github.com/maplibre/maplibre-tile-spec/tree/main/rust/mlt) | Rust | Decoder / Encoder | |

--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -62,6 +62,7 @@ markdown_extensions:
       toc_depth: 6
 nav:
   - Home: index.md
+  - Implementation Status: implementation-status.md
   - Encoding Algorithms: encodings.md
   - Specification: specification.md
 


### PR DESCRIPTION
This PR removes the warning in the README that MLT is "still in active research and development".

Instead, it adds a note that the specification is deemed stable as of October 2025, but explains that MLT is a living standard with experimental features that may undergo changes in the future. Also, it links to a new page with the current status of implementations and intergrations.