### PR TITLE
chore(rust): rm json5, inf floats to string

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1331,22 +1331,12 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.90"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "json5"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733a844dbd6fef128e98cb4487b887cb55454d92cd9994b1bafe004fabbe670c"
-dependencies = [
- "serde",
- "ucd-trie",
 ]
 
 [[package]]
@@ -1536,7 +1526,6 @@ dependencies = [
  "geo-types",
  "glob",
  "globset",
- "json5",
  "mlt-core",
  "ratatui",
  "rayon",
@@ -1593,7 +1582,6 @@ version = "0.1.0"
 dependencies = [
  "geo",
  "geo-types",
- "json5",
  "mlt-core",
  "pretty_assertions",
  "serde_json",
@@ -1990,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "plotters"
@@ -3558,9 +3546,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3571,9 +3559,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3581,9 +3569,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3594,9 +3582,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -3637,9 +3625,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.90"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3994,18 +3982,18 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,7 +33,6 @@ globset = "0.4"
 hex = "0.4.3"
 insta = "1.43.2"
 integer-encoding = "4.0.2"
-json5 = "1.3"
 mlt-core = { version = "0.1.2", path = "mlt-core" }
 mvt-reader = "2.2.0"
 num-traits = "0.2.19"

--- a/rust/mlt-core/src/layer/v01/property/mod.rs
+++ b/rust/mlt-core/src/layer/v01/property/mod.rs
@@ -11,7 +11,7 @@ use crate::analyse::{Analyze, StatType};
 use crate::decode::{FromEncoded, impl_decodable};
 use crate::utils::{
     BinarySerializer as _, FmtOptVec, apply_present, encode_bools_to_bytes, encode_byte_rle,
-    f32_to_json,
+    f32_to_json, f64_to_json,
 };
 use crate::v01::property::decode::{decode_string_streams, decode_struct_children};
 use crate::v01::{
@@ -382,7 +382,6 @@ impl Debug for PropValue {
 impl PropValue {
     /// Convert the value at index `i` to a [`serde_json::Value`]
     #[must_use]
-    #[expect(clippy::cast_possible_truncation)] // f64 stored as f32 in wire format
     pub fn to_geojson(&self, i: usize) -> Option<serde_json::Value> {
         use serde_json::Value;
 
@@ -395,7 +394,7 @@ impl PropValue {
             Self::I64(v) => v[i].map(Value::from),
             Self::U64(v) => v[i].map(Value::from),
             Self::F32(v) => v[i].map(f32_to_json),
-            Self::F64(v) => v[i].map(|f| f32_to_json(f as f32)),
+            Self::F64(v) => v[i].map(f64_to_json),
             Self::Str(v) => v[i].as_ref().map(|s| Value::String(s.clone())),
             Self::Struct => None,
         }

--- a/rust/mlt-core/src/utils/mod.rs
+++ b/rust/mlt-core/src/utils/mod.rs
@@ -8,13 +8,34 @@ mod decode;
 pub(crate) use decode::*;
 mod formatter;
 pub(crate) use formatter::{FmtOptVec, OptSeq, OptSeqOpt, fmt_byte_array};
+use serde_json::{Number, Value};
 
 use crate::MltError;
 
-/// Convert f32 to JSON using the shortest decimal representation (matches Java's `Float.toString()`)
-pub fn f32_to_json(f: f32) -> serde_json::Value {
-    let serialized = &serde_json::to_string(&f).expect("f32 serialization should not fail");
-    serde_json::from_str(serialized).expect("serialized f32 should parse as JSON")
+/// Convert f32 to `GeoJSON` value: finite as number, non-finite as string per issue #978.
+pub fn f32_to_json(f: f32) -> Value {
+    if f.is_nan() {
+        Value::String("f32::NAN".to_owned())
+    } else if f == f32::INFINITY {
+        Value::String("f32::INFINITY".to_owned())
+    } else if f == f32::NEG_INFINITY {
+        Value::String("f32::NEG_INFINITY".to_owned())
+    } else {
+        Number::from_f64(f64::from(f)).expect("finite f32").into()
+    }
+}
+
+/// Convert f64 to `GeoJSON` value: finite as number, non-finite as string per issue #978.
+pub fn f64_to_json(f: f64) -> Value {
+    if f.is_nan() {
+        Value::String("f64::NAN".to_owned())
+    } else if f == f64::INFINITY {
+        Value::String("f64::INFINITY".to_owned())
+    } else if f == f64::NEG_INFINITY {
+        Value::String("f64::NEG_INFINITY".to_owned())
+    } else {
+        Number::from_f64(f).expect("finite f64").into()
+    }
 }
 
 pub trait SetOptionOnce<T> {

--- a/rust/mlt-synthetics/Cargo.toml
+++ b/rust/mlt-synthetics/Cargo.toml
@@ -14,7 +14,6 @@ publish = false
 [dependencies]
 geo.workspace = true
 geo-types.workspace = true
-json5.workspace = true
 mlt-core.workspace = true
 pretty_assertions.workspace = true
 serde_json.workspace = true

--- a/rust/mlt-synthetics/src/layer.rs
+++ b/rust/mlt-synthetics/src/layer.rs
@@ -257,7 +257,7 @@ impl Layer {
             l.decode_all().unwrap();
         }
         let fc = FeatureCollection::from_layers(&data).unwrap();
-        let mut json = serde_json::to_string_pretty(&serde_json::to_value(&fc).unwrap()).unwrap();
+        let mut json = serde_json::to_string_pretty(&fc).unwrap();
         json.push('\n');
         let mut out_file = Self::open_new(&dir.join(format!("{name}.json"))).unwrap();
         out_file.write_all(json.as_bytes()).unwrap();

--- a/rust/mlt/Cargo.toml
+++ b/rust/mlt/Cargo.toml
@@ -26,7 +26,6 @@ flate2.workspace = true
 geo-types.workspace = true
 glob.workspace = true
 globset.workspace = true
-json5.workspace = true
 mlt-core.workspace = true
 ratatui.workspace = true
 rayon.workspace = true

--- a/rust/mlt/src/ls.rs
+++ b/rust/mlt/src/ls.rs
@@ -583,8 +583,9 @@ pub fn analyze_mlt_buffer(buffer: &[u8], path: &Path, flags: LsFlags) -> Result<
     let matches_json = if flags.validate {
         let json_path = path.with_extension("json");
         if json_path.is_file() {
-            let expected: FeatureCollection = json5::from_str(&fs::read_to_string(&json_path)?)
-                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            let expected: FeatureCollection =
+                serde_json::from_str(&fs::read_to_string(&json_path)?)
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
             let actual = FeatureCollection::from_layers(&layers)?;
             let expected_val = normalize_tiny_floats(serde_json::to_value(&expected)?);
             let actual_val = normalize_tiny_floats(serde_json::to_value(&actual)?);

--- a/test/synthetic/0x01-rust/extent_1073741824.json
+++ b/test/synthetic/0x01-rust/extent_1073741824.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 1073741824,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             0,
@@ -11,15 +18,8 @@
             1073741823,
             1073741823
           ]
-        ],
-        "type": "LineString"
-      },
-      "properties": {
-        "_extent": 1073741824,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/extent_131072.json
+++ b/test/synthetic/0x01-rust/extent_131072.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 131072,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             0,
@@ -11,15 +18,8 @@
             131071,
             131071
           ]
-        ],
-        "type": "LineString"
-      },
-      "properties": {
-        "_extent": 131072,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/extent_4096.json
+++ b/test/synthetic/0x01-rust/extent_4096.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             0,
@@ -11,15 +18,8 @@
             4095,
             4095
           ]
-        ],
-        "type": "LineString"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/extent_512.json
+++ b/test/synthetic/0x01-rust/extent_512.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 512,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             0,
@@ -11,15 +18,8 @@
             511,
             511
           ]
-        ],
-        "type": "LineString"
-      },
-      "properties": {
-        "_extent": 512,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/extent_buf_1073741824.json
+++ b/test/synthetic/0x01-rust/extent_buf_1073741824.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 1073741824,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             -42,
@@ -11,15 +18,8 @@
             1073741866,
             1073741866
           ]
-        ],
-        "type": "LineString"
-      },
-      "properties": {
-        "_extent": 1073741824,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/extent_buf_131072.json
+++ b/test/synthetic/0x01-rust/extent_buf_131072.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 131072,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             -42,
@@ -11,15 +18,8 @@
             131114,
             131114
           ]
