### PR TITLE
perf(rust): Add an encoding benchmark

### DIFF
--- a/rust/mlt-core/Cargo.toml
+++ b/rust/mlt-core/Cargo.toml
@@ -15,6 +15,10 @@ rust-version.workspace = true
 name = "decoding"
 harness = false
 
+[[bench]]
+name = "encoding"
+harness = false
+
 [features]
 arbitrary = ["dep:arbitrary", "geo-types/arbitrary"]
 

--- a/rust/mlt-core/benches/bench_utils.rs
+++ b/rust/mlt-core/benches/bench_utils.rs
@@ -1,0 +1,39 @@
+use std::fs;
+use std::path::Path;
+
+pub const BENCHMARKED_ZOOM_LEVELS: [u8; 3] = [4, 7, 13];
+
+#[must_use]
+pub fn load_mlt_tiles(zoom: u8) -> Vec<(String, Vec<u8>)> {
+    load_tiles(zoom, "expected/tag0x01/omt", ".mlt")
+}
+
+#[must_use]
+pub fn load_tiles(zoom: u8, test_subpath: &str, extension: &str) -> Vec<(String, Vec<u8>)> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../test")
+        .join(test_subpath);
+    let prefix = format!("{zoom}_");
+    let mut tiles = Vec::new();
+    let entries =
+        fs::read_dir(&dir).unwrap_or_else(|err| panic!("can't read {}: {err}", dir.display()));
+    for entry in entries {
+        let entry = entry.unwrap_or_else(|err| panic!("can't read entry {}: {err}", dir.display()));
+        let file_name = entry.file_name();
+        let name = file_name.to_string_lossy();
+        if name.starts_with(&prefix)
+            && let Some(stem) = name.strip_suffix(extension)
+        {
+            let data = fs::read(entry.path())
+                .unwrap_or_else(|err| panic!("can't read {}: {err}", entry.path().display()));
+            tiles.push((stem.to_string(), data));
+        }
+    }
+    assert!(
+        !tiles.is_empty(),
+        "No tiles found for zoom level {zoom} in {}",
+        dir.display()
+    );
+    tiles.sort_by(|a, b| a.0.cmp(&b.0));
+    tiles
+}

--- a/rust/mlt-core/benches/decoding.rs
+++ b/rust/mlt-core/benches/decoding.rs
@@ -1,47 +1,14 @@
-use std::fs;
 use std::hint::black_box;
-use std::path::Path;
 
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use mlt_core::parse_layers;
 
