### PR TITLE
chore: add a space to the dynamic arg in MLT encoding server

### DIFF
--- a/java/encoding-server/convert.mjs
+++ b/java/encoding-server/convert.mjs
@@ -152,7 +152,7 @@ function convertTileResponse(filePath, res) {
     (config.nomorton ? " --nomorton" : "") +
     (config.outlines ? " --outlines " + config.outlines : "") +
     (config.tessellate ? " --tessellate" : "") +
-    (config.coercemismatch ? "--coerce-mismatch" : "") +
+    (config.coercemismatch ? " --coerce-mismatch" : "") +
     (config.timer ? " --timer" : "") +
     (config.compare ? " --compare-all" : "");
 


### PR DESCRIPTION
Thank you for this awesome project.
I fixed an issue that `--coerce-mismatch` flag doesn't include a space.