-        ],
-        "type": "LineString"
-      },
-      "properties": {
-        "_extent": 131072,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/extent_buf_4096.json
+++ b/test/synthetic/0x01-rust/extent_buf_4096.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             -42,
@@ -11,15 +18,8 @@
             4138,
             4138
           ]
-        ],
-        "type": "LineString"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/extent_buf_512.json
+++ b/test/synthetic/0x01-rust/extent_buf_512.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 512,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             -42,
@@ -11,15 +18,8 @@
             554,
             554
           ]
-        ],
-        "type": "LineString"
-      },
-      "properties": {
-        "_extent": 512,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/id.json
+++ b/test/synthetic/0x01-rust/id.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 100,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/id0.json
+++ b/test/synthetic/0x01-rust/id0.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 0,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/id64.json
+++ b/test/synthetic/0x01-rust/id64.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 9234567890,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/ids.json
+++ b/test/synthetic/0x01-rust/ids.json
@@ -1,65 +1,65 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 103,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 103,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 103,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 103,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/ids64.json
+++ b/test/synthetic/0x01-rust/ids64.json
@@ -1,65 +1,65 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 9234567890,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 9234567890,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 9234567890,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 9234567890,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/ids64_delta.json
+++ b/test/synthetic/0x01-rust/ids64_delta.json
@@ -1,65 +1,65 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 9234567890,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 9234567890,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 9234567890,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 9234567890,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/ids64_delta_rle.json
+++ b/test/synthetic/0x01-rust/ids64_delta_rle.json
@@ -1,65 +1,65 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 9234567890,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 9234567890,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 9234567890,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 9234567890,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/ids64_opt.json
+++ b/test/synthetic/0x01-rust/ids64_opt.json
@@ -1,79 +1,79 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "id": 9234567890,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "id": 101,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "id": 105,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "id": 106,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/ids64_opt_delta.json
+++ b/test/synthetic/0x01-rust/ids64_opt_delta.json
@@ -1,79 +1,79 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "id": 9234567890,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "id": 101,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "id": 105,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "id": 106,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/ids64_rle.json
+++ b/test/synthetic/0x01-rust/ids64_rle.json
@@ -1,65 +1,65 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 9234567890,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 9234567890,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 9234567890,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 9234567890,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/ids_delta.json
+++ b/test/synthetic/0x01-rust/ids_delta.json
@@ -1,65 +1,65 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 103,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 103,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 103,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 103,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/ids_delta_rle.json
+++ b/test/synthetic/0x01-rust/ids_delta_rle.json
@@ -1,65 +1,65 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 103,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 103,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 103,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 103,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/ids_opt.json
+++ b/test/synthetic/0x01-rust/ids_opt.json
@@ -1,79 +1,79 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 100,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "id": 101,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "id": 105,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "id": 106,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/ids_opt_delta.json
+++ b/test/synthetic/0x01-rust/ids_opt_delta.json
@@ -1,79 +1,79 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 100,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "id": 101,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "id": 105,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "id": 106,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/ids_rle.json
+++ b/test/synthetic/0x01-rust/ids_rle.json
@@ -1,65 +1,65 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 103,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 103,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 103,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "id": 103,
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/line.json
+++ b/test/synthetic/0x01-rust/line.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             4,
@@ -11,15 +18,8 @@
             12,
             53
           ]
