### PR TITLE
fix(rs): Fix error typo

### DIFF
--- a/rust/mlt/src/decoder/helpers.rs
+++ b/rust/mlt/src/decoder/helpers.rs
@@ -9,10 +9,10 @@ pub fn get_data_type_from_column(column_metadata: &Column) -> MltResult<ScalarTy
                 ScalarType::try_from(scalar_type)
                     .map_err(|_| MltError::MetaDecodeInvalidType("ScalarType"))
             }
-            Some(_) => Err(MltError::MetaDecodeUnsupporteddType("column.scalar.type")),
+            Some(_) => Err(MltError::MetaDecodeUnsupportedType("column.scalar.type")),
             None => Err(MltError::MissingField("column.scalar.type")),
         },
-        Some(_) => Err(MltError::MetaDecodeUnsupporteddType("column.type")),
+        Some(_) => Err(MltError::MetaDecodeUnsupportedType("column.type")),
         None => Err(MltError::MissingField("column.type")),
     }
 }

--- a/rust/mlt/src/error.rs
+++ b/rust/mlt/src/error.rs
@@ -46,7 +46,7 @@ pub enum MltError {
     #[error("metadata decode error: invalid type={0}")]
     MetaDecodeInvalidType(&'static str),
     #[error("metadata decode error: unsupported type={0}")]
-    MetaDecodeUnsupporteddType(&'static str),
+    MetaDecodeUnsupportedType(&'static str),
     #[error("missing required logical metadata: {which}")]
     MissingLogicalMetadata { which: &'static str },
 


### PR DESCRIPTION
Not really a world-changing change but was skimming through the error flow and noticed this. 