### PR TITLE
fix(ts): lower TypeScript target to ES2020 for bundler compatibility

### DIFF
--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2020",
     "outDir": "./dist",
     "resolveJsonModule": true,
     "module": "es2022",


### PR DESCRIPTION
## Summary

- Lowers `ts/tsconfig.json` target from `ES2022` to `ES2020` so TypeScript emits class fields as constructor assignments instead of native ES2022 class field declarations.

## Problem

When bundlers like Vite/esbuild target < ES2022, they transform class field declarations into helper function calls (e.g. `__publicField(this, "options")`). In maplibre-gl's UMD bundle, these helpers are defined in ESM module scope but **lost** when worker code is serialized via `.toString()`, causing `_defineProperty is not defined` runtime errors in the Web Worker.

**Affected classes in this package:** `FeatureTable` (6 fields), `LogicalStreamType` (3 fields) — 9 class field declarations total.

## Solution

Lowering the TypeScript target to `ES2020` makes `tsc` emit:
```js
// Before (ES2022) — native class field, breaks in serialized worker
class FeatureTable { _name; _geometryVector; }

// After (ES2020) — constructor assignment, safe for serialization
class FeatureTable { constructor(_name, _geometryVector) { this._name = _name; this._geometryVector = _geometryVector; } }
```

This is a **minimal, non-breaking change**: source code stays modern (class fields, private, etc.), only the emitted JavaScript changes.

## Verification

- Built locally with `npm run build` — no errors
- Confirmed no class field declarations remain in `dist/` output files
- Rebuilt `maplibre-gl-js` with this patched package alongside patched `@maplibre/geojson-vt`
- Tested with Vite repro project (target `es2020`): **0 `__publicField` references** (was 50 before)
- Tested in a Strapi application with maplibre-gl: map loads and works correctly

## Related

- Helps: maplibre/maplibre-gl-js#7069
- Companion PR for `@maplibre/geojson-vt`: maplibre/geojson-vt#79
- Check also Mapbox's: mapbox/mapbox-gl-js#12656 and mapbox/mapbox-gl-js#12658

## Test plan

- [ ] `npm run build` succeeds without errors in `ts/` directory
- [ ] All existing tests pass
- [ ] `ts/dist/` files contain no class field declarations outside constructors
- [ ] maplibre-gl-js builds successfully with this package version
- [ ] Vite build with `target: 'es2020'` produces no `__publicField`/`_defineProperty` references