### PR TITLE
feat(java): add optional int encoding config java

### DIFF
--- a/java/mlt-cli/src/main/java/org/maplibre/mlt/cli/Encode.java
+++ b/java/mlt-cli/src/main/java/org/maplibre/mlt/cli/Encode.java
@@ -156,7 +156,8 @@ public class Encode {
             useMortonEncoding,
             (outlineFeatureTables != null ? List.of(outlineFeatureTables) : List.of()),
             filterPattern,
-            filterInvert);
+            filterInvert,
+            ConversionConfig.IntegerEncodingOption.AUTO);
 
     if (verbose > 0 && outlineFeatureTables != null && outlineFeatureTables.length > 0) {
       System.err.println(
@@ -480,7 +481,8 @@ public class Encode {
         conversionConfig.getUseMortonEncoding(),
         conversionConfig.getOutlineFeatureTableNames(),
         conversionConfig.getLayerFilterPattern(),
-        conversionConfig.getLayerFilterInvert());
+        conversionConfig.getLayerFilterInvert(),
+        conversionConfig.getIntegerEncodingOption());
   }
 
   /// Encode the entire contents of an MBTile file of MVT tiles

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/ConversionConfig.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/ConversionConfig.java
@@ -8,6 +8,23 @@ import java.util.regex.Pattern;
 import org.jetbrains.annotations.NotNull;
 
 public class ConversionConfig {
+  public enum IntegerEncodingOption {
+    AUTO, // Automatically select best encoding (default)
+    PLAIN, // Force plain encoding
+    DELTA, // Force delta encoding
+    RLE, // Force RLE encoding (only for const streams)
+    DELTA_RLE // Force delta-RLE encoding
+  }
+
+  public static final boolean DEFAULT_INCLUDE_IDS = true;
+  public static final boolean DEFAULT_USE_FAST_PFOR = false;
+  public static final boolean DEFAULT_USE_FSST = false;
+  public static final boolean DEFAULT_COERCE_PROPERTY_VALUES = false;
+  public static final boolean DEFAULT_USE_MORTON_ENCODING = true;
+  public static final boolean DEFAULT_PRE_TESSELLATE_POLYGONS = false;
+  public static final boolean DEFAULT_LAYER_FILTER_INVERT = false;
+  public static final IntegerEncodingOption DEFAULT_INTEGER_ENCODING = IntegerEncodingOption.AUTO;
+
   private final boolean includeIds;
   private final boolean useFastPFOR;
   private final boolean useFSST;
@@ -18,6 +35,7 @@ public class ConversionConfig {
   private final @NotNull List<String> outlineFeatureTableNames;
   private final @Nullable Pattern layerFilterPattern;
   private final boolean layerFilterInvert;
+  private final @NotNull IntegerEncodingOption integerEncodingOption;
 
   /**
    * @param includeIds Specifies if the ids should be included into a FeatureTable.
@@ -30,6 +48,7 @@ public class ConversionConfig {
    *     'ALL' for all
    * @param layerFilterPattern A regex to filter layer names
    * @param layerFilterInvert True to invert the pattern
+   * @param integerEncodingOption Specifies which integer encoding to use
    */
   public ConversionConfig(
       boolean includeIds,
@@ -41,7 +60,8 @@ public class ConversionConfig {
       boolean useMortonEncoding,
       List<String> outlineFeatureTableNames,
       @Nullable Pattern layerFilterPattern,
-      boolean layerFilterInvert) {
+      boolean layerFilterInvert,
+      @NotNull IntegerEncodingOption integerEncodingOption) {
     this.includeIds = includeIds;
     this.useFastPFOR = useFastPFOR;
     this.useFSST = useFSST;
@@ -53,6 +73,7 @@ public class ConversionConfig {
         (outlineFeatureTableNames != null) ? outlineFeatureTableNames : List.of();
     this.layerFilterPattern = layerFilterPattern;
     this.layerFilterInvert = layerFilterInvert;
+    this.integerEncodingOption = integerEncodingOption;
   }
 
   public ConversionConfig(
@@ -74,7 +95,8 @@ public class ConversionConfig {
         useMortonEncoding,
         outlineFeatureTableNames,
         /* layerFilterPattern= */ null,
-        /* layerFilterInvert= */ false);
+        /* layerFilterInvert= */ DEFAULT_LAYER_FILTER_INVERT,
+        /* integerEncodingOption= */ DEFAULT_INTEGER_ENCODING);
   }
 
   public ConversionConfig(
@@ -88,11 +110,14 @@ public class ConversionConfig {
         includeIds,
         useFastPFOR,
         useFSST,
-        /* coercePropertyValues= */ false,
+        /* coercePropertyValues= */ DEFAULT_COERCE_PROPERTY_VALUES,
         optimizations,
         preTessellatePolygons,
         useMortonEncoding,
-        /* outlineFeatureTableNames= */ null);
+        /* outlineFeatureTableNames= */ null,
+        /* layerFilterPattern= */ null,
+        /* layerFilterInvert= */ DEFAULT_LAYER_FILTER_INVERT,
+        /* integerEncodingOption= */ DEFAULT_INTEGER_ENCODING);
   }
 
   public ConversionConfig(
@@ -100,16 +125,20 @@ public class ConversionConfig {
       boolean useFastPFOR,
       boolean useFSST,
       Map<String, FeatureTableOptimizations> optimizations,
-      boolean preTessellatePolygons) {
+      boolean preTessellatePolygons,
+      IntegerEncodingOption integerEncodingOption) {
     this(
         includeIds,
         useFastPFOR,
         useFSST,
-        /* coercePropertyValues= */ false,
-        null,
-        preTessellatePolygons,
-        /* useMortonEncoding= */ true,
-        /* outlineFeatureTableNames= */ null);
+        /* coercePropertyValues= */ DEFAULT_COERCE_PROPERTY_VALUES,
+        optimizations, // it was null before, now it is used
+        /* preTessellatePolygons= */ DEFAULT_PRE_TESSELLATE_POLYGONS,
+        /* useMortonEncoding= */ DEFAULT_USE_MORTON_ENCODING,
+        /* outlineFeatureTableNames= */ null,
+        /* layerFilterPattern= */ null,
+        /* layerFilterInvert= */ DEFAULT_LAYER_FILTER_INVERT,
+        integerEncodingOption);
   }
 
   public ConversionConfig(
@@ -121,47 +150,59 @@ public class ConversionConfig {
         includeIds,
         useFastPFOR,
         useFSST,
-        /* coercePropertyValues= */ false,
+        /* coercePropertyValues= */ DEFAULT_COERCE_PROPERTY_VALUES,
         optimizations,
-        /* preTessellatePolygons= */ false,
-        /* useMortonEncoding= */ true,
-        /* outlineFeatureTableNames= */ null);
+        /* preTessellatePolygons= */ DEFAULT_PRE_TESSELLATE_POLYGONS,
+        /* useMortonEncoding= */ DEFAULT_USE_MORTON_ENCODING,
+        /* outlineFeatureTableNames= */ null,
+        /* layerFilterPattern= */ null,
+        /* layerFilterInvert= */ DEFAULT_LAYER_FILTER_INVERT,
+        /* integerEncodingOption= */ DEFAULT_INTEGER_ENCODING);
   }
 
   public ConversionConfig(boolean includeIds, boolean useAdvancedEncodingSchemes) {
     this(
         includeIds,
-        /* useFastPFOR= */ false,
-        /* useFSST= */ false,
-        /* coercePropertyValues= */ false,
+        /* useFastPFOR= */ DEFAULT_USE_FAST_PFOR,
+        /* useFSST= */ DEFAULT_USE_FSST,
+        /* coercePropertyValues= */ DEFAULT_COERCE_PROPERTY_VALUES,
         /* optimizations= */ null,
-        /* preTessellatePolygons= */ false,
-        /* useMortonEncoding= */ true,
-        /* outlineFeatureTableNames= */ null);
+        /* preTessellatePolygons= */ DEFAULT_PRE_TESSELLATE_POLYGONS,
+        /* useMortonEncoding= */ DEFAULT_USE_MORTON_ENCODING,
+        /* outlineFeatureTableNames= */ null,
+        /* layerFilterPattern= */ null,
+        /* layerFilterInvert= */ DEFAULT_LAYER_FILTER_INVERT,
+        /* integerEncodingOption= */ DEFAULT_INTEGER_ENCODING);
   }
 
   public ConversionConfig(boolean includeIds) {
     this(
         includeIds,
-        /* useFastPFOR= */ false,
-        /* useFSST= */ false,
-        /* coercePropertyValues= */ false,
+        /* useFastPFOR= */ DEFAULT_USE_FAST_PFOR,
+        /* useFSST= */ DEFAULT_USE_FSST,
+        /* coercePropertyValues= */ DEFAULT_COERCE_PROPERTY_VALUES,
         /* optimizations= */ null,
-        /* preTessellatePolygons= */ false,
-        /* useMortonEncoding= */ true,
-        /* outlineFeatureTableNames= */ null);
+        /* preTessellatePolygons= */ DEFAULT_PRE_TESSELLATE_POLYGONS,
+        /* useMortonEncoding= */ DEFAULT_USE_MORTON_ENCODING,
+        /* outlineFeatureTableNames= */ null,
+        /* layerFilterPattern= */ null,
+        /* layerFilterInvert= */ DEFAULT_LAYER_FILTER_INVERT,
+        /* integerEncodingOption= */ DEFAULT_INTEGER_ENCODING);
   }
 
   public ConversionConfig() {
     this(
-        /* includeIds= */ true,
-        /* useFastPFOR= */ false,
-        /* useFSST= */ false,
-        /* coercePropertyValues= */ false,
+        /* includeIds= */ DEFAULT_INCLUDE_IDS,
+        /* useFastPFOR= */ DEFAULT_USE_FAST_PFOR,
+        /* useFSST= */ DEFAULT_USE_FSST,
+        /* coercePropertyValues= */ DEFAULT_COERCE_PROPERTY_VALUES,
         /* optimizations= */ null,
-        /* preTessellatePolygons= */ false,
-        /* useMortonEncoding= */ true,
-        /* outlineFeatureTableNames= */ null);
+        /* preTessellatePolygons= */ DEFAULT_PRE_TESSELLATE_POLYGONS,
+        /* useMortonEncoding= */ DEFAULT_USE_MORTON_ENCODING,
+        /* outlineFeatureTableNames= */ null,
+        /* layerFilterPattern= */ null,
+        /* layerFilterInvert= */ DEFAULT_LAYER_FILTER_INVERT,
+        /* integerEncodingOption= */ DEFAULT_INTEGER_ENCODING);
   }
 
   public boolean getIncludeIds() {
@@ -203,5 +244,102 @@ public class ConversionConfig {
 
   public boolean getLayerFilterInvert() {
     return layerFilterInvert;
+  }
+
+  public IntegerEncodingOption getIntegerEncodingOption() {
+    return integerEncodingOption;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Short builder for ConversionConfig with sensible defaults. Example: var config =
+   * ConversionConfig.builder() .includeIds(true) .useFastPFOR(true)
+   * .integerEncoding(IntegerEncodingOption.DELTA) .build();
+   */
+  public static class Builder {
+    private boolean includeIds = DEFAULT_INCLUDE_IDS;
+    private boolean useFastPFOR = DEFAULT_USE_FAST_PFOR;
+    private boolean useFSST = DEFAULT_USE_FSST;
+    private boolean coercePropertyValues = DEFAULT_COERCE_PROPERTY_VALUES;
+    private Map<String, FeatureTableOptimizations> optimizations = null;
+    private boolean preTessellatePolygons = DEFAULT_PRE_TESSELLATE_POLYGONS;
+    private boolean useMortonEncoding = DEFAULT_USE_MORTON_ENCODING;
+    private List<String> outlineFeatureTableNames = null;
+    private Pattern layerFilterPattern = null;
+    private boolean layerFilterInvert = DEFAULT_LAYER_FILTER_INVERT;
+    private IntegerEncodingOption integerEncodingOption = DEFAULT_INTEGER_ENCODING;
+
+    public Builder includeIds(boolean val) {
+      this.includeIds = val;
+      return this;
+    }
+
+    public Builder useFastPFOR(boolean val) {
+      this.useFastPFOR = val;
+      return this;
+    }
+
+    public Builder useFSST(boolean val) {
+      this.useFSST = val;
+      return this;
+    }
+
+    public Builder coercePropertyValues(boolean val) {
+      this.coercePropertyValues = val;
+      return this;
+    }
+
+    public Builder optimizations(Map<String, FeatureTableOptimizations> val) {
+      this.optimizations = val;
+      return this;
+    }
+
+    public Builder preTessellatePolygons(boolean val) {
+      this.preTessellatePolygons = val;
+      return this;
+    }
+
+    public Builder useMortonEncoding(boolean val) {
+      this.useMortonEncoding = val;
+      return this;
+    }
+
+    public Builder outlineFeatureTableNames(List<String> val) {
+      this.outlineFeatureTableNames = val;
+      return this;
+    }
+
+    public Builder layerFilterPattern(Pattern val) {
+      this.layerFilterPattern = val;
+      return this;
+    }
+
+    public Builder layerFilterInvert(boolean val) {
+      this.layerFilterInvert = val;
+      return this;
+    }
+
+    public Builder integerEncoding(IntegerEncodingOption val) {
+      this.integerEncodingOption = val;
+      return this;
+    }
+
+    public ConversionConfig build() {
+      return new ConversionConfig(
+          includeIds,
+          useFastPFOR,
+          useFSST,
+          coercePropertyValues,
+          optimizations,
+          preTessellatePolygons,
+          useMortonEncoding,
+          outlineFeatureTableNames,
+          layerFilterPattern,
+          layerFilterInvert,
+          integerEncodingOption);
+    }
   }
 }

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/MltConverter.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/MltConverter.java
@@ -481,6 +481,7 @@ public class MltConverter {
                 physicalLevelTechnique,
                 config.getUseFSST(),
                 config.getCoercePropertyValues(),
+                config.getIntegerEncodingOption(),
                 streamRecorder);
       }
 
@@ -529,6 +530,7 @@ public class MltConverter {
         config.getUseFSST(),
         config.getCoercePropertyValues(),
         columnMappings,
+        config.getIntegerEncodingOption(),
         streamRecorder);
   }
 


### PR DESCRIPTION
Motivation
- Currently, integer encoding is automatically selected based on size optimization. This makes it difficult to generate predictable test outputs or compare different encoding strategies. This PR makes integer encoding explicitly configurable.

Changes
- `IntegerEncodingOption` enum: Adds explicit control over integer encoding with options
- Builder pattern for `ConversionConfig`: Replaces the implicit factory pattern of multiple constructor overloads with an explicit Builder.

Discussion
This is a proposal to make encoding methods explicitly configurable. If this approach works well, I plan to extend the same pattern to:
- String encoding configuration
- Geometry encoding configuration

This would provide full control over encoding strategies for testing and comparison purposes.