### PR TITLE
chore(ts): improve readability of geometry conversion code

### DIFF
--- a/ts/src/vector/geometry/geometryVectorConverter.ts
+++ b/ts/src/vector/geometry/geometryVectorConverter.ts
@@ -83,7 +83,7 @@ export function convertGeometryVector(geometryVector: GeometryVector): Coordinat
                 break;
             case GEOMETRY_TYPE.LINESTRING:
                 {
-                    let numVertices = 0;
+                    let numVertices: number;
                     if (containsPolygon) {
                         numVertices = ringOffsets[ringOffsetsCounter] - ringOffsets[ringOffsetsCounter - 1];
                         ringOffsetsCounter++;
@@ -169,7 +169,7 @@ export function convertGeometryVector(geometryVector: GeometryVector): Coordinat
                     geometryOffsetsCounter++;
                     const lineStrings: CoordinatesArray = new Array(numLineStrings);
                     for (let j = 0; j < numLineStrings; j++) {
-                        let numVertices = 0;
+                        let numVertices: number;
                         if (containsPolygon) {
                             numVertices = ringOffsets[ringOffsetsCounter] - ringOffsets[ringOffsetsCounter - 1];
                             ringOffsetsCounter++;


### PR DESCRIPTION
This should improve readability of geometry conversion code.
Moves conversion to use switch-case, remove unneeded factory, remove some redundant methods and introduce more reusable ones.
This has the benefit of being 20% shorter, which is not a goal but rather nice to have.