### PR TITLE
chore(java): Add documentation for CLI apps

### DIFF
--- a/java/README-Decode.md
+++ b/java/README-Decode.md
@@ -1,0 +1,5 @@
+## MLT Decoder Java CLI Application
+
+This is a very simple application which serves as an example of how to use the MLT library to decode MLT files.
+
+It can also be used to benchmark the performance of the MLT decoder by timing the repeated decoding of a single tile.

--- a/java/README-Encode.md
+++ b/java/README-Encode.md
@@ -60,7 +60,7 @@ PMTiles conversion can use substantial memory, especially for large archives, hi
   - Very small values may lead to queue starvation and reduced performance.
 
 In addition, it may be beneficial to adjust the JVM heap parameters to allow for a heap size larger than the default, e.g.:
-  - `-Xmx32G` to allow up to 64 GB of heap memory
+  - `-Xmx32G` to allow up to 32 GB of heap memory
   - `-Xms16G` to pre-allocate 16 GB of heap memory at startup
 
 Cache hits are more important when using a remote source, but a very large cache (1GB+) seems to be counterproductive.

--- a/java/README-Encode.md
+++ b/java/README-Encode.md
@@ -10,7 +10,7 @@ See the `--help` output for the full list of options.
 
 At a minimum, the input file(s) must be specified with `--mvt`, `--mbtiles`, `--offlinedb`, or `--pmtiles`.
 
-In the case of `--pmtiles`, the input may be a URL, in which case the data will be seletively downloaded, allowing rapid conversion of zoom-level subsets.
+In the case of `--pmtiles`, the input may be a URL, in which case the data will be selectively downloaded, allowing rapid conversion of zoom-level subsets.
 
 By default, the output file will be the input basename with the `.mlt` extension added, placed in the working directory.  This can be overridden with the `--mlt` option.  The `--dir` option changes the output directory.
 

--- a/java/README-Encode.md
+++ b/java/README-Encode.md
@@ -1,0 +1,68 @@
+## MLT Encoder Java CLI Application
+
+This application currently only supports converting MVT tiles to MLT format.
+
+It can convert standalone tile files, MBTiles files, MLN Offline database files, and PMTiles files.
+
+### Usage
+
+See the `--help` output for the full list of options.
+
+At a minimum, the input file(s) must be specified with `--mvt`, `--mbtiles`, `--offlinedb`, or `--pmtiles`.
+
+In the case of `--pmtiles`, the input may be a URL, in which case the data will be seletively downloaded, allowing rapid conversion of zoom-level subsets.
+
+By default, the output file will be the input basename with the `.mlt` extension added, placed in the working directory.  This can be overridden with the `--mlt` option.  The `--dir` option changes the output directory.
+
+For efficient conversion the `--parallel` option should generally be used to take advantage of all available CPU cores.
+
+### Environment Variables
+
+#### Common
+
+- `MLT_TILE_LOG_INTERVAL`: Controls the number of tiles between progress reports with `--verbose`
+
+#### MBTiles
+
+Tile compression within an MBTiles file is optional.  The encoder will only store compressed MLT tiles if they are slightly smaller than the uncompressed MLT data.  To be stored compressed, a tile must meet both criteria, as controlled by the following environment variables:
+
+- `MLT_COMPRESSION_RATIO_THRESHOLD`: Minimum compression ratio to apply compression (default: 0.98)
+  - If compressed tile is larger than his fraction of the uncompressed tile, it will be discarded and the uncompressed tile will be stored instead.
+  - This value may be greater than 1.0 to indicate that tiles should be stored in compressed form even if it increases their size.
+- `MLT_COMPRESSION_FIXED_THRESHOLD`: Minimum savings in bytes for a tile to be compressed (default:  20)
+  - If the compressed tile size plus this value is greater than the uncompressed tile size, the compressed tile will be discarded and the uncompressed tile will be stored instead.
+  - This value can be negative to indicate that tiles should be stored in compressed form even if they are larger than the uncompressed tile.
+
+#### PMTiles
+
+PMTiles files can be extremely large, and may benefit from careful selection of extended configuration parameters.
+
+PMTiles conversion requires about X bytes of memory per tile.
+
+- `MLT_CACHE_MAX`: Maximum cache size in bytes.
+- `MLT_CACHE_MAX_HEAP_PERCENT`: Maximum cache size as a percentage of maximum heap size.
+  - If a percentage is specified, it will take precedence over `MLT_CACHE_MAX`.
+- `MLT_CACHE_EXPIRE`: Cache expiration duration after access, in ISO-8601 (e.g. P1.2S) or plain (e.g., 1.2s).
+  - This is generally not important, but may decrease memory use with a very large cache in long-running conversions.
+- `MLT_CACHE_BLOCK_SIZE`: Aligned block size of cached data, in bytes
+  - Cache misses will trigger a read of the entire block(s) containing the tile, often allowing reads of nearby tiles without an additional request.
+  - When zero, only the requested tile will be read on a cache miss.  This is not recommended.
+  - Larger block sizes mean fewer entries in the cache, but tend to be more efficient as the main benefit is from other tiles in the same block.
+- `MLT_CACHE_AVERAGE_SIZE`: Average size of tiles in bytes
+  - This is used to estimate the number of tiles that can be stored in the cache.
+  - A value of zero disables cache pre-allocation.
+- `MLT_MAX_TILE_TRACK_SIZE`: Maximum size of a tile to be tracked in memory, in bytes.
+  - PMTiles files combine ranges of identical tiles (in Hilbert index order) into a single directory entry. If the same tile contents appears elsewhere, however, it will be stored as a separate entry. The encoder keeps track of each input tile in order to avoid re-converting it if it's encountered later, reducing the computation needed at the cost of some memory.
+  - Only small tiles, e.g., representing empty ocean, are commonly duplicated and so worth tracking.  So to save memory, only tiles below this threshold are tracked.
+  - Set to zero to disable tracking altogether.
+- `MLT_THREAD_QUEUE_SIZE`: The maximum number of items (per worker thread) to queue when parallel processing is enabled.
+  - Larger values cause the directory traversal to finish earlier allowing for a progress percentage to be displayed, at the cost of more memory use.
+  - Very small values may lead to queue starvation and reduced performance.
+
+In addition, it may be beneficial to adjust the JVM heap parameters to allow for a heap size larger than the default, e.g.:
+  - `-Xmx32G` to allow up to 64 GB of heap memory
+  - `-Xms16G` to pre-allocate 16 GB of heap memory at startup
+
+Cache hits are more important when using a remote source, but a very large cache (1GB+) seems to be counterproductive.
+
+Use `--cache-stats` to print cache statistics to help tune the cache configuration parameters.

