### PR TITLE
feat(ts): add FastPFOR int32 codec (PR1/stack)

### DIFF
--- a/ts/src/decoding/fastPforCodec.reference.spec.ts
+++ b/ts/src/decoding/fastPforCodec.reference.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { decodeFastPfor } from "./integerDecodingUtils";
+import IntWrapper from "./intWrapper";
+import { int32sToBigEndianBytes, uncompressFastPforInt32 } from "../fastPforCodec";
+
+function parseCppUint32Array(source: string, name: string): Int32Array {
+    const match = new RegExp(`const\\s+std::uint32_t\\s+${name}\\s*\\[\\]\\s*=\\s*\\{([\\s\\S]*?)\\};`).exec(source);
+    if (!match) {
+        throw new Error(`Failed to locate C++ array ${name}`);
+    }
+
+    const tokens = match[1]
+        .split(",")
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0);
+
+    const values = new Int32Array(tokens.length);
+    for (let i = 0; i < tokens.length; i++) {
+        let token = tokens[i];
+        token = token.replace(/u$/i, "");
+        token = token.replace(/^UINT32_C\\((.*)\\)$/, "$1");
+        token = token.replace(/^INT32_C\\((.*)\\)$/, "$1");
+
+        const parsed = Number(token);
+        if (!Number.isFinite(parsed)) {
+            throw new Error(`Failed to parse token '${tokens[i]}' in ${name}`);
+        }
+        values[i] = parsed | 0;
+    }
+
+    return values;
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const CPP_FASTPFOR_TEST = path.resolve(__dirname, "../../../cpp/test/test_fastpfor.cpp");
+
+describe("fastpfor decoder compatibility (JavaFastPFOR reference vectors)", () => {
+    it("decodes cpp/test/test_fastpfor.cpp compressed1 -> uncompressed1", () => {
+        const cpp = fs.readFileSync(CPP_FASTPFOR_TEST, "utf8");
+        const encoded = parseCppUint32Array(cpp, "compressed1");
+        const expected = parseCppUint32Array(cpp, "uncompressed1");
+
+        const decoded = uncompressFastPforInt32(encoded, expected.length);
+        expect(Array.from(decoded)).toEqual(Array.from(expected));
+
+        const bytes = int32sToBigEndianBytes(encoded);
+        const offset = new IntWrapper(0);
+        const decodedFromBytes = decodeFastPfor(bytes, expected.length, bytes.length, offset);
+        expect(Array.from(decodedFromBytes)).toEqual(Array.from(expected));
+        expect(offset.get()).toBe(bytes.length);
+    });
+
+    it("decodes cpp/test/test_fastpfor.cpp compressed3 -> uncompressed3", () => {
+        const cpp = fs.readFileSync(CPP_FASTPFOR_TEST, "utf8");
+        const encoded = parseCppUint32Array(cpp, "compressed3");
+        const expected = parseCppUint32Array(cpp, "uncompressed3");
+
+        const decoded = uncompressFastPforInt32(encoded, expected.length);
+        expect(Array.from(decoded)).toEqual(Array.from(expected));
+    });
+});

--- a/ts/src/decoding/integerDecodingUtils.ts
+++ b/ts/src/decoding/integerDecodingUtils.ts
@@ -1,5 +1,6 @@
 import type IntWrapper from "./intWrapper";
 import type BitVector from "../vector/flat/bitVector";
