### PR TITLE
chore: let platforms handle synthetic test reporting/registration

### DIFF
--- a/cpp/tool/test-synthetic.mjs
+++ b/cpp/tool/test-synthetic.mjs
@@ -32,25 +32,35 @@ class SyntheticTestRunnerCpp extends SyntheticTestRunner {
 }
 
 const runner = new SyntheticTestRunnerCpp();
+const { active, skipped: skippedCases } = await runner.getTestCases();
 
 let passed = 0;
 let failed = 0;
 let skipped = 0;
 
-for await (const result of runner) {
+for (const [testName, reason] of skippedCases) {
+  console.log(`SKIP ${testName} (${reason})`);
+  skipped++;
+}
+
+for (const testName of active) {
+  const result = await runner.runCase(testName);
   switch (result.status) {
-    case "ok":
+    case "ok": {
       console.log(`OK - ${result.testName}`);
       passed++;
       break;
-    case "fail":
+    }
+    case "fail": {
       console.log(`FAIL - ${result.testName}`);
       failed++;
       break;
-    case "skip":
+    }
+    case "skip": {
       console.log(`SKIP ${result.testName} (${result.reason})`);
       skipped++;
       break;
+    }
   }
 }
 

--- a/test/synthetic/synthetic-test-tool/index.ts
+++ b/test/synthetic/synthetic-test-tool/index.ts
@@ -52,7 +52,7 @@ export type SyntheticCaseResult =
       error: unknown;
     };
 
-export class SyntheticTestRunner implements AsyncIterable<SyntheticCaseResult> {
+export class SyntheticTestRunner {
   shouldSkip(_testName: string): false | string {
     return false;
   }
@@ -112,7 +112,7 @@ export class SyntheticTestRunner implements AsyncIterable<SyntheticCaseResult> {
         testName,
       };
     } catch (error) {
-      const _actualFile = await this.writeActualOutput(mltFile, actual);
+      await this.writeActualOutput(mltFile, actual);
       return {
         status: "fail",
         testName,
@@ -121,19 +121,8 @@ export class SyntheticTestRunner implements AsyncIterable<SyntheticCaseResult> {
     }
   }
 
-  async *[Symbol.asyncIterator](): AsyncGenerator<SyntheticCaseResult> {
-    const files = await collectGlob(join(syntheticTestDir, "*.mlt"));
-    const names = files.map((fileName) =>
-      basename(fileName).replace(/\.mlt$/, ""),
-    );
-
-    for (const testName of names) {
-      yield await this.runCase(testName, syntheticTestDir);
-    }
-  }
-
   async getTestCases(
-    syntheticDir: string,
+    syntheticDir: string = syntheticTestDir,
   ): Promise<{ active: string[]; skipped: [string, string][] }> {
     const mltFiles = await collectGlob(join(syntheticDir, "*.mlt"));
     const testNames = mltFiles.map((f) => basename(f).replace(/\.mlt$/, ""));

--- a/ts/src/synthetic.spec.ts
+++ b/ts/src/synthetic.spec.ts
@@ -8,7 +8,6 @@ import { classifyRings } from "@maplibre/maplibre-gl-style-spec";
 
 import {
     SyntheticTestRunner,
-    syntheticTestDir,
 } from "synthetic-test-tool";
 
 const EARCUT_MAX_RINGS = 500;
@@ -51,7 +50,7 @@ class SyntheticTestRunnerJS extends SyntheticTestRunner {
 }
 
 const runner = new SyntheticTestRunnerJS();
-const { active, skipped } = await runner.getTestCases(syntheticTestDir);
+const { active, skipped } = await runner.getTestCases();
 
 describe("MLT Decoder - Synthetic tests", () => {
 
@@ -61,7 +60,7 @@ describe("MLT Decoder - Synthetic tests", () => {
 
     for (const testName of active) {
         it(testName, async () => {
-            const result = await runner.runCase(testName, syntheticTestDir);
+            const result = await runner.runCase(testName);
             switch (result.status) {
                 case "ok":
                     return;


### PR DESCRIPTION
Remove reporting from shared synthetic test logic. Instead let platform handle it.

TS uses Vitest, C++ uses simple `console.log`.