--- a/java/README-Encode.md
+++ b/java/README-Encode.md
@@ -37,7 +37,7 @@ Tile compression within an MBTiles file is optional.  The encoder will only stor
 
 PMTiles files can be extremely large, and may benefit from careful selection of extended configuration parameters.
 
-PMTiles conversion requires about X bytes of memory per tile.
+PMTiles conversion can use substantial memory, especially for large archives, high cache sizes, and many parallel worker threads.
 
 - `MLT_CACHE_MAX`: Maximum cache size in bytes.
 - `MLT_CACHE_MAX_HEAP_PERCENT`: Maximum cache size as a percentage of maximum heap size.

--- a/java/README-Encode.md
+++ b/java/README-Encode.md
@@ -27,7 +27,7 @@ For efficient conversion the `--parallel` option should generally be used to tak
 Tile compression within an MBTiles file is optional.  The encoder will only store compressed MLT tiles if they are slightly smaller than the uncompressed MLT data.  To be stored compressed, a tile must meet both criteria, as controlled by the following environment variables:
 
 - `MLT_COMPRESSION_RATIO_THRESHOLD`: Minimum compression ratio to apply compression (default: 0.98)
-  - If compressed tile is larger than his fraction of the uncompressed tile, it will be discarded and the uncompressed tile will be stored instead.
+  - If compressed tile is larger than this fraction of the uncompressed tile, it will be discarded and the uncompressed tile will be stored instead.
   - This value may be greater than 1.0 to indicate that tiles should be stored in compressed form even if it increases their size.
 - `MLT_COMPRESSION_FIXED_THRESHOLD`: Minimum savings in bytes for a tile to be compressed (default:  20)
   - If the compressed tile size plus this value is greater than the uncompressed tile size, the compressed tile will be discarded and the uncompressed tile will be stored instead.

--- a/java/README.MD
+++ b/java/README.MD
@@ -10,6 +10,7 @@ This is a multi-project Gradle build with two main components:
 
 - **`mlt-core`** - The core library containing the MLT encoding/decoding functionality
 - **`mlt-cli`** - Command-line tools for converting between MVT and MLT formats
