### PR TITLE
Use geojson for geometries instead of WKT in Java CLI

### DIFF
--- a/java/mlt-cli/build.gradle
+++ b/java/mlt-cli/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'jakarta.annotation:jakarta.annotation-api:3.0.0'
     implementation 'org.jetbrains:annotations:26.0.2-1'
     implementation 'org.locationtech.jts:jts-core:1.20.0'
+    implementation 'org.locationtech.jts.io:jts-io-common:1.20.0'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:6.0.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:6.0.2'

--- a/java/mlt-cli/src/main/java/org/maplibre/mlt/cli/CliUtil.java
+++ b/java/mlt-cli/src/main/java/org/maplibre/mlt/cli/CliUtil.java
@@ -4,6 +4,7 @@ import com.google.gson.GsonBuilder;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
+import org.locationtech.jts.io.geojson.GeoJsonWriter;
 import org.maplibre.mlt.data.Feature;
 import org.maplibre.mlt.data.Layer;
 import org.maplibre.mlt.data.MapLibreTile;
@@ -28,7 +29,9 @@ public class CliUtil {
   private static Map<String, Object> toJSON(Feature feature) {
     var map = new TreeMap<String, Object>();
     map.put("id", feature.id());
-    map.put("geometry", feature.geometry().toString());
+    map.put("type", "Feature");
+    var writer = new GeoJsonWriter();
+    map.put("geometry", writer.write(feature.geometry()));
     // Print properties sorted by key and drop those with null
     // values to facilitate direct comparison with MVT output.
     map.put(


### PR DESCRIPTION
This changes the output of the CLI json to be "regular" geojson for each layer instead of using WKT for the geometries, which creates a "weird" looking json.

Related to:
- https://github.com/maplibre/maplibre-tile-spec/pull/780