-const BENCHMARKED_ZOOM_LEVELS: [u8; 3] = [4, 7, 13];
-
-fn load_mlt_tiles(zoom: u8) -> Vec<(String, Vec<u8>)> {
-    load_tiles(zoom, "expected/tag0x01/omt", ".mlt")
-}
+#[path = "bench_utils.rs"]
+mod bench_utils;
+use bench_utils::{BENCHMARKED_ZOOM_LEVELS, load_mlt_tiles, load_tiles};
 
 fn load_mvt_tiles(zoom: u8) -> Vec<(String, Vec<u8>)> {
     load_tiles(zoom, "fixtures/omt", ".mvt")
-}
-
-fn load_tiles(zoom: u8, test_subpath: &str, extension: &str) -> Vec<(String, Vec<u8>)> {
-    let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../../test")
-        .join(test_subpath);
-    let prefix = format!("{zoom}_");
-    let mut tiles = Vec::new();
-    let entries =
-        fs::read_dir(&dir).unwrap_or_else(|err| panic!("can't read {}: {err}", dir.display()));
-    for entry in entries {
-        let entry = entry.unwrap_or_else(|err| panic!("can't read entry {}: {err}", dir.display()));
-        let file_name = entry.file_name();
-        let name = file_name.to_string_lossy();
-        if name.starts_with(&prefix)
-            && let Some(name) = name.strip_suffix(extension)
-        {
-            let data = fs::read(entry.path())
-                .unwrap_or_else(|err| panic!("can't read {}: {err}", entry.path().display()));
-            tiles.push((name.to_string(), data));
-        }
-    }
-    assert!(
-        !tiles.is_empty(),
-        "No tiles found for zoom level {zoom} in {}",
-        dir.display()
-    );
-    tiles.sort_by(|a, b| a.0.cmp(&b.0));
-    tiles
 }
 
 fn bench_mlt_parse(c: &mut Criterion) {

--- a/rust/mlt-core/benches/encoding.rs
+++ b/rust/mlt-core/benches/encoding.rs
@@ -1,0 +1,152 @@
+use std::hint::black_box;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use mlt_core::v01::{
+    Encoder, GeometryEncoder, IdEncoder, IdWidth, LogicalEncoder, PhysicalEncoder, PresenceStream,
+    PropertyEncoder,
+};
+use mlt_core::{Encodable as _, OwnedLayer, parse_layers};
+use strum::IntoEnumIterator as _;
+
+#[path = "bench_utils.rs"]
+mod bench_utils;
+use bench_utils::{BENCHMARKED_ZOOM_LEVELS, load_mlt_tiles};
+
+fn decode_to_owned(tiles: &[(String, Vec<u8>)]) -> Vec<OwnedLayer> {
+    tiles
+        .iter()
+        .flat_map(|(_, data)| {
+            let mut layers = parse_layers(data).expect("mlt parse failed");
+            for layer in &mut layers {
+                layer.decode_all().expect("mlt decode_all failed");
+            }
+            layers
+                .iter()
+                .map(borrowme::ToOwned::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn bench_encode_geometry(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mlt encode geometry");
+
+    for zoom in BENCHMARKED_ZOOM_LEVELS {
+        let tiles = load_mlt_tiles(zoom);
+        let total_bytes: usize = tiles.iter().map(|(_, d)| d.len()).sum();
+        group.throughput(Throughput::Bytes(total_bytes as u64));
+
+        for physical in PhysicalEncoder::iter() {
+            for logical in LogicalEncoder::iter() {
+                let geometry_encoder = GeometryEncoder::all(Encoder { logical, physical });
+                group.bench_with_input(
+                    BenchmarkId::new(format!("{logical:?}-{physical:?}"), zoom),
+                    &tiles,
+                    |b, tiles| {
+                        b.iter_batched(
+                            || decode_to_owned(tiles),
+                            |mut layers| {
+                                for layer in &mut layers {
+                                    if let OwnedLayer::Tag01(l) = layer {
+                                        l.geometry
+                                            .encode_with(geometry_encoder)
+                                            .expect("geometry encode failed");
+                                    }
+                                }
+                                black_box(layers);
+                            },
+                            BatchSize::SmallInput,
+                        );
+                    },
+                );
+            }
+        }
+    }
+
+    group.finish();
+}
+
+fn bench_encode_ids(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mlt encode ids");
+
+    for zoom in BENCHMARKED_ZOOM_LEVELS {
+        let tiles = load_mlt_tiles(zoom);
+        let total_bytes: usize = tiles.iter().map(|(_, d)| d.len()).sum();
+        group.throughput(Throughput::Bytes(total_bytes as u64));
+
+        for fmt in IdWidth::iter() {
+            for logical in LogicalEncoder::iter() {
+                let id_encoder = IdEncoder::new(logical, fmt);
+                group.bench_with_input(
+                    BenchmarkId::new(format!("{logical:?}-{fmt:?}"), zoom),
+                    &tiles,
+                    |b, tiles| {
+                        b.iter_batched(
+                            || decode_to_owned(tiles),
+                            |mut layers| {
+                                for layer in &mut layers {
+                                    if let OwnedLayer::Tag01(l) = layer {
+                                        l.id.encode_with(id_encoder).expect("id encode failed");
+                                    }
+                                }
+                                black_box(layers);
+                            },
+                            BatchSize::SmallInput,
+                        );
+                    },
+                );
+            }
+        }
+    }
+
+    group.finish();
+}
+
+fn bench_encode_properties(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mlt encode properties");
+
+    for zoom in BENCHMARKED_ZOOM_LEVELS {
+        let tiles = load_mlt_tiles(zoom);
+        let total_bytes: usize = tiles.iter().map(|(_, d)| d.len()).sum();
+        group.throughput(Throughput::Bytes(total_bytes as u64));
+
+        for presence in PresenceStream::iter() {
+            for physical in PhysicalEncoder::iter() {
+                for logical in LogicalEncoder::iter() {
+                    let property_encoder = PropertyEncoder::new(presence, logical, physical);
+                    group.bench_with_input(
+                        BenchmarkId::new(format!("{presence:?}-{logical:?}-{physical:?}"), zoom),
+                        &tiles,
+                        |b, tiles| {
+                            b.iter_batched(
+                                || decode_to_owned(tiles),
+                                |mut layers| {
+                                    for layer in &mut layers {
+                                        if let OwnedLayer::Tag01(l) = layer {
+                                            for prop in &mut l.properties {
+                                                prop.encode_with(property_encoder)
+                                                    .expect("prop encode failed");
+                                            }
+                                        }
+                                    }
+                                    black_box(layers);
+                                },
+                                BatchSize::SmallInput,
+                            );
+                        },
+                    );
+                }
+            }
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_encode_geometry,
+    bench_encode_ids,
+    bench_encode_properties,
+);
+criterion_main!(benches);

--- a/rust/mlt-core/src/layer/v01/id.rs
+++ b/rust/mlt-core/src/layer/v01/id.rs
@@ -231,7 +231,7 @@ impl IdEncoder {
 }
 
 /// How wide are the IDs
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, strum::EnumIter)]
 #[cfg_attr(all(not(test), feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub enum IdWidth {
     /// 32-bit encoding

--- a/rust/mlt-core/src/layer/v01/property/mod.rs
+++ b/rust/mlt-core/src/layer/v01/property/mod.rs
@@ -505,7 +505,7 @@ impl PropertyEncoder {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumIter)]
 #[cfg_attr(all(not(test), feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub enum PresenceStream {
     /// Attaches a nullability stream

--- a/rust/mlt-core/src/layer/v01/stream/logical.rs
+++ b/rust/mlt-core/src/layer/v01/stream/logical.rs
@@ -238,7 +238,7 @@ impl LogicalValue {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Copy, Default)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Default, strum::EnumIter)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 #[cfg_attr(all(not(test), feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub enum LogicalEncoder {

--- a/rust/mlt-core/src/layer/v01/stream/physical.rs
+++ b/rust/mlt-core/src/layer/v01/stream/physical.rs
@@ -82,7 +82,7 @@ impl PhysicalEncoding {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumIter)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 #[cfg_attr(all(not(test), feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub enum PhysicalEncoder {


### PR DESCRIPTION
This PR adds the missing encoding benchmark.

For propertys it is a bit weak (could be more fine grained), but generally I think this is the kind of north star benchmark that we want to be able to improve encoding perf.