+- **`mlt-tools`** - Utilities for working with MLT, currently only used for testing
 
 The core library is published to Maven Central, while the CLI tools are built locally for development use.
 
@@ -26,7 +27,7 @@ repositories {
 }
 
 dependencies {
-  implementation 'org.maplibre:mlt:0.0.1'
+  implementation 'org.maplibre:mlt:0.0.10'
 }
 ```
 
@@ -41,7 +42,7 @@ repositories {
 }
 
 dependencies {
-  implementation("org.maplibre:mlt:0.0.1")
+  implementation("org.maplibre:mlt:0.0.10")
 }
 ```
 
@@ -63,10 +64,12 @@ dependencies {
   <dependency>
     <groupId>org.maplibre</groupId>
     <artifactId>mlt</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.10</version>
   </dependency>
 </dependencies>
 ```
+
+See the [Maven Central Repository](https://mvnrepository.com/artifact/org.maplibre/mlt) for the latest published versions and syntax for other build systems.
 
 ## Usage Examples
 
@@ -243,6 +246,8 @@ Example of decoding MLT files:
 ```console
 java -jar mlt-cli/build/libs/decode.jar -mlt /tmp/point-boolean.mlt
 ```
+
+For more details, see [README-Encode.md](README-Encode.md) and [README-Encode.md](README-Decode.md).
 
 ## Contributing
 

--- a/java/README.MD
+++ b/java/README.MD
@@ -244,7 +244,7 @@ java -jar mlt-cli/build/libs/encode.jar --pmtiles /path/to/input.pmtiles --mlt /
 Example of decoding MLT files:
 
 ```console
-java -jar mlt-cli/build/libs/decode.jar -mlt /tmp/point-boolean.mlt
+java -jar mlt-cli/build/libs/decode.jar --mlt /tmp/point-boolean.mlt
 ```
 
 For more details, see [README-Encode.md](README-Encode.md) and [README-Encode.md](README-Decode.md).

--- a/java/README.MD
+++ b/java/README.MD
@@ -247,7 +247,7 @@ Example of decoding MLT files:
 java -jar mlt-cli/build/libs/decode.jar --mlt /tmp/point-boolean.mlt
 ```
 
-For more details, see [README-Encode.md](README-Encode.md) and [README-Encode.md](README-Decode.md).
+For more details, see [README-Encode.md](README-Encode.md) and [README-Decode.md](README-Decode.md).
 
 ## Contributing
 

--- a/java/mlt-cli/src/main/kotlin/org/maplibre/mlt/cli/Decode.kt
+++ b/java/mlt-cli/src/main/kotlin/org/maplibre/mlt/cli/Decode.kt
@@ -63,7 +63,7 @@ object Decode {
 
         if (args.isEmpty()) {
             showHelp(options)
-            return
+            System.exit(1)
         }
         try {
             val cmd = DefaultParser().parse(options, args)

--- a/java/mlt-cli/src/main/kotlin/org/maplibre/mlt/cli/Decode.kt
+++ b/java/mlt-cli/src/main/kotlin/org/maplibre/mlt/cli/Decode.kt
@@ -1,11 +1,12 @@
 package org.maplibre.mlt.cli
 
-import org.apache.commons.cli.CommandLineParser
+import org.apache.commons.cli.CommandLine
 import org.apache.commons.cli.DefaultParser
 import org.apache.commons.cli.Option
 import org.apache.commons.cli.Options
 import org.apache.commons.cli.ParseException
-import org.apache.commons.lang3.NotImplementedException
+import org.apache.commons.cli.help.HelpFormatter
+import org.maplibre.mlt.data.MapLibreTile
 import org.maplibre.mlt.decoder.MltDecoder
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -16,7 +17,6 @@ import java.nio.file.Paths
 object Decode {
     private const val FILE_NAME_ARG = "mlt"
     private const val PRINT_MLT_OPTION = "printmlt"
-    private const val VECTORIZED_OPTION = "vectorized"
     private const val TIMER_OPTION = "timer"
 
     @JvmStatic
@@ -43,16 +43,6 @@ object Decode {
         options.addOption(
             Option
                 .builder()
-                .longOpt(VECTORIZED_OPTION)
-                .hasArg(false)
-                .desc(
-                    "Use the vectorized decoding path ([OPTIONAL], default: will use non-vectorized path)",
-                ).required(false)
-                .get(),
-        )
-        options.addOption(
-            Option
-                .builder()
                 .longOpt(PRINT_MLT_OPTION)
                 .hasArg(false)
                 .desc("Print the MLT tile after encoding it ([OPTIONAL], default: false)")
@@ -63,34 +53,60 @@ object Decode {
             Option
                 .builder()
                 .longOpt(TIMER_OPTION)
-                .hasArg(false)
-                .desc("Print the time it takes, in ms, to decode a tile ([OPTIONAL])")
+                .hasArg(true)
+                .optionalArg(true)
+                .argName("count")
+                .desc("Print the time it takes, in ms, to decode a tile <count> times ([OPTIONAL], default 1)")
                 .required(false)
                 .get(),
         )
-        val parser: CommandLineParser = DefaultParser()
-        val cmd = parser.parse(options, args)
+
+        if (args.isEmpty()) {
+            showHelp(options)
+            return
+        }
+        try {
+            val cmd = DefaultParser().parse(options, args)
+            run(cmd)
+            System.out.println("x")
+        } catch (ex: ParseException) {
+            System.err.println(ex.message)
+            showHelp(options)
+        } catch (ex: Exception) {
+            System.err.println("Failed: " + ex.message)
+            ex.printStackTrace(System.err)
+        }
+    }
+
+    private fun run(cmd: CommandLine) {
         val fileName = cmd.getOptionValue(FILE_NAME_ARG)
         if (fileName == null || fileName.isEmpty()) {
             throw ParseException("Missing required argument: " + FILE_NAME_ARG)
         }
         val willPrintMLT = cmd.hasOption(PRINT_MLT_OPTION)
-        val willUseVectorized = cmd.hasOption(VECTORIZED_OPTION)
         val willTime = cmd.hasOption(TIMER_OPTION)
+        val decodeIterations = cmd.getOptionValue(TIMER_OPTION, "1").toInt().coerceAtLeast(1)
         val inputTilePath = Paths.get(fileName)
         require(Files.exists(inputTilePath)) { "Input mlt tile path does not exist: " + inputTilePath }
         val mltTileBuffer = Files.readAllBytes(inputTilePath)
 
         val timer = Timer()
-        if (willUseVectorized) {
-            throw NotImplementedException("Vectorized decoding is not available")
-        } else {
-            val decodedTile = MltDecoder.decodeMlTile(mltTileBuffer)
-            if (willTime) timer.stop("decoding")
-            if (willPrintMLT) {
-                System.out.write(decodedTile.toJson().toByteArray(StandardCharsets.UTF_8))
-            }
+        var decodedTile: MapLibreTile? = null
+        for (i in 0 until decodeIterations) {
+            decodedTile = MltDecoder.decodeMlTile(mltTileBuffer)
         }
+        if (willTime) timer.stop("decoding")
+        if (willPrintMLT && decodedTile != null) {
+            System.out.write(decodedTile.toJson().toByteArray(StandardCharsets.UTF_8))
+        }
+    }
+
+    private fun showHelp(options: Options) {
+        HelpFormatter
+            .builder()
+            .setShowSince(false)
+            .get()
+            .printHelp(Decode::class.java.name, "", options, null, true)
     }
 
     private val logger: Logger = LoggerFactory.getLogger(Decode::class.java)

--- a/java/mlt-cli/src/main/kotlin/org/maplibre/mlt/cli/Decode.kt
+++ b/java/mlt-cli/src/main/kotlin/org/maplibre/mlt/cli/Decode.kt
@@ -71,9 +71,11 @@ object Decode {
         } catch (ex: ParseException) {
             System.err.println(ex.message)
             showHelp(options)
+            throw ex
         } catch (ex: Exception) {
             System.err.println("Failed: " + ex.message)
             ex.printStackTrace(System.err)
+            throw ex
         }
     }
 

--- a/java/mlt-cli/src/main/kotlin/org/maplibre/mlt/cli/Decode.kt
+++ b/java/mlt-cli/src/main/kotlin/org/maplibre/mlt/cli/Decode.kt
@@ -68,7 +68,6 @@ object Decode {
         try {
             val cmd = DefaultParser().parse(options, args)
             run(cmd)
-            System.out.println("x")
         } catch (ex: ParseException) {
             System.err.println(ex.message)
             showHelp(options)


### PR DESCRIPTION
- Remove obsolete vectorized option from decoder
- Add repeated decoding to the timing option
- Clean up decoder command line handling