-        ],
-        "type": "LineString"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_line_line.json
+++ b/test/synthetic/0x01-rust/mixed_line_line.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             4,
@@ -11,17 +18,17 @@
             12,
             53
           ]
-        ],
-        "type": "LineString"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     },
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             4,
@@ -31,15 +38,8 @@
             12,
             53
           ]
-        ],
-        "type": "LineString"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_line_mline.json
+++ b/test/synthetic/0x01-rust/mixed_line_mline.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             4,
@@ -11,17 +18,17 @@
             12,
             53
           ]
-        ],
-        "type": "LineString"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "MultiLineString",
         "coordinates": [
           [
             [
@@ -47,15 +54,8 @@
               49
             ]
           ]
-        ],
-        "type": "MultiLineString"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_line_mline_line.json
+++ b/test/synthetic/0x01-rust/mixed_line_mline_line.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             4,
@@ -11,17 +18,17 @@
             12,
             53
           ]
-        ],
-        "type": "LineString"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "MultiLineString",
         "coordinates": [
           [
             [
@@ -47,17 +54,17 @@
               49
             ]
           ]
-        ],
-        "type": "MultiLineString"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             13,
@@ -71,15 +78,8 @@
             10,
             49
           ]
-        ],
-        "type": "LineString"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_line_mpoint.json
+++ b/test/synthetic/0x01-rust/mixed_line_mpoint.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             4,
@@ -11,17 +18,17 @@
             12,
             53
           ]
-        ],
-        "type": "LineString"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     },
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiPoint",
         "coordinates": [
           [
             12,
@@ -35,15 +42,8 @@
             12,
             53
           ]
-        ],
-        "type": "MultiPoint"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_line_mpoint_line.json
+++ b/test/synthetic/0x01-rust/mixed_line_mpoint_line.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             4,
@@ -11,17 +18,17 @@
             12,
             53
           ]
-        ],
-        "type": "LineString"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "MultiPoint",
         "coordinates": [
           [
             12,
@@ -35,31 +42,24 @@
             12,
             53
           ]
-        ],
-        "type": "MultiPoint"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             12,
             53
           ]
-        ],
-        "type": "LineString"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_line_poly.json
+++ b/test/synthetic/0x01-rust/mixed_line_poly.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             4,
@@ -11,17 +18,17 @@
             12,
             53
           ]
-        ],
-        "type": "LineString"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -41,15 +48,8 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_line_poly_line.json
+++ b/test/synthetic/0x01-rust/mixed_line_poly_line.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             4,
@@ -11,17 +18,17 @@
             12,
             53
           ]
-        ],
-        "type": "LineString"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -41,17 +48,17 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             4,
@@ -61,15 +68,8 @@
             12,
             53
           ]
-        ],
-        "type": "LineString"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_line_pt.json
+++ b/test/synthetic/0x01-rust/mixed_line_pt.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             4,
@@ -11,29 +18,22 @@
             12,
             53
           ]
-        ],
-        "type": "LineString"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_mline_line.json
+++ b/test/synthetic/0x01-rust/mixed_mline_line.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiLineString",
         "coordinates": [
           [
             [
@@ -27,17 +34,17 @@
               49
             ]
           ]
-        ],
-        "type": "MultiLineString"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             13,
@@ -51,15 +58,8 @@
             10,
             49
           ]
-        ],
-        "type": "LineString"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_mline_line_mline.json
+++ b/test/synthetic/0x01-rust/mixed_mline_line_mline.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiLineString",
         "coordinates": [
           [
             [
@@ -27,17 +34,17 @@
               49
             ]
           ]
-        ],
-        "type": "MultiLineString"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             13,
@@ -51,17 +58,17 @@
             10,
             49
           ]
-        ],
-        "type": "LineString"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "MultiLineString",
         "coordinates": [
           [
             [
@@ -87,15 +94,8 @@
               49
             ]
           ]
-        ],
-        "type": "MultiLineString"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_mline_mline.json
+++ b/test/synthetic/0x01-rust/mixed_mline_mline.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiLineString",
         "coordinates": [
           [
             [
@@ -27,17 +34,17 @@
               49
             ]
           ]
-        ],
-        "type": "MultiLineString"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     },
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiLineString",
         "coordinates": [
           [
             [
@@ -63,15 +70,8 @@
               49
             ]
           ]
-        ],
-        "type": "MultiLineString"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_mline_mpoint.json
+++ b/test/synthetic/0x01-rust/mixed_mline_mpoint.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiLineString",
         "coordinates": [
           [
             [
@@ -27,17 +34,17 @@
               49
             ]
           ]
-        ],
-        "type": "MultiLineString"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "MultiPoint",
         "coordinates": [
           [
             13,
@@ -63,15 +70,8 @@
             18,
             45
           ]
-        ],
-        "type": "MultiPoint"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_mline_poly.json
+++ b/test/synthetic/0x01-rust/mixed_mline_poly.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiLineString",
         "coordinates": [
           [
             [
@@ -15,17 +22,17 @@
               53
             ]
           ]
-        ],
-        "type": "MultiLineString"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -45,15 +52,8 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_mline_poly_mline.json
+++ b/test/synthetic/0x01-rust/mixed_mline_poly_mline.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiLineString",
         "coordinates": [
           [
             [
@@ -15,17 +22,17 @@
               53
             ]
           ]
-        ],
-        "type": "MultiLineString"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -45,26 +52,19 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [],
-        "type": "MultiLineString"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "MultiLineString",
+        "coordinates": []
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_mline_pt.json
+++ b/test/synthetic/0x01-rust/mixed_mline_pt.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiLineString",
         "coordinates": [
           [
             [
@@ -27,29 +34,22 @@
               49
             ]
           ]
-        ],
-        "type": "MultiLineString"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_mline_pt_mline.json
+++ b/test/synthetic/0x01-rust/mixed_mline_pt_mline.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiLineString",
         "coordinates": [
           [
             [
@@ -27,31 +34,31 @@
               49
             ]
           ]
-        ],
-        "type": "MultiLineString"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "MultiLineString",
         "coordinates": [
           [
             [
@@ -67,15 +74,8 @@
               48
             ]
           ]
-        ],
-        "type": "MultiLineString"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_mpoint_line.json
+++ b/test/synthetic/0x01-rust/mixed_mpoint_line.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiPoint",
         "coordinates": [
           [
             4,
@@ -15,31 +22,24 @@
             18,
             45
           ]
-        ],
-        "type": "MultiPoint"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             12,
             53
           ]
