### PR TITLE
chore(cpp): allow calculating cpp coverage

### DIFF
--- a/cpp/.gitignore
+++ b/cpp/.gitignore
@@ -1,2 +1,3 @@
 /build
+build-coverage
 /.cache

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -17,6 +17,7 @@ option(MLT_WITH_JSON "Include JSON support" ON)
 option(MLT_WITH_FASTPFOR "Include FastPFor support" ON)
 option(MLT_WITH_TESTS "Include Tests" ON)
 option(MLT_WITH_TOOLS "Include CLI tools" ON)
+option(MLT_WITH_COVERAGE "Enable code coverage instrumentation" OFF)
 
 set_target_properties(
     mlt-cpp
@@ -75,6 +76,16 @@ add_cxx_compiler_flag(-wd4061) # MSVC: enum member not handled in switch
 add_cxx_compiler_flag(-wd4514) # MSVC: unreferenced inline function has been removed
 add_cxx_compiler_flag(-wd4710) # MSVC: function not inlined
 add_cxx_compiler_flag(-wd4820) # MSVC: padding added after data member
+
+if(MLT_WITH_COVERAGE)
+    message(STATUS "[MLT] Enabling code coverage instrumentation")
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
+        target_compile_options(mlt-cpp PRIVATE --coverage -fprofile-arcs -ftest-coverage)
+        target_link_options(mlt-cpp PRIVATE --coverage)
+    else()
+        message(WARNING "[MLT] Coverage is not supported for compiler ${CMAKE_CXX_COMPILER_ID}")
+    endif()
+endif()
 
 target_include_directories(mlt-cpp
     PUBLIC ${PROJECT_SOURCE_DIR}/include

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -35,3 +35,16 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 add_subdirectory("${PROJECT_SOURCE_DIR}/vendor/googletest" "${CMAKE_CURRENT_BINARY_DIR}/googletest" EXCLUDE_FROM_ALL SYSTEM)
 
 target_link_libraries(mlt-cpp-test mlt-cpp gtest_main)
+
+if(MLT_WITH_COVERAGE)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
+        target_compile_options(mlt-cpp-test PRIVATE --coverage -fprofile-arcs -ftest-coverage)
+        target_link_options(mlt-cpp-test PRIVATE --coverage)
+        # On macOS, force-load the static library to include coverage symbols
+        # Coverage initialization/writeout functions are not referenced, so they won't be
+        # linked from static libraries unless we force-load them
+        if(APPLE)
+            target_link_options(mlt-cpp-test PRIVATE -Wl,-force_load,$<TARGET_LINKER_FILE:mlt-cpp>)
+        endif()
+    endif()
+endif()

--- a/justfile
+++ b/justfile
@@ -122,6 +122,24 @@ test-js: install-js
 test-rust:
     cd rust && cargo test
 
+# Generate code coverage report for C++
+[working-directory: 'cpp']
+coverage-cpp:
+    mkdir -p coverage
+    cmake -B build-coverage -S . -DMLT_WITH_COVERAGE=ON
+    cmake --build build-coverage --target mlt-cpp-test
+    build-coverage/test/mlt-cpp-test
+    lcov --directory build-coverage --capture --output-file coverage/coverage.info --ignore-errors inconsistent
+    lcov --extract coverage/coverage.info '*/cpp/src/mlt/*' '*/cpp/include/mlt/*' --output-file coverage/coverage.info --ignore-errors inconsistent
+    echo "Coverage report generated at cpp/coverage/coverage.info"
+    lcov --summary coverage/coverage.info --ignore-errors inconsistent,corrupt || true
+
+# Generate HTML code coverage report for C++
+[working-directory: 'cpp']
+coverage-cpp-html: coverage-cpp
+    genhtml coverage/coverage.info --output-directory coverage/html --title "MLT C++ Coverage" --legend --demangle-cpp --show-details --branch-coverage --ignore-errors inconsistent,corrupt
+    echo "HTML coverage report generated at file://{{justfile_directory()}}/cpp/coverage/html/index.html"
+
 # Delete integration test output files
 [private]
 clean-int-test:


### PR DESCRIPTION
@TimSylvester Could you try this with

```
just coverage-cpp-html
```

I only tried on macOS.

<img width="2670" height="1842" alt="image" src="https://github.com/user-attachments/assets/310ac915-bdc9-4d0d-a846-80e72dce3b5f" />

You need to have `lcov` installed

```
brew install lcov
```