### PR TITLE
Tiles -> Tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   </picture>
 </p>
 
-# MapLibre Tiles (MLT)
+# MapLibre Tile (MLT)
 
 > [!NOTE]
 > [The specification](https://maplibre.org/maplibre-tile-spec/specification/) is deemed stable as of October 2025. However, as a living standard, experimental features may continue to evolve. Implementations and integrations are being developed, refer to the [implementation status](https://maplibre.org/maplibre-tile-spec/implementation-status/) page for the current status.


### PR DESCRIPTION
As defined by [Markus'](https://www.arxiv.org/abs/2508.10791) publication, MLT stands for MapLibre Tile, not MapLibre Tiles. Also makes more sense because MVT stands for Mapbox Vector Tile.