-        ],
-        "type": "LineString"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_mpoint_line_mpoint.json
+++ b/test/synthetic/0x01-rust/mixed_mpoint_line_mpoint.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiPoint",
         "coordinates": [
           [
             4,
@@ -15,33 +22,33 @@
             18,
             45
           ]
-        ],
-        "type": "MultiPoint"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             12,
             53
           ]
-        ],
-        "type": "LineString"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "MultiPoint",
         "coordinates": [
           [
             12,
@@ -59,15 +66,8 @@
             18,
             45
           ]
-        ],
-        "type": "MultiPoint"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_mpoint_mpoint.json
+++ b/test/synthetic/0x01-rust/mixed_mpoint_mpoint.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiPoint",
         "coordinates": [
           [
             4,
@@ -15,17 +22,17 @@
             18,
             45
           ]
-        ],
-        "type": "MultiPoint"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     },
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiPoint",
         "coordinates": [
           [
             4,
@@ -39,15 +46,8 @@
             18,
             45
           ]
-        ],
-        "type": "MultiPoint"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_mpoint_poly.json
+++ b/test/synthetic/0x01-rust/mixed_mpoint_poly.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiPoint",
         "coordinates": [
           [
             4,
@@ -15,17 +22,17 @@
             18,
             45
           ]
-        ],
-        "type": "MultiPoint"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -45,15 +52,8 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_mpoint_poly_mpoint.json
+++ b/test/synthetic/0x01-rust/mixed_mpoint_poly_mpoint.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiPoint",
         "coordinates": [
           [
             4,
@@ -15,17 +22,17 @@
             18,
             45
           ]
-        ],
-        "type": "MultiPoint"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -45,17 +52,17 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "MultiPoint",
         "coordinates": [
           [
             12,
@@ -77,15 +84,8 @@
             18,
             45
           ]
-        ],
-        "type": "MultiPoint"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_mpoly_line.json
+++ b/test/synthetic/0x01-rust/mixed_mpoly_line.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiPolygon",
         "coordinates": [
           [
             [
@@ -43,17 +50,17 @@
               ]
             ]
           ]
-        ],
-        "type": "MultiPolygon"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             13,
@@ -67,15 +74,8 @@
             12,
             50
           ]
-        ],
-        "type": "LineString"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_mpoly_line_mpoly.json
+++ b/test/synthetic/0x01-rust/mixed_mpoly_line_mpoly.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiPolygon",
         "coordinates": [
           [
             [
@@ -43,17 +50,17 @@
               ]
             ]
           ]
-        ],
-        "type": "MultiPolygon"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             13,
@@ -67,17 +74,17 @@
             12,
             50
           ]
-        ],
-        "type": "LineString"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "MultiPolygon",
         "coordinates": [
           [
             [
@@ -117,15 +124,8 @@
               ]
             ]
           ]
-        ],
-        "type": "MultiPolygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_mpoly_mpoint.json
+++ b/test/synthetic/0x01-rust/mixed_mpoly_mpoint.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiPolygon",
         "coordinates": [
           [
             [
@@ -43,17 +50,17 @@
               ]
             ]
           ]
-        ],
-        "type": "MultiPolygon"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "MultiPoint",
         "coordinates": [
           [
             18,
@@ -83,15 +90,8 @@
             18,
             45
           ]
-        ],
-        "type": "MultiPoint"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_mpoly_mpoly.json
+++ b/test/synthetic/0x01-rust/mixed_mpoly_mpoly.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiPolygon",
         "coordinates": [
           [
             [
@@ -43,17 +50,17 @@
               ]
             ]
           ]
-        ],
-        "type": "MultiPolygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     },
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiPolygon",
         "coordinates": [
           [
             [
@@ -95,15 +102,8 @@
               ]
             ]
           ]
-        ],
-        "type": "MultiPolygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_mpoly_poly.json
+++ b/test/synthetic/0x01-rust/mixed_mpoly_poly.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiPolygon",
         "coordinates": [
           [
             [
@@ -43,17 +50,17 @@
               ]
             ]
           ]
-        ],
-        "type": "MultiPolygon"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -73,15 +80,8 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_mpoly_poly_mpoly.json
+++ b/test/synthetic/0x01-rust/mixed_mpoly_poly_mpoly.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiPolygon",
         "coordinates": [
           [
             [
@@ -43,17 +50,17 @@
               ]
             ]
           ]
-        ],
-        "type": "MultiPolygon"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -73,17 +80,17 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "MultiPolygon",
         "coordinates": [
           [
             [
@@ -125,15 +132,8 @@
               ]
             ]
           ]
