### PR TITLE
Revert "chore(rust): try to remove java install for rust builds"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
+      - uses: ./.github/actions/mlt-setup-java
       - uses: ./.github/actions/mlt-setup-rust
       - run: just -v rust::ci-check
       - run: just -v rust::ci-lint
@@ -30,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
+      - uses: ./.github/actions/mlt-setup-java
       - uses: ./.github/actions/mlt-setup-rust
         with: { toolchain: nightly } # because of covs --doctests
       - uses: taiki-e/install-action@v2
@@ -94,6 +96,7 @@ jobs:
   #    runs-on: ubuntu-latest
   #    steps:
   #      - uses: actions/checkout@v6.0.2
+  #      - uses: ./.github/actions/mlt-setup-java  # generate MLT test files
   #      - uses: ./.github/actions/mlt-setup-rust
   #        with: { toolchain: msrv }
   #      - run: just -v rust::ci-test-msrv


### PR DESCRIPTION
Reverts maplibre/maplibre-tile-spec#1249

I will need this for the JNI PR that I have not yet rebased onto main