### PR TITLE
fix(cpp): three decoder bugs found via encoder roundtrip testing

### DIFF
--- a/cpp/src/mlt/decode/property.hpp
+++ b/cpp/src/mlt/decode/property.hpp
@@ -159,9 +159,9 @@ protected:
                 return {scalarType, std::move(result), std::move(presentStream)};
             }
             case ScalarType::INT_64: {
-                std::vector<std::uint64_t> longBuffer;
+                std::vector<std::int64_t> longBuffer;
                 longBuffer.reserve(streamMetadata->getNumValues());
-                intDecoder.decodeIntStream<std::uint64_t, std::uint64_t, std::uint64_t>(
+                intDecoder.decodeIntStream<std::uint64_t, std::uint64_t, std::int64_t>(
                     tileData, longBuffer, *streamMetadata, /*isSigned=*/true);
 
                 PropertyVec result{std::move(longBuffer)};
@@ -178,7 +178,7 @@ protected:
                 checkBits(presentStream, result);
                 return {scalarType, std::move(result), std::move(presentStream)};
             }
-            case ScalarType::DOUBLE: // doubles currently written as floats
+            case ScalarType::DOUBLE: // wire format stores doubles as floats
             case ScalarType::FLOAT: {
                 std::vector<float> floatBuffer;
                 floatBuffer.reserve(streamMetadata->getNumValues());

--- a/cpp/src/mlt/util/space_filling_curve.hpp
+++ b/cpp/src/mlt/util/space_filling_curve.hpp
@@ -12,7 +12,7 @@ public:
     SpaceFillingCurve(std::int32_t minVertexValue, std::int32_t maxVertexValue)
         : coordinateShift((minVertexValue < 0) ? std::abs(minVertexValue) : 0),
           tileExtent(maxVertexValue + coordinateShift),
-          numBits(static_cast<std::uint32_t>(std::ceil(std::log2(tileExtent)))),
+          numBits(static_cast<std::uint32_t>(std::ceil(std::log2(tileExtent + 1)))),
           minBound(minVertexValue),
           maxBound(maxVertexValue) {
         // TODO: fix tile buffer problem


### PR DESCRIPTION
Found while building the encoder (#813) — roundtrip tests (encode → decode → compare) exercised decoder paths the existing tests don't cover.

### Bugs fixed

**Polygon ring closing** (`geometry_vector.cpp`)

MLT stores polygon rings without closing points; the decoder must add them back. The plain vertex buffer path had this commented out:

```cpp
// This breaks embedded tessellation because it changes the indexes.
// Disabling it doesn't seem to break anything, is it needed?
// if (closeLineString && !coords.empty() && coords.front() != coords.back()) {
//     coords.push_back(coords.front());
// }
```

The dictionary and Morton paths already close rings — the plain path was inconsistent. Re-enabled, matching the Java decoder behavior (`ringToLineString` strips closing points via `Arrays.copyOf(..., length - 1)`, decoder is expected to restore them).

**INT_64 decoded as unsigned** (`decode/property.hpp`)

`INT_64` properties were decoded into `vector<uint64_t>`, corrupting negative values. Changed to `vector<int64_t>`, matching the `INT_32`/`UINT_32`/`UINT_64` pattern already in the same switch.

**Space-filling curve bit width off-by-one** (`space_filling_curve.hpp`)

`ceil(log2(4096))` = 12, but 12 bits only represent 0..4095 — coordinate 4096 (valid at tile extent boundary) maps to 0. Changed to `ceil(log2(tileExtent + 1))` for the correct ceiling.

### Also fixed

Shadow variables in `geometry_vector.cpp` — inner loops shadowed the outer geometry iterator (`i`→`j`, `j`→`k`), and multiple `totalVertices` variables shadowed each other across if/else branches. Pure renames, no behavior change.

### Regression test

Added a polygon ring closing check to `Decode.SimplePolygonBoolean` — verified it fails without the fix, passes with it.