-        ],
-        "type": "MultiPolygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_mpoly_pt.json
+++ b/test/synthetic/0x01-rust/mixed_mpoly_pt.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiPolygon",
         "coordinates": [
           [
             [
@@ -43,29 +50,22 @@
               ]
             ]
           ]
-        ],
-        "type": "MultiPolygon"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_mpoly_pt_mpoly.json
+++ b/test/synthetic/0x01-rust/mixed_mpoly_pt_mpoly.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiPolygon",
         "coordinates": [
           [
             [
@@ -43,31 +50,31 @@
               ]
             ]
           ]
-        ],
-        "type": "MultiPolygon"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "MultiPolygon",
         "coordinates": [
           [
             [
@@ -93,15 +100,8 @@
               ]
             ]
           ]
-        ],
-        "type": "MultiPolygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_poly_line.json
+++ b/test/synthetic/0x01-rust/mixed_poly_line.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -21,17 +28,17 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             4,
@@ -41,15 +48,8 @@
             12,
             53
           ]
-        ],
-        "type": "LineString"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_poly_mpoint.json
+++ b/test/synthetic/0x01-rust/mixed_poly_mpoint.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -21,17 +28,17 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "MultiPoint",
         "coordinates": [
           [
             12,
@@ -45,15 +52,8 @@
             4,
             47
           ]
-        ],
-        "type": "MultiPoint"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_poly_mpoly.json
+++ b/test/synthetic/0x01-rust/mixed_poly_mpoly.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -21,17 +28,17 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "MultiPolygon",
         "coordinates": [
           [
             [
@@ -73,15 +80,8 @@
               ]
             ]
           ]
-        ],
-        "type": "MultiPolygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_poly_mpoly_poly.json
+++ b/test/synthetic/0x01-rust/mixed_poly_mpoly_poly.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -21,17 +28,17 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "MultiPolygon",
         "coordinates": [
           [
             [
@@ -73,17 +80,17 @@
               ]
             ]
           ]
-        ],
-        "type": "MultiPolygon"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -103,15 +110,8 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_poly_poly.json
+++ b/test/synthetic/0x01-rust/mixed_poly_poly.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -21,17 +28,17 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     },
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -51,15 +58,8 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_poly_pt.json
+++ b/test/synthetic/0x01-rust/mixed_poly_pt.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -21,29 +28,22 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_pt_line.json
+++ b/test/synthetic/0x01-rust/mixed_pt_line.json
@@ -1,21 +1,28 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             4,
@@ -25,15 +32,8 @@
             12,
             53
           ]
-        ],
-        "type": "LineString"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_pt_line_pt.json
+++ b/test/synthetic/0x01-rust/mixed_pt_line_pt.json
@@ -1,21 +1,28 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "LineString",
         "coordinates": [
           [
             4,
@@ -25,29 +32,22 @@
             12,
             53
           ]
-        ],
-        "type": "LineString"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_pt_mline.json
+++ b/test/synthetic/0x01-rust/mixed_pt_mline.json
@@ -1,21 +1,28 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiLineString",
         "coordinates": [
           [
             [
@@ -41,15 +48,8 @@
               49
             ]
           ]
-        ],
-        "type": "MultiLineString"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_pt_mline_pt.json
+++ b/test/synthetic/0x01-rust/mixed_pt_mline_pt.json
@@ -1,21 +1,28 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiLineString",
         "coordinates": [
           [
             [
@@ -41,29 +48,22 @@
               49
             ]
           ]
-        ],
-        "type": "MultiLineString"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_pt_mpoly.json
+++ b/test/synthetic/0x01-rust/mixed_pt_mpoly.json
@@ -1,21 +1,28 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiPolygon",
         "coordinates": [
           [
             [
@@ -57,15 +64,8 @@
               ]
             ]
           ]
-        ],
-        "type": "MultiPolygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_pt_mpoly_pt.json
+++ b/test/synthetic/0x01-rust/mixed_pt_mpoly_pt.json
@@ -1,21 +1,28 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiPolygon",
         "coordinates": [
           [
             [
@@ -57,29 +64,22 @@
               ]
             ]
           ]
-        ],
-        "type": "MultiPolygon"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_pt_poly.json
+++ b/test/synthetic/0x01-rust/mixed_pt_poly.json
@@ -1,21 +1,28 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -35,15 +42,8 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_pt_poly_pt.json
+++ b/test/synthetic/0x01-rust/mixed_pt_poly_pt.json
@@ -1,21 +1,28 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -35,29 +42,22 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/mixed_pt_pt.json
+++ b/test/synthetic/0x01-rust/mixed_pt_pt.json
@@ -1,33 +1,33 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/multiline.json
+++ b/test/synthetic/0x01-rust/multiline.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiLineString",
         "coordinates": [
           [
             [
@@ -27,15 +34,8 @@
               49
             ]
           ]
-        ],
-        "type": "MultiLineString"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/multipoint.json
+++ b/test/synthetic/0x01-rust/multipoint.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiPoint",
         "coordinates": [
           [
             4,
@@ -15,15 +22,8 @@
             18,
             45
           ]
-        ],
-        "type": "MultiPoint"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/point.json
+++ b/test/synthetic/0x01-rust/point.json
@@ -1,19 +1,19 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/polygon.json
+++ b/test/synthetic/0x01-rust/polygon.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -21,15 +28,8 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/polygon_fpf.json
+++ b/test/synthetic/0x01-rust/polygon_fpf.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -21,15 +28,8 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/polygon_fpf_tes.json
+++ b/test/synthetic/0x01-rust/polygon_fpf_tes.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -21,15 +28,8 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/polygon_hole.json
+++ b/test/synthetic/0x01-rust/polygon_hole.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -39,15 +46,8 @@
               48
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/polygon_hole_fpf.json
+++ b/test/synthetic/0x01-rust/polygon_hole_fpf.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -39,15 +46,8 @@
               48
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/polygon_multi.json
+++ b/test/synthetic/0x01-rust/polygon_multi.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiPolygon",
         "coordinates": [
           [
             [
@@ -43,15 +50,8 @@
               ]
             ]
           ]
