### PR TITLE
chore(rust): release

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "mlt"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arbitrary",
  "borrowme",
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-py"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "geo-types",
  "mlt-core",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-wasm"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "js-sys",
  "mlt-core",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -34,7 +34,7 @@ hex = "0.4.3"
 insta = "1.43.2"
 integer-encoding = "4.0.2"
 js-sys = "0.3"
-mlt-core = { version = "0.4.0", path = "mlt-core", default-features = false }
+mlt-core = { version = "0.5.0", path = "mlt-core", default-features = false }
 mvt-reader = "2.3.0"
 num-traits = "0.2.19"
 num_enum = "0.7.4"

--- a/rust/mlt-core/CHANGELOG.md
+++ b/rust/mlt-core/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-core-v0.4.0...rust-mlt-core-v0.5.0) - 2026-03-10
+
+### Added
+
+- *(rust)* PGO based Id optimiser ([#1105](https://github.com/maplibre/maplibre-tile-spec/pull/1105))
+
+### Other
+
+- *(rust)* move name into DecodedStrings ([#1108](https://github.com/maplibre/maplibre-tile-spec/pull/1108))
+- *(rust)* change tests to be based on the new trait based optimisation api ([#1104](https://github.com/maplibre/maplibre-tile-spec/pull/1104))
+
 ## [0.4.0](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-core-v0.3.0...rust-mlt-core-v0.4.0) - 2026-03-10
 
 ### Added

--- a/rust/mlt-core/Cargo.toml
+++ b/rust/mlt-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-core"
 description = "MapLibre Tile library code"
-version = "0.4.0"
+version = "0.5.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/rust/mlt-py/CHANGELOG.md
+++ b/rust/mlt-py/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.6...python-mlt-v0.1.7) - 2026-03-10
+
+### Other
+
+- *(rust)* move name into DecodedStrings ([#1108](https://github.com/maplibre/maplibre-tile-spec/pull/1108))
+
 ## [0.1.6](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.5...python-mlt-v0.1.6) - 2026-03-10
 
 ### Other

--- a/rust/mlt-py/Cargo.toml
+++ b/rust/mlt-py/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-py"
 description = "Python bindings for MapLibre Tile (MLT) format via PyO3"
-version = "0.1.6"
+version = "0.1.7"
 readme = "README.md"
 repository.workspace = true
 edition.workspace = true

--- a/rust/mlt-py/pyproject.toml
+++ b/rust/mlt-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "maplibre-tiles"
-version = "0.1.6"
+version = "0.1.7"
 description = "Python bindings for MapLibre Tile (MLT) format"
 requires-python = ">=3.10"
 license = { text = "MIT OR Apache-2.0" }

--- a/rust/mlt-wasm/CHANGELOG.md
+++ b/rust/mlt-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-wasm-v0.1.1...rust-mlt-wasm-v0.1.2) - 2026-03-10
+
+### Other
+
+- *(rust)* move name into DecodedStrings ([#1108](https://github.com/maplibre/maplibre-tile-spec/pull/1108))
+
 ## [0.1.1](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-wasm-v0.1.0...rust-mlt-wasm-v0.1.1) - 2026-03-10
 
 ### Other

--- a/rust/mlt-wasm/Cargo.toml
+++ b/rust/mlt-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-wasm"
 description = "WebAssembly bindings for the MapLibre Tile (MLT) format"
-version = "0.1.1"
+version = "0.1.2"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/rust/mlt-wasm/package-lock.json
+++ b/rust/mlt-wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/mlt-wasm",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/mlt-wasm",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@mapbox/point-geometry": "1.1.0"

--- a/rust/mlt-wasm/package.json
+++ b/rust/mlt-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/mlt-wasm",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "WebAssembly-backed MapLibre Tile (MLT) decoder",
   "type": "module",
   "main": "dist/index.js",

--- a/rust/mlt/CHANGELOG.md
+++ b/rust/mlt/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.6...rust-mlt-v0.1.7) - 2026-03-10
+
+### Other
+
+- updated the following local packages: mlt-core
+
 ## [0.1.6](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.5...rust-mlt-v0.1.6) - 2026-03-10
 
 ### Fixed

--- a/rust/mlt/Cargo.toml
+++ b/rust/mlt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt"
 description = "MapLibre Tile Tools"
-version = "0.1.6"
+version = "0.1.7"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `mlt-core`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `mlt-py`: 0.1.6 -> 0.1.7
* `mlt-wasm`: 0.1.1 -> 0.1.2
* `mlt`: 0.1.6 -> 0.1.7

### ⚠ `mlt-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field DecodedStrings.name in /tmp/.tmpqAmoCs/maplibre-tile-spec/rust/mlt-core/src/layer/v01/property/model.rs:94
  field DecodedStrings.name in /tmp/.tmpqAmoCs/maplibre-tile-spec/rust/mlt-core/src/layer/v01/property/model.rs:94

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum mlt_core::layer::v01::ApproxPropertyType, previously in file /tmp/.tmpUlLB4s/mlt-core/src/layer/v01/property/model.rs:26
  enum mlt_core::v01::ApproxPropertyType, previously in file /tmp/.tmpUlLB4s/mlt-core/src/layer/v01/property/model.rs:26

--- failure enum_tuple_variant_field_missing: pub enum tuple variant's field removed ---

Description:
A field of a tuple variant in a pub enum has been removed.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_tuple_variant_field_missing.ron

Failed in:
  field 1 of variant DecodedProperty::Str, previously in file /tmp/.tmpUlLB4s/mlt-core/src/layer/v01/property/model.rs:67
  field 1 of variant DecodedProperty::Str, previously in file /tmp/.tmpUlLB4s/mlt-core/src/layer/v01/property/model.rs:67

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  DecodedProperty::approx_type, previously in file /tmp/.tmpUlLB4s/mlt-core/src/layer/v01/property/mod.rs:379
  DecodedProperty::approx_type, previously in file /tmp/.tmpUlLB4s/mlt-core/src/layer/v01/property/mod.rs:379
  OwnedProperty::approx_type, previously in file /tmp/.tmpUlLB4s/mlt-core/src/layer/v01/property/mod.rs:60
  OwnedProperty::approx_type, previously in file /tmp/.tmpUlLB4s/mlt-core/src/layer/v01/property/mod.rs:60

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct mlt_core::layer::v01::GeometryOptimizer, previously in file /tmp/.tmpUlLB4s/mlt-core/src/layer/v01/geometry/optimizer.rs:28
  struct mlt_core::v01::GeometryOptimizer, previously in file /tmp/.tmpUlLB4s/mlt-core/src/layer/v01/geometry/optimizer.rs:28
  struct mlt_core::layer::v01::PropertyOptimizer, previously in file /tmp/.tmpUlLB4s/mlt-core/src/layer/v01/property/optimizer.rs:109
  struct mlt_core::v01::PropertyOptimizer, previously in file /tmp/.tmpUlLB4s/mlt-core/src/layer/v01/property/optimizer.rs:109
  struct mlt_core::layer::v01::IdOptimizer, previously in file /tmp/.tmpUlLB4s/mlt-core/src/layer/v01/id/optimizer.rs:33
  struct mlt_core::v01::IdOptimizer, previously in file /tmp/.tmpUlLB4s/mlt-core/src/layer/v01/id/optimizer.rs:33
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `mlt-core`

<blockquote>

## [0.5.0](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-core-v0.4.0...rust-mlt-core-v0.5.0) - 2026-03-10

### Added

- *(rust)* PGO based Id optimiser ([#1105](https://github.com/maplibre/maplibre-tile-spec/pull/1105))

### Other

- *(rust)* move name into DecodedStrings ([#1108](https://github.com/maplibre/maplibre-tile-spec/pull/1108))
- *(rust)* change tests to be based on the new trait based optimisation api ([#1104](https://github.com/maplibre/maplibre-tile-spec/pull/1104))
</blockquote>

## `mlt-py`

<blockquote>

## [0.1.7](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.6...python-mlt-v0.1.7) - 2026-03-10

### Other

- *(rust)* move name into DecodedStrings ([#1108](https://github.com/maplibre/maplibre-tile-spec/pull/1108))
</blockquote>

## `mlt-wasm`

<blockquote>

## [0.1.2](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-wasm-v0.1.1...rust-mlt-wasm-v0.1.2) - 2026-03-10

### Other

- *(rust)* move name into DecodedStrings ([#1108](https://github.com/maplibre/maplibre-tile-spec/pull/1108))
</blockquote>

## `mlt`

<blockquote>

## [0.1.7](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.6...rust-mlt-v0.1.7) - 2026-03-10

### Other

- updated the following local packages: mlt-core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).