### PR TITLE
fix(cpp): Remove explicit deployment specification to fix build error

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -4,12 +4,6 @@ project(mlt-cpp LANGUAGES CXX)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 include(AddCXXCompilerFlag)
 
-# Use the same deployment target as the parent project, if set.
-if (NOT MLT_OSX_DEPLOYMENT_TARGET)
-    set(MLT_OSX_DEPLOYMENT_TARGET 16)
-endif()
-set(CMAKE_OSX_DEPLOYMENT_TARGET ${MLT_OSX_DEPLOYMENT_TARGET})
-
 # generate compile_commands.json https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 


### PR DESCRIPTION
After a forced Xcode update, this build started producing:

    clang++: warning: overriding deployment version from '16' to '26.0' [-Woverriding-deployment-version]

I'm not sure this configuration is needed at all