-        ],
-        "type": "MultiPolygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/polygon_multi_fpf.json
+++ b/test/synthetic/0x01-rust/polygon_multi_fpf.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "MultiPolygon",
         "coordinates": [
           [
             [
@@ -43,15 +50,8 @@
               ]
             ]
           ]
-        ],
-        "type": "MultiPolygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/polygon_tes.json
+++ b/test/synthetic/0x01-rust/polygon_tes.json
@@ -1,7 +1,14 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1"
+      },
       "geometry": {
+        "type": "Polygon",
         "coordinates": [
           [
             [
@@ -21,15 +28,8 @@
               47
             ]
           ]
-        ],
-        "type": "Polygon"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1"
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_bool.json
+++ b/test/synthetic/0x01-rust/prop_bool.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": true
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_bool_false.json
+++ b/test/synthetic/0x01-rust/prop_bool_false.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": false
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_f32.json
+++ b/test/synthetic/0x01-rust/prop_f32.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
-        "val": 3.14
+        "val": 3.140000104904175
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_f32_max.json
+++ b/test/synthetic/0x01-rust/prop_f32_max.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
-        "val": 3.4028235e+38
+        "val": 3.4028234663852886e+38
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_f32_min.json
+++ b/test/synthetic/0x01-rust/prop_f32_min.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
-        "val": 1.0000000000000001e-45
+        "val": 1.401298464324817e-45
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_f32_nan.json
+++ b/test/synthetic/0x01-rust/prop_f32_nan.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
-        "val": null
+        "val": "f32::NAN"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_f32_neg_inf.json
+++ b/test/synthetic/0x01-rust/prop_f32_neg_inf.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
-        "val": null
+        "val": "f32::NEG_INFINITY"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_f32_pos_inf.json
+++ b/test/synthetic/0x01-rust/prop_f32_pos_inf.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
-        "val": null
+        "val": "f32::INFINITY"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_f32_zero.json
+++ b/test/synthetic/0x01-rust/prop_f32_zero.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 0.0
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_f64.json
+++ b/test/synthetic/0x01-rust/prop_f64.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
-        "val": 3.1415927
+        "val": 3.1415927410125732
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_f64_max.json
+++ b/test/synthetic/0x01-rust/prop_f64_max.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
-        "val": null
+        "val": "f64::INFINITY"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_f64_min.json
+++ b/test/synthetic/0x01-rust/prop_f64_min.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 0.0
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_f64_nan.json
+++ b/test/synthetic/0x01-rust/prop_f64_nan.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
-        "val": null
+        "val": "f64::NAN"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_f64_neg_inf.json
+++ b/test/synthetic/0x01-rust/prop_f64_neg_inf.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
-        "val": null
+        "val": "f64::NEG_INFINITY"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_f64_neg_zero.json
+++ b/test/synthetic/0x01-rust/prop_f64_neg_zero.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": -0.0
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_i32.json
+++ b/test/synthetic/0x01-rust/prop_i32.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 42
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_i32_max.json
+++ b/test/synthetic/0x01-rust/prop_i32_max.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 2147483647
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_i32_min.json
+++ b/test/synthetic/0x01-rust/prop_i32_min.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": -2147483648
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_i32_neg.json
+++ b/test/synthetic/0x01-rust/prop_i32_neg.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": -42
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_i64.json
+++ b/test/synthetic/0x01-rust/prop_i64.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9876543210
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_i64_max.json
+++ b/test/synthetic/0x01-rust/prop_i64_max.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9223372036854775807
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_i64_min.json
+++ b/test/synthetic/0x01-rust/prop_i64_min.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": -9223372036854775808
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_i64_neg.json
+++ b/test/synthetic/0x01-rust/prop_i64_neg.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": -9876543210
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_str_ascii.json
+++ b/test/synthetic/0x01-rust/prop_str_ascii.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": "42"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_str_empty.json
+++ b/test/synthetic/0x01-rust/prop_str_empty.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": ""
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_str_escape.json
+++ b/test/synthetic/0x01-rust/prop_str_escape.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": "Line1\n\t\"quoted\"\\path"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_str_unicode.json
+++ b/test/synthetic/0x01-rust/prop_str_unicode.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": "München 📍 café"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_u32.json
+++ b/test/synthetic/0x01-rust/prop_u32.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 42
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_u32_max.json
+++ b/test/synthetic/0x01-rust/prop_u32_max.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 4294967295
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_u32_min.json
+++ b/test/synthetic/0x01-rust/prop_u32_min.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 0
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_u64.json
+++ b/test/synthetic/0x01-rust/prop_u64.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "bignum": 1234567890123456789
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_u64_max.json
+++ b/test/synthetic/0x01-rust/prop_u64_max.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "bignum": 18446744073709551615
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/prop_u64_min.json
+++ b/test/synthetic/0x01-rust/prop_u64_min.json
@@ -1,20 +1,20 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          42
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "bignum": 0
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          42
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/props_i32.json
+++ b/test/synthetic/0x01-rust/props_i32.json
@@ -1,65 +1,65 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1",
+        "val": 42
+      },
       "geometry": {
+        "type": "Point",
         "coordinates": [
           4,
           47
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 42
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           12,
           53
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 42
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           18,
           45
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 42
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           48
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1",
-        "val": 42
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/props_i32_delta.json
+++ b/test/synthetic/0x01-rust/props_i32_delta.json
@@ -1,65 +1,65 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1",
+        "val": 42
+      },
       "geometry": {
+        "type": "Point",
         "coordinates": [
           4,
           47
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 42
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           12,
           53
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 42
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           18,
           45
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 42
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           48
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1",
-        "val": 42
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/props_i32_delta_rle.json
+++ b/test/synthetic/0x01-rust/props_i32_delta_rle.json
@@ -1,65 +1,65 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1",
+        "val": 42
+      },
       "geometry": {
+        "type": "Point",
         "coordinates": [
           4,
           47
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 42
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           12,
           53
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 42
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           18,
           45
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 42
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           48
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1",
-        "val": 42
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/props_i32_rle.json
+++ b/test/synthetic/0x01-rust/props_i32_rle.json
@@ -1,65 +1,65 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1",
+        "val": 42
+      },
       "geometry": {
+        "type": "Point",
         "coordinates": [
           4,
           47
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 42
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           12,
           53
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 42
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           18,
           45
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 42
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           48
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1",
-        "val": 42
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/props_mixed.json
+++ b/test/synthetic/0x01-rust/props_mixed.json
@@ -1,24 +1,24 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          4,
-          47
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "active": true,
         "count": 42,
         "name": "Test Point",
-        "precision": 0.12345679,
+        "precision": 0.12345679104328156,
         "temp": 25.5
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          4,
+          47
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/props_no_shared_dict.json
+++ b/test/synthetic/0x01-rust/props_no_shared_dict.json
@@ -1,21 +1,21 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          4,
-          47
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "name:de": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         "name:en": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          4,
+          47
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/props_str.json
+++ b/test/synthetic/0x01-rust/props_str.json
@@ -1,95 +1,95 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          4,
-          47
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": "residential_zone_north_sector_1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          4,
+          47
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          12,
-          53
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": "commercial_zone_south_sector_2"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12,
+          53
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          18,
-          45
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": "industrial_zone_east_sector_3"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          18,
+          45
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          48
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": "park_zone_west_sector_4"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          48
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          12,
-          50
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": "water_zone_north_sector_5"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12,
+          50
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          10,
-          49
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": "residential_zone_south_sector_6"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10,
+          49
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/props_str_fsst-rust.json
+++ b/test/synthetic/0x01-rust/props_str_fsst-rust.json
@@ -1,95 +1,95 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
-      "geometry": {
-        "coordinates": [
-          4,
-          47
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": "residential_zone_north_sector_1"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          4,
+          47
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          12,
-          53
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": "commercial_zone_south_sector_2"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12,
+          53
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          18,
-          45
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": "industrial_zone_east_sector_3"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          18,
+          45
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          13,
-          48
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": "park_zone_west_sector_4"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13,
+          48
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          12,
-          50
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": "water_zone_north_sector_5"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12,
+          50
+        ]
+      }
     },
     {
-      "geometry": {
-        "coordinates": [
-          10,
-          49
-        ],
-        "type": "Point"
-      },
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": "residential_zone_south_sector_6"
       },
-      "type": "Feature"
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10,
+          49
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/props_u32.json
+++ b/test/synthetic/0x01-rust/props_u32.json
@@ -1,65 +1,65 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1",
+        "val": 9000
+      },
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           4,
           47
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           12,
           53
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           18,
           45
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1",
-        "val": 9000
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/props_u32_delta.json
+++ b/test/synthetic/0x01-rust/props_u32_delta.json
@@ -1,65 +1,65 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1",
+        "val": 9000
+      },
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           4,
           47
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           12,
           53
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           18,
           45
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1",
-        "val": 9000
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/props_u32_delta_rle.json
+++ b/test/synthetic/0x01-rust/props_u32_delta_rle.json
@@ -1,65 +1,65 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1",
+        "val": 9000
+      },
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           4,
           47
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           12,
           53
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           18,
           45
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1",
-        "val": 9000
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/props_u32_rle.json
+++ b/test/synthetic/0x01-rust/props_u32_rle.json
@@ -1,65 +1,65 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1",
+        "val": 9000
+      },
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           4,
           47
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           12,
           53
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           18,
           45
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1",
-        "val": 9000
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/props_u64.json
+++ b/test/synthetic/0x01-rust/props_u64.json
@@ -1,65 +1,65 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1",
+        "val": 9000
+      },
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           4,
           47
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           12,
           53
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           18,
           45
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1",
-        "val": 9000
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/props_u64_delta.json
+++ b/test/synthetic/0x01-rust/props_u64_delta.json
@@ -1,65 +1,65 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1",
+        "val": 9000
+      },
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           4,
           47
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           12,
           53
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           18,
           45
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1",
-        "val": 9000
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/props_u64_delta_rle.json
+++ b/test/synthetic/0x01-rust/props_u64_delta_rle.json
@@ -1,65 +1,65 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1",
+        "val": 9000
+      },
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           4,
           47
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           12,
           53
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           18,
           45
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1",
-        "val": 9000
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }

