### PR TITLE
Make fastpfor an API dependency

### DIFF
--- a/java/mlt-core/build.gradle
+++ b/java/mlt-core/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     runtimeOnly 'com.google.protobuf:protobuf-java:4.33.2'
     implementation 'io.github.earcut4j:earcut4j:2.2.2'
     testImplementation 'io.github.sebasbaumh:mapbox-vector-tile-java:25.1.0'
-    implementation 'me.lemire.integercompression:JavaFastPFOR:0.3.10'
+    api 'me.lemire.integercompression:JavaFastPFOR:0.3.10'
     implementation 'no.ecc.vectortile:java-vector-tile:1.3.23'
     implementation 'org.locationtech.jts:jts-core:1.20.0'
     implementation 'org.slf4j:slf4j-simple:2.0.17'


### PR DESCRIPTION
All `implementation` dependencies get exposed as scope=runtime in the generated pom file: https://repo1.maven.org/maven2/org/maplibre/mlt/0.0.7/mlt-0.0.7.pom. But, some APIs take IntWrapper from JavaFastPFOR as an argument so this changes it to an API dependency so that projects that depend on it will have access to IntWrapper at compile time.