### PR TITLE
fix(java): add Gradle toolchains plugin to fix build

### DIFF
--- a/java/settings.gradle
+++ b/java/settings.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
+
 rootProject.name = 'maplibre-tiles'
 
 include 'mlt-core'


### PR DESCRIPTION
`build` caused this issue

```
❯ ./gradlew build
...

FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':mlt-cli:compileJava'.
> Could not resolve all dependencies for configuration ':mlt-cli:compileClasspath'.
   > Failed to calculate the value of task ':mlt-cli:compileJava' property 'javaCompiler'.
      > Cannot find a Java installation on your machine (Linux 6.8.0-100-generic amd64) matching: {languageVersion=21, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}. Toolchain download repositories have not been configured.

* Try:
> Learn more about toolchain auto-detection and auto-provisioning at https://docs.gradle.org/9.2.1/userguide/toolchains.html#sec:auto_detection.
> Learn more about toolchain repositories at https://docs.gradle.org/9.2.1/userguide/toolchains.html#sub:download_repositories.
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to generate a Build Scan (powered by Develocity).
> Get more help at https://help.gradle.org.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/9.2.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
```

I vibe-fixed it by adding this to settings, which seemed to have worked.

```
plugins {
    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
}
```