### PR TITLE
fix(cpp): Add support for optional string columns

### DIFF
--- a/cpp/include/mlt/metadata/type_map.hpp
+++ b/cpp/include/mlt/metadata/type_map.hpp
@@ -61,12 +61,12 @@ struct Tag0x01 {
                 return Column{.name = {},
                               .nullable = false,
                               .columnScope = ColumnScope::FEATURE,
-                              .type = ComplexColumn{.type = ComplexType::GEOMETRY}};
+                              .type = ComplexColumn{.type = ComplexType::GEOMETRY, .children = {}}};
             case 30:
                 return Column{.name = {},
                               .nullable = false,
                               .columnScope = ColumnScope::FEATURE,
-                              .type = ComplexColumn{.type = ComplexType::STRUCT}};
+                              .type = ComplexColumn{.type = ComplexType::STRUCT, .children = {}}};
             default:
                 if (const auto type = mapScalarType(typeCode); type) {
                     return Column{.name = {},

--- a/cpp/src/mlt/decode/property.hpp
+++ b/cpp/src/mlt/decode/property.hpp
@@ -87,7 +87,7 @@ protected:
         }
         const auto scalarType = scalarColumn.getPhysicalType();
 
-        // Everything but string has stream metadata.
+        // String stream metadata is read by StringDecoder
         std::unique_ptr<StreamMetadata> streamMetadata;
         if (scalarType != ScalarType::STRING) {
             streamMetadata = StreamMetadata::decode(tileData);

--- a/cpp/src/mlt/decode/property.hpp
+++ b/cpp/src/mlt/decode/property.hpp
@@ -93,7 +93,7 @@ protected:
             streamMetadata = StreamMetadata::decode(tileData);
         }
 
-        if (streamMetadata && presentValueCount && presentValueCount < streamMetadata->getNumValues()) {
+        if (column.nullable && streamMetadata && presentValueCount < streamMetadata->getNumValues()) {
             throw std::runtime_error("Unexpected present value column");
         }
 
@@ -194,9 +194,8 @@ protected:
                 return {scalarType, std::move(result), std::move(presentStream)};
             }
             case ScalarType::STRING: {
-                const auto stringCount = presentStream.empty() ? presentValueCount : countSetBits(presentStream);
                 auto strings = stringDecoder.decode(tileData, numStreams);
-                if (presentValueCount && countSetBits(presentStream) != strings.getStrings().size()) {
+                if (column.nullable && countSetBits(presentStream) != strings.getStrings().size()) {
                     throw std::runtime_error("String count doesn't match present value count");
                 }
 

--- a/cpp/src/mlt/decode/property.hpp
+++ b/cpp/src/mlt/decode/property.hpp
@@ -78,6 +78,7 @@ protected:
             if ((presentValueCount + 7) / 8 != presentStream.size()) {
                 throw std::runtime_error("invalid present stream");
             }
+            numStreams -= 1;
         }
 
         const auto scalarColumn = std::get<ScalarColumn>(column.type);
@@ -88,25 +89,8 @@ protected:
 
         // Everything but string has stream metadata.
         std::unique_ptr<StreamMetadata> streamMetadata;
-        switch (scalarType) {
-            case ScalarType::BOOLEAN:
-            case ScalarType::INT_8:
-            case ScalarType::UINT_8:
-            case ScalarType::INT_32:
-            case ScalarType::UINT_32:
-            case ScalarType::INT_64:
-            case ScalarType::UINT_64:
-            case ScalarType::FLOAT:
-            case ScalarType::DOUBLE:
-                streamMetadata = StreamMetadata::decode(tileData);
-                break;
-            default:
-            case ScalarType::STRING:
-                // String always has present values stream.
-                if (!presentValueCount) {
-                    throw std::runtime_error("Missing present value column");
-                }
-                break;
+        if (scalarType != ScalarType::STRING) {
+            streamMetadata = StreamMetadata::decode(tileData);
         }
 
         if (streamMetadata && presentValueCount && presentValueCount < streamMetadata->getNumValues()) {
@@ -114,6 +98,7 @@ protected:
         }
 
         const auto checkBits = [&](const auto& presentBuffer, const auto& propertyBuffer, bool isBoolean = false) {
+#ifndef NDEBUG
             if (!presentStream.empty()) {
                 const auto actualProperties = propertyCount(propertyBuffer, isBoolean);
                 const auto presentBits = countSetBits(presentBuffer);
@@ -123,7 +108,9 @@ protected:
                                              " doesn't match present bits " + std::to_string(presentBits));
                 }
             }
+#endif
         };
+
         switch (scalarType) {
             case ScalarType::BOOLEAN: {
                 std::vector<std::uint8_t> byteBuffer;
@@ -208,8 +195,10 @@ protected:
             }
             case ScalarType::STRING: {
                 const auto stringCount = presentStream.empty() ? presentValueCount : countSetBits(presentStream);
-                // FIXME? why numStreams - 1? what if its not optional
-                auto strings = stringDecoder.decode(tileData, numStreams - 1, static_cast<std::uint32_t>(stringCount));
+                auto strings = stringDecoder.decode(tileData, numStreams);
+                if (presentValueCount && countSetBits(presentStream) != strings.getStrings().size()) {
+                    throw std::runtime_error("String count doesn't match present value count");
+                }
 
                 PropertyVec result{std::move(strings)};
                 checkBits(presentStream, result);

--- a/cpp/src/mlt/decode/string.hpp
+++ b/cpp/src/mlt/decode/string.hpp
@@ -142,9 +142,8 @@ public:
         }
 
         for (const auto& child : column.getComplexType().children) {
-            const auto childStreams = decodeVarint<std::uint32_t>(tileData);
-            // TODO: We don't really need this stream count until the present stream is optional.
-            // We could infer it from the nullable bit in the column, but only if that applies to all children.
+            [[maybe_unused]] const auto childStreams = decodeVarint<std::uint32_t>(tileData);
+
             if (!child.hasScalarType() || child.getScalarType().getPhysicalType() != ScalarType::STRING) {
                 throw std::runtime_error("Currently only string fields are implemented for a struct");
             }
@@ -166,15 +165,12 @@ public:
             std::vector<std::string_view> propertyValues;
             propertyValues.reserve(dataReferenceStream.size());
 
-            std::uint32_t counter = 0;
             for (std::uint32_t i = 0; i < dataReferenceStream.size(); ++i) {
-                if (presentStream.empty() || testBit(presentStream, i)) {
-                    const auto dictIndex = dataReferenceStream[counter++];
-                    if (dictIndex >= dictionaryViews.size()) {
-                        throw std::runtime_error("StringDecoder: dictionaryViews index out of bounds");
-                    }
-                    propertyValues.push_back(dictionaryViews[dictIndex]);
+                const auto dictIndex = dataReferenceStream[i];
+                if (dictIndex >= dictionaryViews.size()) {
+                    throw std::runtime_error("StringDecoder: dictionaryViews index out of bounds");
                 }
+                propertyValues.push_back(dictionaryViews[dictIndex]);
             }
 
             results.emplace(column.name + child.name,

--- a/cpp/src/mlt/decode/string.hpp
+++ b/cpp/src/mlt/decode/string.hpp
@@ -28,7 +28,7 @@ public:
      * -> fsst dictionary -> symbolTable, symbolLength, dictionary, length, present, data
      * */
 
-    StringDictViews decode(BufferStream& tileData, std::uint32_t numStreams, std::uint32_t numValues) {
+    StringDictViews decode(BufferStream& tileData, std::uint32_t numStreams) {
         using namespace metadata::stream;
         using namespace util::decoding;
 
@@ -40,8 +40,6 @@ public:
         std::vector<std::uint32_t> dictLengthStream;
         std::vector<std::uint32_t> symbolLengthStream;
         std::vector<std::string_view> views;
-        std::optional<std::uint32_t> presentValueCount;
-        views.reserve(numValues);
         for (std::uint32_t i = 0; i < numStreams; ++i) {
             const auto streamMetadata = StreamMetadata::decode(tileData);
             switch (streamMetadata->getPhysicalStreamType()) {
@@ -73,19 +71,15 @@ public:
             }
         }
 
-        if (presentValueCount && *presentValueCount != numValues) {
-            throw std::runtime_error("Unexpected present value count for string column");
-        }
-
         if (!dictLengthStream.empty() && !symbolLengthStream.empty()) {
             auto data = decodeFSST(symbolStream, symbolLengthStream, dictionaryStream, 2 * dictionaryStream.size());
-            decodeDictionary(dictLengthStream, data, offsetStream, views, numValues);
+            decodeDictionary(dictLengthStream, data, offsetStream, views);
             return {std::move(data), std::move(views)};
         } else if (!offsetStream.empty() && !dictLengthStream.empty()) {
-            decodeDictionary(dictLengthStream, dictionaryStream, offsetStream, views, numValues);
+            decodeDictionary(dictLengthStream, dictionaryStream, offsetStream, views);
             return {std::move(dictionaryStream), std::move(views)};
         } else if (!symbolLengthStream.empty()) {
-            decodePlain(symbolLengthStream, symbolStream, views, numValues);
+            decodePlain(symbolLengthStream, symbolStream, views);
             return {std::move(symbolStream), std::move(views)};
         } else {
             throw std::runtime_error("Expected streams missing in string decoding");
@@ -108,8 +102,6 @@ public:
         auto dictionaryStream = std::make_shared<std::vector<std::uint8_t>>();
         std::vector<std::uint32_t> symbolLengthStream;
         std::vector<std::uint8_t> symbolTableStream;
-        PackedBitset presentStream;
-        std::optional<std::uint32_t> presentValueCount;
         PropertyVecMap results;
 
         bool dictionaryStreamDecoded = false;
@@ -153,17 +145,18 @@ public:
             const auto childStreams = decodeVarint<std::uint32_t>(tileData);
             // TODO: We don't really need this stream count until the present stream is optional.
             // We could infer it from the nullable bit in the column, but only if that applies to all children.
-            if (childStreams != 2 || !child.hasScalarType() ||
-                child.getScalarType().getPhysicalType() != ScalarType::STRING) {
-                throw std::runtime_error("Currently only optional string fields are implemented for a struct");
+            if (!child.hasScalarType() || child.getScalarType().getPhysicalType() != ScalarType::STRING) {
+                throw std::runtime_error("Currently only string fields are implemented for a struct");
             }
 
-            const auto presentStreamMetadata = metadata::stream::StreamMetadata::decode(tileData);
-            const auto presentValueCount = presentStreamMetadata->getNumValues();
             PackedBitset presentStream;
-            rle::decodeBoolean(tileData, presentStream, *presentStreamMetadata, /*consume=*/true);
-            if ((presentValueCount + 7) / 8 != presentStream.size()) {
-                throw std::runtime_error("invalid present stream");
+            if (child.nullable) {
+                const auto presentStreamMetadata = metadata::stream::StreamMetadata::decode(tileData);
+                const auto presentValueCount = presentStreamMetadata->getNumValues();
+                rle::decodeBoolean(tileData, presentStream, *presentStreamMetadata, /*consume=*/true);
+                if ((presentValueCount + 7) / 8 != presentStream.size()) {
+                    throw std::runtime_error("invalid present stream");
+                }
             }
 
             const auto dataStreamMetadata = metadata::stream::StreamMetadata::decode(tileData);
@@ -171,15 +164,12 @@ public:
             intDecoder.decodeIntStream<std::uint32_t>(tileData, dataReferenceStream, *dataStreamMetadata);
 
             std::vector<std::string_view> propertyValues;
-            propertyValues.reserve(presentValueCount);
+            propertyValues.reserve(dataReferenceStream.size());
 
             std::uint32_t counter = 0;
-            for (std::uint32_t i = 0; i < presentValueCount; ++i) {
-                if (testBit(presentStream, i)) {
-                    if (counter >= dataReferenceStream.size()) {
-                        throw std::runtime_error("StringDecoder: dataReferenceStream out of bounds");
-                    }
-                    auto dictIndex = dataReferenceStream[counter++];
+            for (std::uint32_t i = 0; i < dataReferenceStream.size(); ++i) {
+                if (presentStream.empty() || testBit(presentStream, i)) {
+                    const auto dictIndex = dataReferenceStream[counter++];
                     if (dictIndex >= dictionaryViews.size()) {
                         throw std::runtime_error("StringDecoder: dictionaryViews index out of bounds");
                     }
@@ -272,11 +262,11 @@ private:
 
     static void decodePlain(const std::vector<std::uint32_t>& lengthStream,
                             const std::vector<std::uint8_t>& utf8bytes,
-                            std::vector<std::string_view>& out,
-                            std::uint32_t numValues) {
+                            std::vector<std::string_view>& out) {
         std::size_t dataOffset = 0;
         std::size_t lengthOffset = 0;
-        for (std::uint32_t i = 0; i < numValues; ++i) {
+        out.reserve(lengthStream.size());
+        for (std::uint32_t i = 0; i < lengthStream.size(); ++i) {
             const auto length = lengthStream[lengthOffset++];
             const char* bytes = reinterpret_cast<std::string::const_pointer>(utf8bytes.data() + dataOffset);
             out.push_back(view(bytes, length));
@@ -299,8 +289,7 @@ private:
     static void decodeDictionary(const std::vector<std::uint32_t>& lengthStream,
                                  const std::vector<std::uint8_t>& utf8bytes,
                                  const std::vector<std::uint32_t>& offsets,
-                                 std::vector<std::string_view>& out,
-                                 std::uint32_t numValues) {
+                                 std::vector<std::string_view>& out) {
         const auto* const utf8Ptr = reinterpret_cast<const char*>(utf8bytes.data());
 
         std::vector<std::string_view> dictionary;
@@ -312,9 +301,9 @@ private:
             dictionaryOffset += length;
         }
 
-        std::size_t offsetIndex = 0;
-        for (std::uint32_t i = 0; i < numValues; ++i) {
-            out.push_back(dictionary[offsets[offsetIndex++]]);
+        out.reserve(offsets.size());
+        for (std::uint32_t i = 0; i < offsets.size(); ++i) {
+            out.push_back(dictionary[offsets[i]]);
         }
     }
 };

--- a/cpp/tool/synthetic.test.ts
+++ b/cpp/tool/synthetic.test.ts
@@ -11,28 +11,7 @@ import { describe, expect, it } from "vitest";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const binary = resolve(__dirname, "../build/tool/mlt-cpp-json");
 
-const SKIPPED_TESTS = [
-  "0x01-rust/prop_str_ascii_np",
-  "0x01-rust/prop_str_empty_np",
-  "0x01-rust/prop_str_escape_np",
-  "0x01-rust/prop_str_special_np",
-  "0x01-rust/prop_str_unicode_np",
-  "0x01-rust/props_mixed_np",
-  "0x01-rust/props_no_shared_dict_np",
-  "0x01-rust/props_offset_str_fsst_np",
-  "0x01-rust/props_offset_str_np",
-  "0x01-rust/props_shared_dict_2_same_prefix_np",
-  "0x01-rust/props_shared_dict_fsst_np",
-  "0x01-rust/props_shared_dict_no_child_name_fsst_np",
-  "0x01-rust/props_shared_dict_no_child_name_np",
-  "0x01-rust/props_shared_dict_no_struct_name_fsst_np",
-  "0x01-rust/props_shared_dict_no_struct_name_np",
-  "0x01-rust/props_shared_dict_np",
-  "0x01-rust/props_shared_dict_one_child_fsst_np",
-  "0x01-rust/props_shared_dict_one_child_np",
-  "0x01-rust/props_str_fsst_np",
-  "0x01-rust/props_str_np",
-];
+const SKIPPED_TESTS = [];
 
 describe("MLT Decoder - Synthetic tests", () => {
   expect.addEqualityTesters([compareWithTolerance]);


### PR DESCRIPTION
The C++ decoder rejected optional string columns because the Java encoder never produced them.