### PR TITLE
Bump version to 0.0.1-alpha.12, fix vitest issue

### DIFF
--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/mlt",
-  "version": "0.0.1-alpha.11",
+  "version": "0.0.1-alpha.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/mlt",
-      "version": "0.0.1-alpha.11",
+      "version": "0.0.1-alpha.12",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@mapbox/point-geometry": "^1.1.0"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/mlt",
-  "version": "0.0.1-alpha.11",
+  "version": "0.0.1-alpha.12",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -19,7 +19,6 @@
     "lint": "eslint",
     "format": "prettier --write \"**/*.ts\""
   },
-  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maplibre/maplibre-tile-spec.git"

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -6,7 +6,7 @@
     "module": "es2022",
     "declaration": true,
     "sourceMap": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
It seems that a recent change that was made created an issue for vitest in maplibre-gl repo.
In the future we should probably consider using some bundler like rollup to bundle the code instead of using `tsc` but if it's not absolutely necessary I'd like to avoid adding all the relevant rollup dependencies...

This also bumps the version to 12 in order to create a new release.