### PR TITLE
Add sources content to source map files

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -4,8 +4,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "/dist",
-    "/src"
+    "/dist"
   ],
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/maplibre/maplibre-tile-spec/#readme",

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "es2022",
     "declaration": true,
     "sourceMap": true,
+    "inlineSources": true,
     "moduleResolution": "bundler",
     "esModuleInterop": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
Source mapping is using the `.ts` files (not inline source mapping).
So in order to get proper source mapping, there's a need to include the `.ts` files as well in the npm package.
I've discovered this while running vitest with coverage on maplibre-gl-js as vitest complained that it can't find the source files linked in the source mapping...
This PR inlines the ts files into the source map files.