+import { bigEndianBytesToInt32s, uncompressFastPforInt32 } from "../fastPforCodec";
 
 //based on https://github.com/mapbox/pbf/blob/main/index.js
 export function decodeVarintInt32(buf: Uint8Array, bufferOffset: IntWrapper, numValues: number): Int32Array {
@@ -145,7 +146,11 @@ export function decodeFastPfor(
     byteLength: number,
     offset: IntWrapper,
 ): Int32Array {
-    throw new Error("FastPFor is not implemented yet.");
+    const start = offset.get();
+    const encoded = bigEndianBytesToInt32s(data, start, byteLength);
+    const decoded = uncompressFastPforInt32(encoded, numValues);
+    offset.add(byteLength);
+    return decoded;
 }
 
 export function decodeZigZagInt32Value(encoded: number): number {

--- a/ts/src/encoding/fastPforEncodingUtils.spec.ts
+++ b/ts/src/encoding/fastPforEncodingUtils.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { decodeFastPfor } from "../decoding/integerDecodingUtils";
+import IntWrapper from "../decoding/intWrapper";
+import { encodeFastPfor } from "./integerEncodingUtils";
+import { bigEndianBytesToInt32s } from "../fastPforCodec";
+
+function readInt32BigEndian(buf: Uint8Array, offset: number): number {
+    return ((buf[offset] << 24) | (buf[offset + 1] << 16) | (buf[offset + 2] << 8) | buf[offset + 3]) | 0;
+}
+
+function roundTrip(values: Int32Array): { encoded: Uint8Array; decoded: Int32Array; offset: number } {
+    const encoded = encodeFastPfor(values);
+    const offset = new IntWrapper(0);
+    const decoded = decodeFastPfor(encoded, values.length, encoded.length, offset);
+    return { encoded, decoded, offset: offset.get() };
+}
+
+describe("fastpfor encode/decode round-trip", () => {
+    it("converts trailing bytes to last int32 (big-endian)", () => {
+        const bytes = new Uint8Array([0x01, 0x02, 0x03, 0x04, 0xaa, 0xbb]);
+        const ints = bigEndianBytesToInt32s(bytes, 0, bytes.length);
+        expect(ints.length).toBe(2);
+        expect(ints[0]).toBe(0x01020304);
+        expect(ints[1]).toBe(0xaabb0000 | 0);
+    });
+
+    it("handles empty input", () => {
+        const values = new Int32Array(0);
+
+        const { encoded, decoded, offset } = roundTrip(values);
+
+        expect(encoded.length).toBe(0);
+        expect(Array.from(decoded)).toEqual([]);
+        expect(offset).toBe(0);
+    });
+
+    it("uses VariableByte-only path for <256 values", () => {
+        const values = new Int32Array(Array.from({ length: 100 }, (_, i) => (i % 17) * 12345));
+
+        const { encoded, decoded, offset } = roundTrip(values);
+
+        expect(encoded.length % 4).toBe(0);
+        expect(readInt32BigEndian(encoded, 0)).toBe(0);
+        expect(Array.from(decoded)).toEqual(Array.from(values));
+        expect(offset).toBe(encoded.length);
+    });
+
+    it("encodes 256 FastPFOR values + VariableByte remainder", () => {
+        const values = new Int32Array(Array.from({ length: 358 }, (_, i) => i));
+
+        const { encoded, decoded, offset } = roundTrip(values);
+
+        expect(encoded.length % 4).toBe(0);
+        expect(readInt32BigEndian(encoded, 0)).toBe(256);
+        expect(Array.from(decoded)).toEqual(Array.from(values));
+        expect(offset).toBe(encoded.length);
+    });
+
+    it("encodes full FastPFOR blocks when divisible by 256", () => {
+        const values = new Int32Array(Array.from({ length: 512 }, (_, i) => i));
+
+        const { encoded, decoded, offset } = roundTrip(values);
+
+        expect(encoded.length % 4).toBe(0);
+        expect(readInt32BigEndian(encoded, 0)).toBe(512);
+        expect(Array.from(decoded)).toEqual(Array.from(values));
+        expect(offset).toBe(encoded.length);
+    });
+
+    it("encodes multi-page FastPFOR streams (>65536 values)", () => {
+        const values = new Int32Array(Array.from({ length: 66000 }, (_, i) => i % 10000));
+
+        const { encoded, decoded, offset } = roundTrip(values);
+
+        expect(encoded.length % 4).toBe(0);
+        expect(readInt32BigEndian(encoded, 0)).toBe(65792);
+        expect(decoded.length).toBe(values.length);
+        expect(decoded[0]).toBe(0);
+        expect(decoded[12345]).toBe(2345);
+        expect(decoded[65999]).toBe(5999);
+        expect(offset).toBe(encoded.length);
+    });
+});

--- a/ts/src/encoding/integerEncodingUtils.ts
+++ b/ts/src/encoding/integerEncodingUtils.ts
@@ -1,5 +1,6 @@
 import BitVector from "../vector/flat/bitVector";
 import IntWrapper from "../decoding/intWrapper";
+import { compressFastPforInt32, int32sToBigEndianBytes } from "../fastPforCodec";
 
 export function encodeVarintInt32Value(value: number, dst: Uint8Array, offset: IntWrapper): void {
     let v = value;
@@ -103,7 +104,8 @@ function encodeVarintFloat64Value(val: number, buf: Uint8Array, offset: IntWrapp
 }
 
 export function encodeFastPfor(data: Int32Array): Uint8Array {
-    throw new Error("FastPFor is not implemented yet.");
+    const compressed = compressFastPforInt32(data);
+    return int32sToBigEndianBytes(compressed);
 }
 
 export function encodeZigZagInt32Value(value: number): number {
@@ -525,6 +527,105 @@ export function encodeDeltaInt32(data: Int32Array): void {
 // encodeComponentwiseDeltaVec2
 // decodeComponentwiseDeltaVec2Scaled
 
+export function encodeNullableZigZagDeltaInt32(inputData: Int32Array): {
+    data: Int32Array;
+    bitVector: BitVector;
+    totalSize: number;
+} {
+    if (inputData.length === 0) {
+        return { data: new Int32Array(0), bitVector: new BitVector(new Uint8Array(0), 0), totalSize: 0 };
+    }
+
+    const totalSize = inputData.length;
+    const bitVector = new BitVector(new Uint8Array(totalSize), totalSize);
+    // We will collect the non-null/non-zero deltas here first
+    const encodedDeltas: number[] = [];
+
+    let previousValue = 0; // The base for the first delta is implicitly zero
+
+    for (let i = 0; i < totalSize; i++) {
+        const currentValue = inputData[i];
+
+        // Calculate the delta (difference from the previous value)
+        const delta = currentValue - previousValue;
+
+        // If the delta is non-zero, we store it.
+        if (delta !== 0) {
+            // Mark presence in the bit vector
+            bitVector.set(i, true);
+
+            // Zigzag encode the non-zero delta
+            // Formula: (delta << 1) ^ (delta >> 31)
+            const zigzagEncoded = ((delta << 1) ^ (delta >> 31)) >>> 0;
+
+            encodedDeltas.push(zigzagEncoded);
+        }
+        // If delta is 0, we don't store anything in encodedDeltas, and the bit is left false.
+
+        // Update the previous value tracker for the next iteration's delta calculation
+        previousValue = currentValue;
+    }
+
+    // Convert the temporary list of deltas into a final Int32Array for storage
+    const finalEncodedData = new Int32Array(encodedDeltas);
+
+    return {
+        data: finalEncodedData,
+        bitVector: bitVector,
+        totalSize: totalSize,
+    };
+}
+
+export function encodeNullableZigZagDeltaInt64(inputData: BigInt64Array): {
+    data: BigInt64Array;
+    bitVector: BitVector;
+    totalSize: number;
+} {
+    if (inputData.length === 0) {
+        return { data: new BigInt64Array(0), bitVector: new BitVector(new Uint8Array(0), 0), totalSize: 0 };
+    }
+
+    const totalSize = inputData.length;
+    const bitVector = new BitVector(new Uint8Array(totalSize), totalSize);
+    // We will collect the non-null/non-zero deltas here first
+    const encodedDeltas: bigint[] = [];
+
+    // The base for the first delta is implicitly zero
+    let previousValue: bigint = 0n;
+
+    for (let i = 0; i < totalSize; i++) {
+        const currentValue = inputData[i];
+
+        // Calculate the delta (difference from the previous value)
+        const delta = currentValue - previousValue;
+
+        // If the delta is non-zero, we store it.
+        if (delta !== 0n) {
+            // Mark presence in the bit vector
+            bitVector.set(i, true);
+
+            // Zigzag encode the non-zero delta using 64-bit logic
+            // Formula: (delta << 1n) ^ (delta >> 63n)
+            const zigzagEncoded = (delta << 1n) ^ (delta >> 63n);
+
+            encodedDeltas.push(zigzagEncoded);
+        }
+        // If delta is 0n, we don't store anything in encodedDeltas, and the bit is left false.
+
+        // Update the previous value tracker for the next iteration's delta calculation
+        previousValue = currentValue;
+    }
+
+    // Convert the temporary list of deltas into a final BigInt64Array for storage
+    const finalEncodedData = new BigInt64Array(encodedDeltas);
+
+    return {
+        data: finalEncodedData,
+        bitVector: bitVector,
+        totalSize: totalSize,
+    };
+}
+
 // HM TODO:
 // zigZagDeltaOfDeltaDecoding
 
@@ -661,6 +762,229 @@ export function encodeRleDeltaInt32(values: Int32Array | number[]): {
         numTotalValues: values.length,
     };
 }
+
+export function encodeNullableUnsignedRleInt32(
+    values: Int32Array,
+    bitVector: BitVector,
+): { data: Int32Array; numRuns: number } {
+    const lengths: number[] = [];
+    const runValues: number[] = [];
+    let i = 0;
+    const size = values.length;
+    while (i < size) {
+        let searchIndex = i;
+        let validValue: number | null = null;
+        while (searchIndex < size) {
+            if (bitVector.get(searchIndex)) {
+                validValue = values[searchIndex];
+                break;
+            }
+            searchIndex++;
+        }
+        if (validValue === null) break;
+        let currentRunValidCount = 0;
+        let scanIndex = i;
+        while (scanIndex < size) {
+            const isSet = bitVector.get(scanIndex);
+            if (!isSet) {
+                scanIndex++;
+            } else {
+                const val = values[scanIndex];
+                if (val === validValue) {
+                    currentRunValidCount++;
+                    scanIndex++;
+                } else {
+                    break;
+                }
+            }
+        }
+        lengths.push(currentRunValidCount);
+        runValues.push(validValue);
+        i = scanIndex;
+    }
+    const numRuns = lengths.length;
+    const resultData = new Int32Array(numRuns * 2);
+    for (let k = 0; k < numRuns; k++) {
+        resultData[k] = lengths[k];
+        resultData[k + numRuns] = runValues[k];
+    }
+    return { data: resultData, numRuns };
+}
+
+export function encodeNullableZigZagRleInt32(
+    values: Int32Array | number[],
+    bitVector: BitVector,
+): { data: Int32Array; runs: number } {
+    const size = bitVector.size();
+    if (size === 0) {
+        return { data: new Int32Array(0), runs: 0 };
+    }
+
+    const runLengths: number[] = [];
+    const encodedValues: number[] = [];
+
+    let currentRunValue: number | null = null;
+    let currentRunLength = 0;
+
+    for (let i = 0; i < size; i++) {
+        const isValid = bitVector.get(i);
+        const val = values[i];
+
+        if (!isValid) {
+            // Null Encountered: Flush the current run if it exists, and reset run tracking.
+            if (currentRunValue !== null) {
+                runLengths.push(currentRunLength);
+                encodedValues.push(encodeZigZagInt32Value(currentRunValue));
+            }
+            // Reset for the next run (since nulls cannot start a run)
+            currentRunValue = null;
+            currentRunLength = 0;
+            continue;
+        }
+
+        // Valid Value Encountered
+        if (currentRunValue === null) {
+            // Start of a new run
+            currentRunValue = val;
+            currentRunLength = 1;
+        } else if (val === currentRunValue) {
+            // Continuation of the current run
+            currentRunLength++;
+        } else {
+            // Value changed: Flush the previous run
+            runLengths.push(currentRunLength);
+            encodedValues.push(encodeZigZagInt32Value(currentRunValue));
+
+            // Start new run
+            currentRunValue = val;
+            currentRunLength = 1;
+        }
+    }
+
+    // Flush the final run
+    if (currentRunValue !== null) {
+        runLengths.push(currentRunLength);
+        encodedValues.push(encodeZigZagInt32Value(currentRunValue));
+    }
+
+    const numRuns = runLengths.length;
+
+    // Pack: [ RunLength 1...N | Value 1...N ]
+    const data = new Int32Array(numRuns * 2);
+    for (let i = 0; i < numRuns; i++) {
+        data[i] = runLengths[i];
+        data[i + numRuns] = encodedValues[i];
+    }
+
+    return {
+        data,
+        runs: numRuns,
+    };
+}
+
+export function encodeNullableUnsignedRleInt64(
+    values: BigInt64Array,
+    bitVector: BitVector,
+): { data: BigInt64Array; numRuns: number } {
+    const lengths: number[] = [];
+    const runValues: bigint[] = [];
+    let i = 0;
+    const size = values.length;
+    while (i < size) {
+        let searchIndex = i;
+        let validValue: bigint | null = null;
+        while (searchIndex < size) {
+            if (bitVector.get(searchIndex)) {
+                validValue = values[searchIndex];
+                break;
+            }
+            searchIndex++;
+        }
+        if (validValue === null) break;
+        let currentRunValidCount = 0;
+        let scanIndex = i;
+        while (scanIndex < size) {
+            const isSet = bitVector.get(scanIndex);
+            if (!isSet) {
+                scanIndex++;
+            } else {
+                const val = values[scanIndex];
+                if (val === validValue) {
+                    currentRunValidCount++;
+                    scanIndex++;
+                } else {
+                    break;
+                }
+            }
+        }
+        lengths.push(currentRunValidCount);
+        runValues.push(validValue);
+        i = scanIndex;
+    }
+    const numRuns = lengths.length;
+    const resultData = new BigInt64Array(numRuns * 2);
+    for (let k = 0; k < numRuns; k++) {
+        resultData[k] = BigInt(lengths[k]);
+        resultData[k + numRuns] = runValues[k];
+    }
+    return { data: resultData, numRuns };
+}
+
+export function encodeNullableZigZagRleInt64(
+    bitVector: BitVector,
+    values: BigInt64Array,
+): { data: BigInt64Array; numRuns: number } {
+    const size = bitVector.size();
+    // Temporary storage for runs
+    const runs: { length: number; value: bigint }[] = [];
+
+    let currentRunValue: bigint | null = null;
+    let currentRunLength = 0;
+
+    for (let i = 0; i < size; i++) {
+        // We only care about non-null values for run grouping.
+        // The decoder's logic automatically handles skipping nulls (offset++)
+        // while applying the run value.
+        if (bitVector.get(i)) {
+            const val = values[i];
+
+            if (currentRunLength === 0) {
+                // Start of a new run
+                currentRunValue = val;
+                currentRunLength = 1;
+            } else if (val === currentRunValue) {
+                // Continue current run
+                currentRunLength++;
+            } else {
+                // Value changed: Commit the current run and start a new one
+                runs.push({ length: currentRunLength, value: currentRunValue });
+                currentRunValue = val;
+                currentRunLength = 1;
+            }
+        }
+    }
+
+    // Commit the final run if it exists
+    if (currentRunLength > 0 && currentRunValue !== null) {
+        runs.push({ length: currentRunLength, value: currentRunValue });
+    }
+
+    const numRuns = runs.length;
+    // Allocate the data array: first half for lengths, second half for values
+    const data = new BigInt64Array(numRuns * 2);
+
+    for (let i = 0; i < numRuns; i++) {
+        const run = runs[i];
+        // 1. Store Run Length
+        data[i] = BigInt(run.length);
+
+        // 2. Store ZigZag Encoded Value
+        data[i + numRuns] = encodeZigZagInt64Value(run.value);
+    }
+
+    return { data, numRuns };
+}
+
 
 export function encodeDeltaRleInt32(input: Int32Array): {
     data: Int32Array;

--- a/ts/src/fastPforCodec.ts
+++ b/ts/src/fastPforCodec.ts
@@ -1,0 +1,614 @@
+import IntWrapper from "./decoding/intWrapper";
+
+type Int32Buf = Int32Array<ArrayBufferLike>;
+
+const OVERHEAD_OF_EACH_EXCEPT = 8;
+const DEFAULT_PAGE_SIZE = 65536;
+const BLOCK_SIZE = 256;
+
+interface Int32Codec {
+    compress(inValues: Int32Array, inPos: IntWrapper, inLength: number, out: Int32Buf, outPos: IntWrapper): Int32Buf;
+    uncompress(inValues: Int32Array, inPos: IntWrapper, inLength: number, out: Int32Array, outPos: IntWrapper): void;
+}
+
+function greatestMultiple(value: number, factor: number): number {
+    return value - (value % factor);
+}
+
+function roundUpToMultipleOf32(value: number): number {
+    return greatestMultiple(value + 31, 32);
+}
+
+function bits(value: number): number {
+    return 32 - Math.clz32(value);
+}
+
+function normalizePageSize(pageSize: number): number {
+    if (!Number.isFinite(pageSize) || pageSize <= 0) return DEFAULT_PAGE_SIZE;
+
+    const aligned = greatestMultiple(Math.floor(pageSize), BLOCK_SIZE);
+    return aligned === 0 ? BLOCK_SIZE : aligned;
+}
+
+function ensureInt32Capacity(buffer: Int32Buf, requiredLength: number): Int32Buf {
+    if (requiredLength <= buffer.length) return buffer;
+
+    let newLength = buffer.length === 0 ? 1 : buffer.length;
+    while (newLength < requiredLength) {
+        newLength *= 2;
+    }
+
+    const next = new Int32Array(newLength) as Int32Buf;
+    next.set(buffer);
+    return next;
+}
+
+function ensureUint8Capacity(buffer: Uint8Array, requiredLength: number): Uint8Array {
+    if (requiredLength <= buffer.length) return buffer;
+
+    let newLength = buffer.length === 0 ? 1 : buffer.length;
+    while (newLength < requiredLength) {
+        newLength *= 2;
+    }
+
+    const next = new Uint8Array(newLength);
+    next.set(buffer);
+    return next;
+}
+
+function getMask(bitWidth: number): number {
+    if (bitWidth === 0) return 0;
+    return 0xffffffff >>> (32 - bitWidth);
+}
+
+/**
+ * Generic bit-packing of 32 integers, matching JavaFastPFOR BitPacking.fastpack ordering.
+ * Writes exactly `bitWidth` int32 words into `out` starting at `outPos`.
+ */
+function fastPack32(inValues: Int32Array, inPos: number, out: Int32Buf, outPos: number, bitWidth: number): void {
+    if (bitWidth === 0) return;
+    if (bitWidth === 32) {
+        out.set(inValues.subarray(inPos, inPos + 32), outPos);
+        return;
+    }
+
+    const mask = getMask(bitWidth);
+    let outputWordIndex = outPos;
+    let bitOffset = 0;
+    let currentWord = 0;
+
+    for (let i = 0; i < 32; i++) {
+        const value = (inValues[inPos + i] >>> 0) & mask;
+
+        if (bitOffset + bitWidth <= 32) {
+            currentWord |= value << bitOffset;
+            bitOffset += bitWidth;
+
+            if (bitOffset === 32) {
+                out[outputWordIndex++] = currentWord | 0;
+                bitOffset = 0;
+                currentWord = 0;
+            }
+        } else {
+            const lowBits = 32 - bitOffset;
+            const lowMask = getMask(lowBits);
+            currentWord |= (value & lowMask) << bitOffset;
+            out[outputWordIndex++] = currentWord | 0;
+            currentWord = value >>> lowBits;
+            bitOffset = bitWidth - lowBits;
+        }
+    }
+}
+
+/**
+ * Generic bit-unpacking of 32 integers, matching JavaFastPFOR BitPacking.fastunpack ordering.
+ * Reads exactly `bitWidth` int32 words from `inValues` starting at `inPos`.
+ */
+function fastUnpack32(inValues: Int32Array, inPos: number, out: Int32Array, outPos: number, bitWidth: number): void {
+    if (bitWidth === 0) {
+        out.fill(0, outPos, outPos + 32);
+        return;
+    }
+    if (bitWidth === 32) {
+        out.set(inValues.subarray(inPos, inPos + 32), outPos);
+        return;
+    }
+
+    const mask = getMask(bitWidth) >>> 0;
+    let inputWordIndex = inPos;
+    let bitOffset = 0;
+    let currentWord = inValues[inputWordIndex] >>> 0;
+
+    for (let i = 0; i < 32; i++) {
+        if (bitOffset + bitWidth <= 32) {
+            const value = (currentWord >>> bitOffset) & mask;
+            out[outPos + i] = value | 0;
+            bitOffset += bitWidth;
+
+            if (bitOffset === 32) {
+                bitOffset = 0;
+                inputWordIndex++;
+                if (i !== 31) currentWord = inValues[inputWordIndex] >>> 0;
+            }
+        } else {
+            const lowBits = 32 - bitOffset;
+            const low = currentWord >>> bitOffset;
+
+            inputWordIndex++;
+            currentWord = inValues[inputWordIndex] >>> 0;
+            const highMask = getMask(bitWidth - lowBits);
+            const high = currentWord & highMask;
+
+            const value = (low | (high << lowBits)) & mask;
+            out[outPos + i] = value | 0;
+            bitOffset = bitWidth - lowBits;
+        }
+    }
+}
+
+class FastPfor implements Int32Codec {
+    private readonly pageSize: number;
+    private dataToBePacked: Int32Array[] = new Array(33);
+    private byteContainer: Uint8Array;
+    private byteContainerPos = 0;
+    private readonly dataPointers = new Int32Array(33);
+    private readonly freqs = new Int32Array(33);
+    private readonly best = new Int32Array(3);
+
+    constructor(pageSize = DEFAULT_PAGE_SIZE) {
+        this.pageSize = normalizePageSize(pageSize);
+
+        const byteContainerSize = (3 * this.pageSize) / BLOCK_SIZE + this.pageSize;
+        this.byteContainer = new Uint8Array(byteContainerSize);
+
+        const initialPackedSize = (this.pageSize / 32) * 4;
+        for (let k = 1; k < this.dataToBePacked.length; k++) {
+            this.dataToBePacked[k] = new Int32Array(initialPackedSize);
+        }
+    }
+
+    public compress(inValues: Int32Array, inPos: IntWrapper, inLength: number, out: Int32Buf, outPos: IntWrapper): Int32Buf {
+        const alignedLength = greatestMultiple(inLength, BLOCK_SIZE);
+        if (alignedLength === 0) return out;
+
+        out = ensureInt32Capacity(out, outPos.get() + 1);
+        out[outPos.get()] = alignedLength;
+        outPos.increment();
+
+        return this.headlessCompress(inValues, inPos, alignedLength, out, outPos);
+    }
+
+    private headlessCompress(
+        inValues: Int32Array,
+        inPos: IntWrapper,
+        inLength: number,
+        out: Int32Buf,
+        outPos: IntWrapper,
+    ): Int32Buf {
+        const alignedLength = greatestMultiple(inLength, BLOCK_SIZE);
+        const finalInPos = inPos.get() + alignedLength;
+
+        while (inPos.get() !== finalInPos) {
+            const thisSize = Math.min(this.pageSize, finalInPos - inPos.get());
+            out = this.encodePage(inValues, inPos, thisSize, out, outPos);
+        }
+
+        return out;
+    }
+
+    private getBestBFromData(inValues: Int32Array, pos: number): void {
+        this.freqs.fill(0);
+        for (let k = pos, kEnd = pos + BLOCK_SIZE; k < kEnd; k++) {
+            this.freqs[bits(inValues[k])]++;
+        }
+
+        let maxBits = 32;
+        while (this.freqs[maxBits] === 0) maxBits--;
+
+        let bestB = maxBits;
+        let bestCost = maxBits * BLOCK_SIZE;
+        let cExcept = 0;
+        let bestCExcept = cExcept;
+
+        for (let b = maxBits - 1; b >= 0; b--) {
+            cExcept += this.freqs[b + 1];
+            if (cExcept === BLOCK_SIZE) break;
+
+            let thisCost =
+                cExcept * OVERHEAD_OF_EACH_EXCEPT + cExcept * (maxBits - b) + b * BLOCK_SIZE + 8;
+            if (maxBits - b === 1) thisCost -= cExcept;
+
+            if (thisCost < bestCost) {
+                bestCost = thisCost;
+                bestB = b;
+                bestCExcept = cExcept;
+            }
+        }
+
+        this.best[0] = bestB;
+        this.best[1] = bestCExcept;
+        this.best[2] = maxBits;
+    }
+
+    private byteContainerClear(): void {
+        this.byteContainerPos = 0;
+    }
+
+    private byteContainerPut(byteValue: number): void {
+        if (this.byteContainerPos >= this.byteContainer.length) {
+            this.byteContainer = ensureUint8Capacity(this.byteContainer, this.byteContainerPos + 1);
+        }
+        this.byteContainer[this.byteContainerPos++] = byteValue & 0xff;
+    }
+
+    private encodePage(
+        inValues: Int32Array,
+        inPos: IntWrapper,
+        thisSize: number,
+        out: Int32Buf,
+        outPos: IntWrapper,
+    ): Int32Buf {
+        const headerPos = outPos.get();
+        out = ensureInt32Capacity(out, headerPos + 1);
+        outPos.increment();
+        let tmpOutPos = outPos.get();
+
+        this.dataPointers.fill(0);
+        this.byteContainerClear();
+
+        let tmpInPos = inPos.get();
+        const finalInPos = tmpInPos + thisSize - BLOCK_SIZE;
+
+        for (; tmpInPos <= finalInPos; tmpInPos += BLOCK_SIZE) {
+            this.getBestBFromData(inValues, tmpInPos);
+
+            const bestB = this.best[0];
+            const cExcept = this.best[1];
+            const maxBits = this.best[2];
+
+            this.byteContainerPut(bestB);
+            this.byteContainerPut(cExcept);
+
+            if (cExcept > 0) {
+                this.byteContainerPut(maxBits);
+                const index = maxBits - bestB;
+
+                if (index >= 0 && index < this.dataToBePacked.length) {
+                    const needed = this.dataPointers[index] + cExcept;
+                    if (needed >= this.dataToBePacked[index].length) {
+                        let newSize = 2 * needed;
+                        newSize = roundUpToMultipleOf32(newSize);
+                        const next = new Int32Array(newSize);
+                        next.set(this.dataToBePacked[index]);
+                        this.dataToBePacked[index] = next;
+                    }
+                }
+
+                for (let k = 0; k < BLOCK_SIZE; k++) {
+                    const value = inValues[tmpInPos + k] >>> 0;
+                    if ((value >>> bestB) !== 0) {
+                        this.byteContainerPut(k);
+                        if (index !== 1) {
+                            this.dataToBePacked[index][this.dataPointers[index]++] = (value >>> bestB) | 0;
+                        }
+                    }
+                }
+            }
+
+            for (let k = 0; k < BLOCK_SIZE; k += 32) {
+                out = ensureInt32Capacity(out, tmpOutPos + bestB);
+                fastPack32(inValues, tmpInPos + k, out, tmpOutPos, bestB);
+                tmpOutPos += bestB;
+            }
+        }
+
+        inPos.set(tmpInPos);
+        out[headerPos] = (tmpOutPos - headerPos) | 0;
+
+        const byteSize = this.byteContainerPos;
+        while ((this.byteContainerPos & 3) !== 0) this.byteContainerPut(0);
+
+        out = ensureInt32Capacity(out, tmpOutPos + 1);
+        out[tmpOutPos++] = byteSize | 0;
+
+        const howManyInts = this.byteContainerPos / 4;
+        out = ensureInt32Capacity(out, tmpOutPos + howManyInts);
+        for (let i = 0; i < howManyInts; i++) {
+            const base = i * 4;
+            // byteContainer is serialized in little-endian inside int32 words (matching JavaFastPFOR),
+            // independent of how the overall Int32 stream is later converted to bytes.
+            const v =
+                (this.byteContainer[base] |
+                    (this.byteContainer[base + 1] << 8) |
+                    (this.byteContainer[base + 2] << 16) |
+                    (this.byteContainer[base + 3] << 24)) |
+                0;
+            out[tmpOutPos + i] = v;
+        }
+        tmpOutPos += howManyInts;
+
+        let bitmap = 0;
+        for (let k = 2; k <= 32; k++) {
+            if (this.dataPointers[k] !== 0) bitmap |= 1 << (k - 1);
+        }
+
+        out = ensureInt32Capacity(out, tmpOutPos + 1);
+        out[tmpOutPos++] = bitmap | 0;
+
+        for (let k = 2; k <= 32; k++) {
+            const size = this.dataPointers[k];
+            if (size !== 0) {
+                out = ensureInt32Capacity(out, tmpOutPos + 1);
+                out[tmpOutPos++] = size | 0;
+
+                let j = 0;
+                for (; j < size; j += 32) {
+                    out = ensureInt32Capacity(out, tmpOutPos + k);
+                    fastPack32(this.dataToBePacked[k], j, out, tmpOutPos, k);
+                    tmpOutPos += k;
+                }
+
+                const overflow = j - size;
+                tmpOutPos -= Math.floor((overflow * k) / 32);
+            }
+        }
+
+        outPos.set(tmpOutPos);
+        return out;
+    }
+
+    public uncompress(inValues: Int32Array, inPos: IntWrapper, inLength: number, out: Int32Array, outPos: IntWrapper): void {
+        if (inLength === 0) return;
+        const outLength = inValues[inPos.get()];
+        inPos.increment();
+        this.headlessUncompress(inValues, inPos, inLength, out, outPos, outLength);
+    }
+
+    private headlessUncompress(
+        inValues: Int32Array,
+        inPos: IntWrapper,
+        _inLength: number,
+        out: Int32Array,
+        outPos: IntWrapper,
+        outLength: number,
+    ): void {
+        const alignedOutLength = greatestMultiple(outLength, BLOCK_SIZE);
+        const finalOut = outPos.get() + alignedOutLength;
+        while (outPos.get() !== finalOut) {
+            const thisSize = Math.min(this.pageSize, finalOut - outPos.get());
+            this.decodePage(inValues, inPos, out, outPos, thisSize);
+        }
+    }
+
+    private decodePage(inValues: Int32Array, inPos: IntWrapper, out: Int32Array, outPos: IntWrapper, thisSize: number): void {
+        const initPos = inPos.get();
+        const whereMeta = inValues[inPos.get()];
+        inPos.increment();
+
+        let inExcept = initPos + whereMeta;
+        const byteSize = inValues[inExcept++] >>> 0;
+
+        const byteContainer = new Uint8Array(byteSize);
+        for (let i = 0; i < byteSize; i++) {
+            const intIdx = inExcept + (i >> 2);
+            const byteInInt = i & 3;
+            byteContainer[i] = (inValues[intIdx] >>> (byteInInt * 8)) & 0xff;
+        }
+
+        inExcept += Math.ceil(byteSize / 4);
+
+        const bitmap = inValues[inExcept++];
+
+        for (let k = 2; k <= 32; k++) {
+            if ((bitmap & (1 << (k - 1))) !== 0) {
+                const size = inValues[inExcept++];
+                const roundedUp = roundUpToMultipleOf32(size);
+
+                if (this.dataToBePacked[k].length < roundedUp) {
+                    this.dataToBePacked[k] = new Int32Array(roundedUp);
+                }
+
+                let j = 0;
+                for (; j < size; j += 32) {
+                    fastUnpack32(inValues, inExcept, this.dataToBePacked[k], j, k);
+                    inExcept += k;
+                }
+
+                const overflow = j - size;
+                inExcept -= Math.floor((overflow * k) / 32);
+            }
+        }
+
+        this.dataPointers.fill(0);
+        let tmpOutPos = outPos.get();
+        let tmpInPos = inPos.get();
+
+        let bytePosIn = 0;
+        const blocks = thisSize / BLOCK_SIZE;
+
+        for (let run = 0; run < blocks; run++, tmpOutPos += BLOCK_SIZE) {
+            const b = byteContainer[bytePosIn++];
+            const cExcept = byteContainer[bytePosIn++];
+
+            for (let k = 0; k < BLOCK_SIZE; k += 32) {
+                fastUnpack32(inValues, tmpInPos, out, tmpOutPos + k, b);
+                tmpInPos += b;
+            }
+
+            if (cExcept > 0) {
+                const maxBits = byteContainer[bytePosIn++];
+                const index = maxBits - b;
+
+                if (index === 1) {
+                    for (let k = 0; k < cExcept; k++) {
+                        const pos = byteContainer[bytePosIn++];
+                        out[pos + tmpOutPos] |= 1 << b;
+                    }
+                } else {
+                    for (let k = 0; k < cExcept; k++) {
+                        const pos = byteContainer[bytePosIn++];
+                        const exceptValue = this.dataToBePacked[index][this.dataPointers[index]++];
+                        out[pos + tmpOutPos] |= exceptValue << b;
+                    }
+                }
+            }
+        }
+
+        outPos.set(tmpOutPos);
+        inPos.set(inExcept);
+    }
+}
+
+class VariableByte implements Int32Codec {
+    public compress(inValues: Int32Array, inPos: IntWrapper, inLength: number, out: Int32Buf, outPos: IntWrapper): Int32Buf {
+        if (inLength === 0) return out;
+
+        const bytes: number[] = [];
+        bytes.length = 0;
+
+        const start = inPos.get();
+        for (let k = start; k < start + inLength; k++) {
+            let v = inValues[k] >>> 0;
+            while (v >= 0x80) {
+                bytes.push(v & 0x7f);
+                v >>>= 7;
+            }
+            bytes.push(v | 0x80);
+        }
+
+        while (bytes.length % 4 !== 0) bytes.push(0);
+
+        const intsToWrite = bytes.length / 4;
+        out = ensureInt32Capacity(out, outPos.get() + intsToWrite);
+
+        let outIdx = outPos.get();
+        for (let i = 0; i < bytes.length; i += 4) {
+            const v = (bytes[i] | (bytes[i + 1] << 8) | (bytes[i + 2] << 16) | (bytes[i + 3] << 24)) | 0;
+            out[outIdx++] = v;
+        }
+
+        outPos.set(outIdx);
+        inPos.add(inLength);
+        return out;
+    }
+
+    public uncompress(inValues: Int32Array, inPos: IntWrapper, inLength: number, out: Int32Array, outPos: IntWrapper): void {
+        let s = 0;
+        let p = inPos.get();
+        const finalP = inPos.get() + inLength;
+        let tmpOutPos = outPos.get();
+
+        let v = 0;
+        let shift = 0;
+
+        while (p < finalP) {
+            const val = inValues[p];
+            const c = (val >>> s) & 0xff;
+            s += 8;
+            p += s >>> 5;
+            s &= 31;
+
+            v += (c & 127) << shift;
+            if ((c & 128) === 128) {
+                out[tmpOutPos++] = v;
+                v = 0;
+                shift = 0;
+            } else {
+                shift += 7;
+            }
+        }
+
+        outPos.set(tmpOutPos);
+        inPos.add(inLength);
+    }
+}
+
+class Composition {
+    constructor(
+        private readonly first: Int32Codec,
+        private readonly second: Int32Codec,
+    ) {}
+
+    public compress(inValues: Int32Array, inPos: IntWrapper, inLength: number, out: Int32Buf, outPos: IntWrapper): Int32Buf {
+        if (inLength === 0) return out;
+
+        const inPosInit = inPos.get();
+        const outPosInit = outPos.get();
+
+        out = this.first.compress(inValues, inPos, inLength, out, outPos);
+        if (outPos.get() === outPosInit) {
+            out = ensureInt32Capacity(out, outPosInit + 1);
+            out[outPosInit] = 0;
+            outPos.increment();
+        }
+
+        const remaining = inLength - (inPos.get() - inPosInit);
+        out = this.second.compress(inValues, inPos, remaining, out, outPos);
+        return out;
+    }
+
+    public uncompress(inValues: Int32Array, inPos: IntWrapper, inLength: number, out: Int32Array, outPos: IntWrapper): void {
+        if (inLength === 0) return;
+        const init = inPos.get();
+        this.first.uncompress(inValues, inPos, inLength, out, outPos);
+        const remainingLength = inLength - (inPos.get() - init);
+        this.second.uncompress(inValues, inPos, remainingLength, out, outPos);
+    }
+}
+
+const fastPforCodec = new Composition(new FastPfor(), new VariableByte());
+
+export function compressFastPforInt32(values: Int32Array): Int32Buf {
+    const inPos = new IntWrapper(0);
+    const outPos = new IntWrapper(0);
+    let out = new Int32Array(values.length + 1024) as Int32Buf;
+    out = fastPforCodec.compress(values, inPos, values.length, out, outPos);
+    return out.subarray(0, outPos.get());
+}
+
+export function uncompressFastPforInt32(encoded: Int32Buf, numValues: number): Int32Array {
+    const inPos = new IntWrapper(0);
+    const outPos = new IntWrapper(0);
+    const decoded = new Int32Array(numValues);
+    fastPforCodec.uncompress(encoded, inPos, encoded.length, decoded, outPos);
+    return decoded;
+}
+
+export function int32sToBigEndianBytes(values: Int32Buf): Uint8Array {
+    // Note: the FastPFOR codec operates on an Int32 stream. When converted to bytes for the tile format,
+    // we serialize those int32 words using big-endian order (consistent with existing MLT TS code paths).
+    const bytes = new Uint8Array(values.length * 4);
+    for (let i = 0; i < values.length; i++) {
+        const v = values[i];
+        const base = i * 4;
+        bytes[base] = (v >>> 24) & 0xff;
+        bytes[base + 1] = (v >>> 16) & 0xff;
+        bytes[base + 2] = (v >>> 8) & 0xff;
+        bytes[base + 3] = v & 0xff;
+    }
+    return bytes;
+}
+
+export function bigEndianBytesToInt32s(bytes: Uint8Array, offset: number, byteLength: number): Int32Buf {
+    const numCompleteInts = Math.floor(byteLength / 4);
+    const hasTrailingBytes = byteLength % 4 !== 0;
+    const numInts = hasTrailingBytes ? numCompleteInts + 1 : numCompleteInts;
+
+    const ints = new Int32Array(numInts) as Int32Buf;
+    for (let i = 0; i < numCompleteInts; i++) {
+        const base = offset + i * 4;
+        ints[i] =
+            ((bytes[base] << 24) | (bytes[base + 1] << 16) | (bytes[base + 2] << 8) | bytes[base + 3]) | 0;
+    }
+
+    if (hasTrailingBytes) {
+        const base = offset + numCompleteInts * 4;
+        const remaining = byteLength - numCompleteInts * 4;
+        let v = 0;
+        for (let i = 0; i < remaining; i++) {
+            v |= bytes[base + i] << (24 - i * 8);
+        }
+        ints[numCompleteInts] = v | 0;
+    }
+    return ints;
+}


### PR DESCRIPTION
This is PR 1 in a small stacked series to keep review diffs manageable.

**What**
- Add a TypeScript FastPFOR int32 codec (encode/decode) and integrate it into the TS stream encode/decode utilities.

**Why**
- Implement the FAST_PFOR physical level technique in the TS decoder/encoder stack for 32-bit integer streams.

**Scope**
- Core codec + minimal integration and tests.
- Follow-ups will handle hardening/perf/refactors in smaller diffs.

**Tests**
- `cd ts && npm test`