--- a/test/synthetic/0x01-rust/props_u64_rle.json
+++ b/test/synthetic/0x01-rust/props_u64_rle.json
@@ -1,65 +1,65 @@
 {
+  "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
+      "properties": {
+        "_extent": 4096,
+        "_layer": "layer1",
+        "val": 9000
+      },
       "geometry": {
+        "type": "Point",
         "coordinates": [
           13,
           42
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           4,
           47
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           12,
           53
-        ],
-        "type": "Point"
-      },
+        ]
+      }
+    },
+    {
+      "type": "Feature",
       "properties": {
         "_extent": 4096,
         "_layer": "layer1",
         "val": 9000
       },
-      "type": "Feature"
-    },
-    {
       "geometry": {
+        "type": "Point",
         "coordinates": [
           18,
           45
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "_extent": 4096,
-        "_layer": "layer1",
-        "val": 9000
-      },
-      "type": "Feature"
+        ]
+      }
     }
-  ],
-  "type": "FeatureCollection"
+  ]
 }


### PR DESCRIPTION
fix #978 

This pull request makes several improvements to GeoJSON serialization and floating-point handling, while also cleaning up dependencies and updating test fixtures for consistency. The most significant changes include custom serialization for GeoJSON features, robust handling of non-finite floating-point values, and removal of unused dependencies.

