### PR TITLE
Improve comparison output

### DIFF
--- a/java/src/main/java/org/maplibre/mlt/converter/ConversionConfig.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/ConversionConfig.java
@@ -178,11 +178,11 @@ public class ConversionConfig {
   }
 
   @Nullable
-  Pattern getLayerFilterPattern() {
+  public Pattern getLayerFilterPattern() {
     return layerFilterPattern;
   }
 
-  boolean getLayerFilterInvert() {
+  public boolean getLayerFilterInvert() {
     return layerFilterInvert;
   }
 }

--- a/java/src/main/java/org/maplibre/mlt/converter/ConversionConfig.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/ConversionConfig.java
@@ -62,11 +62,11 @@ public class ConversionConfig {
     this(
         includeIds,
         useAdvancedEncodingSchemes,
-        /* coercePropertyValues= */ false,
+        coercePropertyValues,
         optimizations,
         preTessellatePolygons,
         useMortonEncoding,
-        /* outlineFeatureTableNames= */ null,
+        outlineFeatureTableNames,
         /* layerFilterPattern= */ null,
         /* layerFilterInvert= */ false);
   }

--- a/java/src/main/java/org/maplibre/mlt/converter/ConversionConfig.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/ConversionConfig.java
@@ -1,8 +1,11 @@
 package org.maplibre.mlt.converter;
 
+import jakarta.annotation.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
+import org.jetbrains.annotations.NotNull;
 
 public class ConversionConfig {
   private final boolean includeIds;
@@ -10,15 +13,21 @@ public class ConversionConfig {
   private final boolean coercePropertyValues;
   private final boolean useMortonEncoding;
   private final boolean preTessellatePolygons;
-  private final Map<String, FeatureTableOptimizations> optimizations;
-  private final List<String> outlineFeatureTableNames;
+  private final @NotNull Map<String, FeatureTableOptimizations> optimizations;
+  private final @NotNull List<String> outlineFeatureTableNames;
+  private final @Nullable Pattern layerFilterPattern;
+  private final boolean layerFilterInvert;
 
   /**
    * @param includeIds Specifies if the ids should be included into a FeatureTable.
    * @param useAdvancedEncodingSchemes Specifies if advanced encodings like FastPfor can be used.
    * @param optimizations Specifies if optimizations can be applied on a specific FeatureTable.
    * @param preTessellatePolygons Specifies if Polygons should be pre-tessellated.
-   * @param outlineFeatureTableNames The tables for which to include outlines
+   * @param useMortonEncoding Use Morton encoding
+   * @param outlineFeatureTableNames A collection of names for which to include outline geometry, or
+   *     '*' for all
+   * @param layerFilterPattern A regex to filter layer names
+   * @param layerFilterInvert True to invert the pattern
    */
   public ConversionConfig(
       boolean includeIds,
@@ -27,7 +36,9 @@ public class ConversionConfig {
       Map<String, FeatureTableOptimizations> optimizations,
       boolean preTessellatePolygons,
       boolean useMortonEncoding,
-      List<String> outlineFeatureTableNames) {
+      List<String> outlineFeatureTableNames,
+      @Nullable Pattern layerFilterPattern,
+      boolean layerFilterInvert) {
     this.includeIds = includeIds;
     this.useAdvancedEncodingSchemes = useAdvancedEncodingSchemes;
     this.coercePropertyValues = coercePropertyValues;
@@ -36,6 +47,28 @@ public class ConversionConfig {
     this.optimizations = (optimizations != null) ? optimizations : new HashMap<>();
     this.outlineFeatureTableNames =
         (outlineFeatureTableNames != null) ? outlineFeatureTableNames : List.of();
+    this.layerFilterPattern = layerFilterPattern;
+    this.layerFilterInvert = layerFilterInvert;
+  }
+
+  public ConversionConfig(
+      boolean includeIds,
+      boolean useAdvancedEncodingSchemes,
+      boolean coercePropertyValues,
+      Map<String, FeatureTableOptimizations> optimizations,
+      boolean preTessellatePolygons,
+      boolean useMortonEncoding,
+      List<String> outlineFeatureTableNames) {
+    this(
+        includeIds,
+        useAdvancedEncodingSchemes,
+        /* coercePropertyValues= */ false,
+        optimizations,
+        preTessellatePolygons,
+        useMortonEncoding,
+        /* outlineFeatureTableNames= */ null,
+        /* layerFilterPattern= */ null,
+        /* layerFilterInvert= */ false);
   }
 
   public ConversionConfig(
@@ -142,5 +175,14 @@ public class ConversionConfig {
 
   public List<String> getOutlineFeatureTableNames() {
     return outlineFeatureTableNames;
+  }
+
+  @Nullable
+  Pattern getLayerFilterPattern() {
+    return layerFilterPattern;
+  }
+
+  boolean getLayerFilterInvert() {
+    return layerFilterInvert;
   }
 }

--- a/java/src/main/java/org/maplibre/mlt/converter/MltConverter.java
+++ b/java/src/main/java/org/maplibre/mlt/converter/MltConverter.java
@@ -421,12 +421,21 @@ public class MltConverter {
 
     var mapLibreTileBuffer = new byte[0];
     for (var mvtLayer : mvt.layers()) {
-      final var layerMetadata = metaMap.get(mvtLayer.name());
+      final var featureTableName = mvtLayer.name();
+
+      if (config.getLayerFilterPattern() != null) {
+        final var matcher = config.getLayerFilterPattern().matcher(featureTableName);
+        final var isMatch = matcher.matches() ^ config.getLayerFilterInvert();
+        if (!isMatch) {
+          continue;
+        }
+      }
+
+      final var layerMetadata = metaMap.get(featureTableName);
       if (layerMetadata == null) {
         throw new RuntimeException("Missing Metadata");
       }
 
-      final var featureTableName = mvtLayer.name();
       final var mvtFeatures = mvtLayer.features();
       final var featureTableOptimizations =
           config.getOptimizations() == null


### PR DESCRIPTION
- Add CLI arguments for filtering layers.  This makes it easier to troubleshoot issues by only processing the problematic layer(s).
- When comparing MVT/MLT, assume that the features are written in the same order instead of looking them up by ID value.  In some cases, the IDs are all zero leading to incorrect differences.
- Add layer and feature info to comparison output
- Check for valid geometries before comparing them, preventing exceptions from invalid geometry from appearing to be a difference