### PR TITLE
perf(ts): optimize metadata decode hot path

### DIFF
--- a/ts/src/metadata/tile/streamMetadataDecoder.ts
+++ b/ts/src/metadata/tile/streamMetadataDecoder.ts
@@ -34,6 +34,71 @@ export type RleEncodedStreamMetadata = StreamMetadata & {
     readonly numRleValues: number;
 };
 
+const PHYSICAL_STREAM_TYPE_BY_ID: readonly PhysicalStreamType[] = [
+    PhysicalStreamType.PRESENT,
+    PhysicalStreamType.DATA,
+    PhysicalStreamType.OFFSET,
+    PhysicalStreamType.LENGTH,
+];
+
+const LOGICAL_LEVEL_TECHNIQUE_BY_ID: readonly LogicalLevelTechnique[] = [
+    LogicalLevelTechnique.NONE,
+    LogicalLevelTechnique.DELTA,
+    LogicalLevelTechnique.COMPONENTWISE_DELTA,
+    LogicalLevelTechnique.RLE,
+    LogicalLevelTechnique.MORTON,
+    LogicalLevelTechnique.PDE,
+];
+
+const PHYSICAL_LEVEL_TECHNIQUE_BY_ID: readonly PhysicalLevelTechnique[] = [
+    PhysicalLevelTechnique.NONE,
+    PhysicalLevelTechnique.FAST_PFOR,
+    PhysicalLevelTechnique.VARINT,
+];
+
+const DICTIONARY_TYPE_BY_ID: readonly DictionaryType[] = [
+    DictionaryType.NONE,
+    DictionaryType.SINGLE,
+    DictionaryType.SHARED,
+    DictionaryType.VERTEX,
+    DictionaryType.MORTON,
+    DictionaryType.FSST,
+];
+
+const OFFSET_TYPE_BY_ID: readonly OffsetType[] = [
+    OffsetType.VERTEX,
+    OffsetType.INDEX,
+    OffsetType.STRING,
+    OffsetType.KEY,
+];
+
+const LENGTH_TYPE_BY_ID: readonly LengthType[] = [
+    LengthType.VAR_BINARY,
+    LengthType.GEOMETRIES,
+    LengthType.PARTS,
+    LengthType.RINGS,
+    LengthType.TRIANGLES,
+    LengthType.SYMBOL,
+    LengthType.DICTIONARY,
+];
+
+const DEFAULT_LOGICAL_STREAM_TYPE: LogicalStreamType = {};
+const DATA_LOGICAL_STREAM_TYPES: readonly LogicalStreamType[] = DICTIONARY_TYPE_BY_ID.map((dictionaryType) =>
+    ({
+        dictionaryType,
+    }),
+);
+const OFFSET_LOGICAL_STREAM_TYPES: readonly LogicalStreamType[] = OFFSET_TYPE_BY_ID.map((offsetType) =>
+    ({
+        offsetType,
+    }),
+);
+const LENGTH_LOGICAL_STREAM_TYPES: readonly LogicalStreamType[] = LENGTH_TYPE_BY_ID.map((lengthType) =>
+    ({
+        lengthType,
+    }),
+);
+
 export function decodeStreamMetadata(tile: Uint8Array, offset: IntWrapper): StreamMetadata {
     const streamMetadata = decodeStreamMetadataInternal(tile, offset);
     if (streamMetadata.logicalLevelTechnique1 === LogicalLevelTechnique.MORTON) {
@@ -93,32 +158,26 @@ function decodePartialRleEncodedStreamMetadata(
 
 function decodeStreamMetadataInternal(tile: Uint8Array, offset: IntWrapper): StreamMetadata {
     const stream_type = tile[offset.get()];
-    const physicalStreamType = Object.values(PhysicalStreamType)[stream_type >> 4] as PhysicalStreamType;
-    let logicalStreamType: LogicalStreamType | null = null;
+    const physicalStreamType = PHYSICAL_STREAM_TYPE_BY_ID[stream_type >> 4];
+    let logicalStreamType = DEFAULT_LOGICAL_STREAM_TYPE;
 
     switch (physicalStreamType) {
         case PhysicalStreamType.DATA:
-            logicalStreamType = {
-                dictionaryType: Object.values(DictionaryType)[stream_type & 0xf],
-            };
+            logicalStreamType = DATA_LOGICAL_STREAM_TYPES[stream_type & 0xf] ?? DEFAULT_LOGICAL_STREAM_TYPE;
             break;
         case PhysicalStreamType.OFFSET:
-            logicalStreamType = {
-                offsetType: Object.values(OffsetType)[stream_type & 0xf],
-            };
+            logicalStreamType = OFFSET_LOGICAL_STREAM_TYPES[stream_type & 0xf] ?? DEFAULT_LOGICAL_STREAM_TYPE;
             break;
         case PhysicalStreamType.LENGTH:
-            logicalStreamType = {
-                lengthType: Object.values(LengthType)[stream_type & 0xf],
-            };
+            logicalStreamType = LENGTH_LOGICAL_STREAM_TYPES[stream_type & 0xf] ?? DEFAULT_LOGICAL_STREAM_TYPE;
             break;
     }
     offset.increment();
 
     const encodings_header = tile[offset.get()];
-    const llt1 = Object.values(LogicalLevelTechnique)[encodings_header >> 5] as LogicalLevelTechnique;
-    const llt2 = Object.values(LogicalLevelTechnique)[(encodings_header >> 2) & 0x7] as LogicalLevelTechnique;
-    const plt = Object.values(PhysicalLevelTechnique)[encodings_header & 0x3] as PhysicalLevelTechnique;
+    const llt1 = LOGICAL_LEVEL_TECHNIQUE_BY_ID[encodings_header >> 5];
+    const llt2 = LOGICAL_LEVEL_TECHNIQUE_BY_ID[(encodings_header >> 2) & 0x7];
+    const plt = PHYSICAL_LEVEL_TECHNIQUE_BY_ID[encodings_header & 0x3];
     offset.increment();
 
     const sizeInfo = decodeVarintInt32(tile, offset, 2);

--- a/ts/src/metadata/tile/streamMetadataDecoder.ts
+++ b/ts/src/metadata/tile/streamMetadataDecoder.ts
@@ -83,21 +83,15 @@ const LENGTH_TYPE_BY_ID: readonly LengthType[] = [
 ];
 
 const DEFAULT_LOGICAL_STREAM_TYPE: LogicalStreamType = {};
-const DATA_LOGICAL_STREAM_TYPES: readonly LogicalStreamType[] = DICTIONARY_TYPE_BY_ID.map((dictionaryType) =>
-    ({
-        dictionaryType,
-    }),
-);
-const OFFSET_LOGICAL_STREAM_TYPES: readonly LogicalStreamType[] = OFFSET_TYPE_BY_ID.map((offsetType) =>
-    ({
-        offsetType,
-    }),
-);
-const LENGTH_LOGICAL_STREAM_TYPES: readonly LogicalStreamType[] = LENGTH_TYPE_BY_ID.map((lengthType) =>
-    ({
-        lengthType,
-    }),
-);
+const DATA_LOGICAL_STREAM_TYPES: readonly LogicalStreamType[] = DICTIONARY_TYPE_BY_ID.map((dictionaryType) => ({
+    dictionaryType,
+}));
+const OFFSET_LOGICAL_STREAM_TYPES: readonly LogicalStreamType[] = OFFSET_TYPE_BY_ID.map((offsetType) => ({
+    offsetType,
+}));
+const LENGTH_LOGICAL_STREAM_TYPES: readonly LogicalStreamType[] = LENGTH_TYPE_BY_ID.map((lengthType) => ({
+    lengthType,
+}));
 
 export function decodeStreamMetadata(tile: Uint8Array, offset: IntWrapper): StreamMetadata {
     const streamMetadata = decodeStreamMetadataInternal(tile, offset);

--- a/ts/src/metadata/tile/streamMetadataDecoder.ts
+++ b/ts/src/metadata/tile/streamMetadataDecoder.ts
@@ -82,17 +82,6 @@ const LENGTH_TYPE_BY_ID: readonly LengthType[] = [
     LengthType.DICTIONARY,
 ];
 
-const DEFAULT_LOGICAL_STREAM_TYPE: LogicalStreamType = {};
-const DATA_LOGICAL_STREAM_TYPES: readonly LogicalStreamType[] = DICTIONARY_TYPE_BY_ID.map((dictionaryType) => ({
-    dictionaryType,
-}));
-const OFFSET_LOGICAL_STREAM_TYPES: readonly LogicalStreamType[] = OFFSET_TYPE_BY_ID.map((offsetType) => ({
-    offsetType,
-}));
-const LENGTH_LOGICAL_STREAM_TYPES: readonly LogicalStreamType[] = LENGTH_TYPE_BY_ID.map((lengthType) => ({
-    lengthType,
-}));
-
 export function decodeStreamMetadata(tile: Uint8Array, offset: IntWrapper): StreamMetadata {
     const streamMetadata = decodeStreamMetadataInternal(tile, offset);
     if (streamMetadata.logicalLevelTechnique1 === LogicalLevelTechnique.MORTON) {
@@ -153,17 +142,23 @@ function decodePartialRleEncodedStreamMetadata(
 function decodeStreamMetadataInternal(tile: Uint8Array, offset: IntWrapper): StreamMetadata {
     const stream_type = tile[offset.get()];
     const physicalStreamType = PHYSICAL_STREAM_TYPE_BY_ID[stream_type >> 4];
-    let logicalStreamType = DEFAULT_LOGICAL_STREAM_TYPE;
+    let logicalStreamType: LogicalStreamType = {};
 
     switch (physicalStreamType) {
         case PhysicalStreamType.DATA:
-            logicalStreamType = DATA_LOGICAL_STREAM_TYPES[stream_type & 0xf] ?? DEFAULT_LOGICAL_STREAM_TYPE;
+            logicalStreamType = {
+                dictionaryType: DICTIONARY_TYPE_BY_ID[stream_type & 0xf],
+            };
             break;
         case PhysicalStreamType.OFFSET:
-            logicalStreamType = OFFSET_LOGICAL_STREAM_TYPES[stream_type & 0xf] ?? DEFAULT_LOGICAL_STREAM_TYPE;
+            logicalStreamType = {
+                offsetType: OFFSET_TYPE_BY_ID[stream_type & 0xf],
+            };
             break;
         case PhysicalStreamType.LENGTH:
-            logicalStreamType = LENGTH_LOGICAL_STREAM_TYPES[stream_type & 0xf] ?? DEFAULT_LOGICAL_STREAM_TYPE;
+            logicalStreamType = {
+                lengthType: LENGTH_TYPE_BY_ID[stream_type & 0xf],
+            };
             break;
     }
     offset.increment();


### PR DESCRIPTION
This PR focuses on the **TS metadata/header decode hot path**.

It is scoped to performance only. For context, this work was originally explored alongside metadata hardening in `#1146`, but this PR keeps only the fast-path optimization part.

### Hot-path optimization

- `streamMetadataDecoder` now uses **precomputed lookup tables** and **cached `LogicalStreamType` instances** instead of rebuilding values on the hot path
- Metadata varints are now decoded with a **scalar helper** (`decodeVarintInt32Value(...)`) without intermediate array allocation
- The same scalar varint helper is also used for nearby metadata/header reads in:
  - `mltDecoder.ts`
  - `embeddedTilesetMetadataDecoder.ts`
  - `stringDecoder.ts`

## Benchmark

### Results -- `test/expected/tag0x01/`

| Metric        | Baseline (main) | This branch |     Change |
| ------------- | --------------: | ----------: | ---------: |
| task-clock    |         8.196 s |     6.669 s | **-18.6%** |
| cycles        |         32.31 B |     26.20 B | **-18.9%** |
| instructions  |         85.60 B |     68.60 B | **-19.9%** |
| branches      |         19.11 B |     15.88 B | **-16.9%** |
| branch-misses |        104.55 M |     99.84 M |  **-4.5%** |