**GeoJSON serialization and floating-point handling:**

* Implemented a custom `Serialize` implementation for the `Feature` struct in `geojson.rs`, ensuring GeoJSON keys are serialized in the preferred order and geometry is serialized correctly. (`rust/mlt-core/src/convert/geojson.rs`)
* Added new helper functions `f32_to_json` and `f64_to_json` to serialize finite floats as numbers and non-finite floats (NaN, infinity) as strings, addressing edge cases in GeoJSON output. (`rust/mlt-core/src/utils/mod.rs`)
* Updated property value serialization to use `f64_to_json` for `F64` types, improving correctness and consistency in GeoJSON output. (`rust/mlt-core/src/layer/v01/property/mod.rs`)

**Dependency cleanup:**

* Removed the unused `json5` dependency from multiple `Cargo.toml` files, and replaced its usage with `serde_json` for JSON parsing and validation. (`rust/Cargo.toml`, `rust/mlt/Cargo.toml`, `rust/mlt-synthetics/Cargo.toml`, `rust/mlt/src/ls.rs`) [[1]](diffhunk://#diff-74eb46d64310c0817ed15b2389cf81183c18cdebbaa256a4198057855ecf14d7L36) [[2]](diffhunk://#diff-8885a72db0c3c083dbf28e13576a568734fffa7b656e45c0059304bbc9a43543L29) [[3]](diffhunk://#diff-4531ea7fa6586ce9cdf58f9b68019aa26ee6130ef334bccf899b3443373bb45bL17) [[4]](diffhunk://#diff-8996517786ef98b02fe1b124ee62ca4f6252bda3e47817b5ef8587369fd18e93L586-R587)

**Test fixture updates:**

* Updated all synthetic GeoJSON test fixtures to consistently include `"type": "FeatureCollection"` and `"type": "Feature"` keys, and to order keys according to the new serialization logic. (`test/synthetic/0x01-rust/*.json`) [[1]](diffhunk://#diff-f246997c061146236985383951636f10a954dd8861aa88b6feb732fecf9464b8R2-R11) [[2]](diffhunk://#diff-f246997c061146236985383951636f10a954dd8861aa88b6feb732fecf9464b8L14-R24) [[3]](diffhunk://#diff-ae637711861a0c022887d1fe02a16c7a222de79decc949664fe26a31e74ed66dR2-R11) [[4]](diffhunk://#diff-ae637711861a0c022887d1fe02a16c7a222de79decc949664fe26a31e74ed66dL14-R24) [[5]](diffhunk://#diff-827bd51224887c529b3d3aec83e569d0582df34f8cd7e3a2430bd5bf4f42477aR2-R11) [[6]](diffhunk://#diff-827bd51224887c529b3d3aec83e569d0582df34f8cd7e3a2430bd5bf4f42477aL14-R24) [[7]](diffhunk://#diff-b1bdffc05aa46a6ed46f2c29617bc86422cdc1554dc2dc65af476c8ac25afebaR2-R11) [[8]](diffhunk://#diff-b1bdffc05aa46a6ed46f2c29617bc86422cdc1554dc2dc65af476c8ac25afebaL14-R24) [[9]](diffhunk://#diff-a5c9c2cb66e475ea868ff0b1d7b06fa84491165ad2a29c175b0661b3844334e3R2-R11) [[10]](diffhunk://#diff-a5c9c2cb66e475ea868ff0b1d7b06fa84491165ad2a29c175b0661b3844334e3L14-R24) [[11]](diffhunk://#diff-56cbb1b9d2543c9fedddd40de9acdede1361bef397e329d70994cf093fa8f082R2-R11) [[12]](diffhunk://#diff-56cbb1b9d2543c9fedddd40de9acdede1361bef397e329d70994cf093fa8f082L14-R24) [[13]](diffhunk://#diff-da75190bc19d61949f3547fbef50c0d57def84c0c84b06bf6199695de4a95d5fR2-R11) [[14]](diffhunk://#diff-da75190bc19d61949f3547fbef50c0d57def84c0c84b06bf6199695de4a95d5fL14-R24) [[15]](diffhunk://#diff-6bfa269b7ecba523202c41af565c215a0f3ee1c7532603cd50d4521e37316764R2-R11) [[16]](diffhunk://#diff-6bfa269b7ecba523202c41af565c215a0f3ee1c7532603cd50d4521e37316764L14-R24) [[17]](diffhunk://#diff-66aecf21d49118925632b82c5ee42c229c9e6bd6e4aef9fd9238562bdfc68719R2-R19) [[18]](diffhunk://#diff-007742407235d1dade80a5f75a4c4f13e2ecba9e472b331071924e4d9957825cR2-R19) [[19]](diffhunk://#diff-f32a20a23bd0339cb2157fac2362df6b60986af7105673a28283b0e40e265b18R2-R19) [[20]](diffhunk://#diff-5a7f70f66bdd9e76f95d4e915b88f20fb438ffe857bc5a66c05db28c38fb7c5bR2-R64)

These changes improve standards compliance, robustness, and maintainability for GeoJSON handling in the codebase.