### PR TITLE
perf(rust): Don't allocate for calculating the hilbert params and resulting parameters

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1440,7 +1440,6 @@ dependencies = [
  "robust",
  "rstar",
  "sif-itree",
- "spade",
 ]
 
 [[package]]
@@ -4668,18 +4667,6 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "spade"
-version = "2.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9699399fd9349b00b184f5635b074f9ec93afffef30c853f8c875b32c0f8c7fa"
-dependencies = [
- "hashbrown 0.16.1",
- "num-traits",
- "robust",
- "smallvec",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,7 +28,7 @@ fastpfor = { version = "0.9", features = ["rust"] }
 flate2 = "1"
 fsst-rs = "0.5"
 futures = "0.3"
-geo = {version =  "0.32.0", default-features = false }
+geo = { version = "0.32.0", default-features = false }
 geo-types = "0.7.18"
 glob = "0.3"
 globset = "0.4"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,7 +28,7 @@ fastpfor = { version = "0.9", features = ["rust"] }
 flate2 = "1"
 fsst-rs = "0.5"
 futures = "0.3"
-geo = "0.32.0"
+geo = {version =  "0.32.0", default-features = false }
 geo-types = "0.7.18"
 glob = "0.3"
 globset = "0.4"

--- a/rust/mlt-core/Cargo.toml
+++ b/rust/mlt-core/Cargo.toml
@@ -37,9 +37,15 @@ harness = false
 required-features = ["__private"]
 
 [features]
-# Workaround until new WASM-compatible geo is released
-default = ["tessellate"]
-tessellate = ["geo/earcutr", "geo/multithreading"]
+# Workaround until new WASM-compatible geo is released: both `tessellate` and
+# `sort-coords-iter` transitively depend on the `geo` crate, which does not
+# yet build on `wasm32-unknown-unknown`. Remove the feature gating once a
+# WASM-capable `geo` release is available.
+default = ["sort-coords-iter", "tessellate"]
+tessellate = ["dep:geo", "geo/earcutr", "geo/multithreading"]
+# Enables feature sort strategies (`SpatialMorton`, `SpatialHilbert`) which
+# use `geo::CoordsIter` for bounds computation. Disable on WASM.
+sort-coords-iter = ["dep:geo"]
 arbitrary = ["dep:arbitrary", "geo-types/arbitrary"]
 # Used internally for testing and benchmarking, not intended for public use
 __private = []
@@ -50,7 +56,8 @@ bytemuck.workspace = true
 enum_dispatch.workspace = true
 fastpfor.workspace = true
 fsst-rs.workspace = true
-geo.workspace = true
+# Only used for tessellation; remove the `optional = true` once `geo` is WASM-capable.
+geo = { workspace = true, optional = true }
 geo-types.workspace = true
 hex.workspace = true
 hilbert_2d.workspace = true

--- a/rust/mlt-core/Cargo.toml
+++ b/rust/mlt-core/Cargo.toml
@@ -39,7 +39,7 @@ required-features = ["__private"]
 [features]
 # Workaround until new WASM-compatible geo is released
 default = ["tessellate"]
-tessellate = ["dep:geo"]
+tessellate = ["geo/earcutr", "geo/multithreading"]
 arbitrary = ["dep:arbitrary", "geo-types/arbitrary"]
 # Used internally for testing and benchmarking, not intended for public use
 __private = []
@@ -50,7 +50,7 @@ bytemuck.workspace = true
 enum_dispatch.workspace = true
 fastpfor.workspace = true
 fsst-rs.workspace = true
-geo = { workspace = true, optional = true }
+geo.workspace = true
 geo-types.workspace = true
 hex.workspace = true
 hilbert_2d.workspace = true

--- a/rust/mlt-core/fuzz/src/decoded_layer.rs
+++ b/rust/mlt-core/fuzz/src/decoded_layer.rs
@@ -27,7 +27,11 @@ impl DecodedLayerInput {
         let tile2 = encode_decode(StagedLayer01::from_tile(tile1, SortStrategy::Unsorted, &[]));
 
         // Same roundtrip again — must be a fixpoint.
-        let tile3 = encode_decode(StagedLayer01::from_tile(tile2.clone(), SortStrategy::Unsorted, &[]));
+        let tile3 = encode_decode(StagedLayer01::from_tile(
+            tile2.clone(),
+            SortStrategy::Unsorted,
+            &[],
+        ));
 
         assert_eq!(tile2, tile3, "canonical roundtrip is not idempotent");
     }
@@ -43,8 +47,7 @@ fn encode_decode(staged: StagedLayer01) -> TileLayer01 {
         .expect("into_layer_bytes should not fail");
 
     let mut parser = Parser::default();
-    let (remaining, layer) =
-        Layer::from_bytes(&buffer, &mut parser).expect("layer must re-parse");
+    let (remaining, layer) = Layer::from_bytes(&buffer, &mut parser).expect("layer must re-parse");
     assert!(
         remaining.is_empty(),
         "Re-parsing left {} trailing bytes",

--- a/rust/mlt-core/src/codecs/hilbert.rs
+++ b/rust/mlt-core/src/codecs/hilbert.rs
@@ -3,6 +3,7 @@
 /// The grid has side `2^level`; both `x` and `y` must be in `[0, 2^level)`,
 /// and `level` must be in `[1, 16]`.  The returned index is in
 /// `[0, 4^level)` and fits in a `u32` for all valid levels.
+#[cfg(any(feature = "sort-coords-iter", test))]
 #[must_use]
 pub fn hilbert_xy_to_index(level: u32, x: u32, y: u32) -> u32 {
     debug_assert!((1..=16).contains(&level), "level must be in [1, 16]");
@@ -21,6 +22,7 @@ pub fn hilbert_xy_to_index(level: u32, x: u32, y: u32) -> u32 {
 ///
 /// Use [`hilbert_curve_params_from_bounds`] to compute `shift` and `num_bits`
 /// from global min/max coordinates.
+#[cfg(any(feature = "sort-coords-iter", test))]
 #[must_use]
 pub fn hilbert_sort_key(x: i32, y: i32, shift: u32, num_bits: u32) -> u32 {
     debug_assert!((1..=16).contains(&num_bits));
@@ -50,6 +52,7 @@ pub fn hilbert_sort_key(x: i32, y: i32, shift: u32, num_bits: u32) -> u32 {
 ///   shifted values fit in `[0, 2^l)`.
 ///
 /// If `min > max` (empty input), returns `(0, 1)`.
+#[cfg(any(feature = "sort-coords-iter", test))]
 #[must_use]
 pub fn hilbert_curve_params_from_bounds(min_val: i32, max_val: i32) -> (u32, u32) {
     if min_val > max_val {

--- a/rust/mlt-core/src/codecs/hilbert.rs
+++ b/rust/mlt-core/src/codecs/hilbert.rs
@@ -19,8 +19,8 @@ pub fn hilbert_xy_to_index(level: u32, x: u32, y: u32) -> u32 {
 /// per-axis).  `num_bits` is the grid level — both shifted components must
 /// fit in `[0, 2^num_bits)`.
 ///
-/// Use [`hilbert_curve_params`] to compute `shift` and `num_bits` from a
-/// vertex buffer in one pass.
+/// Use [`hilbert_curve_params_from_bounds`] to compute `shift` and `num_bits`
+/// from global min/max coordinates.
 #[must_use]
 pub fn hilbert_sort_key(x: i32, y: i32, shift: u32, num_bits: u32) -> u32 {
     debug_assert!((1..=16).contains(&num_bits));
@@ -39,8 +39,8 @@ pub fn hilbert_sort_key(x: i32, y: i32, shift: u32, num_bits: u32) -> u32 {
     hilbert_xy_to_index(num_bits, sx, sy)
 }
 
-/// Compute the coordinate shift and grid level needed for Hilbert curve
-/// sorting over a flat interleaved `[x0, y0, x1, y1, …]` vertex buffer.
+/// Compute the coordinate shift and grid level from pre-computed global
+/// min/max values across all vertex coordinates (both axes combined).
 ///
 /// Returns `(shift, num_bits)` where:
 /// - `shift` is subtracted from the global minimum (i.e. it equals
@@ -49,21 +49,12 @@ pub fn hilbert_sort_key(x: i32, y: i32, shift: u32, num_bits: u32) -> u32 {
 /// - `num_bits` is the smallest level `l` in `[1, 16]` such that all
 ///   shifted values fit in `[0, 2^l)`.
 ///
-/// Matches the semantics of Java's `SpaceFillingCurve` constructor: a single
-/// shared shift is used for both axes so that the bounding box maps to a
-/// square grid.
+/// If `min > max` (empty input), returns `(0, 1)`.
 #[must_use]
-pub fn hilbert_curve_params(vertices: &[i32]) -> (u32, u32) {
-    if vertices.is_empty() {
+pub fn hilbert_curve_params_from_bounds(min_val: i32, max_val: i32) -> (u32, u32) {
+    if min_val > max_val {
         return (0, 1);
     }
-    let (min_val, max_val) = vertices
-        .iter()
-        .copied()
-        .fold((i32::MAX, i32::MIN), |(min_v, max_v), v| {
-            (min_v.min(v), max_v.max(v))
-        });
-
     let shift: u32 = if min_val < 0 {
         min_val.unsigned_abs()
     } else {
@@ -98,8 +89,6 @@ mod tests {
         debug_assert!(u64::from(pos) < (1u64 << (2 * level)), "pos out of range");
         hilbert_2d::u32::h2xy_discrete(pos, level, hilbert_2d::Variant::Hilbert)
     }
-
-    // ── Hilbert encode/decode ─────────────────────────────────────────────────
 
     #[test]
     fn hilbert_origin_always_zero() {
@@ -192,7 +181,7 @@ mod tests {
 
     #[test]
     fn hilbert_sort_key_negative_coords_shift_correctly() {
-        // (-1, -1) shifted by 1 maps to (0, 0) → Hilbert index 0 at any level.
+        // (-1, -1) shifted by 1 maps to (0, 0) -> Hilbert index 0 at any level.
         assert_eq!(hilbert_sort_key(-1, -1, 1, 1), 0);
     }
 
@@ -215,60 +204,58 @@ mod tests {
         }
     }
 
-    // ── hilbert_curve_params ──────────────────────────────────────────────────
-
     #[test]
-    fn hilbert_curve_params_empty_vertices() {
-        let (shift, num_bits) = hilbert_curve_params(&[]);
+    fn curve_params_empty_bounds() {
+        // min > max signals empty input.
+        let (shift, num_bits) = hilbert_curve_params_from_bounds(i32::MAX, i32::MIN);
         assert_eq!(shift, 0);
         assert_eq!(num_bits, 1);
     }
 
     #[test]
-    fn hilbert_curve_params_all_zero() {
-        let (shift, num_bits) = hilbert_curve_params(&[0, 0, 0, 0]);
+    fn curve_params_all_zero() {
+        // Degenerate: single point at origin, extent = 0 -> level 1.
+        let (shift, num_bits) = hilbert_curve_params_from_bounds(0, 0);
         assert_eq!(shift, 0);
-        assert_eq!(num_bits, 1); // degenerate: extent = 0 → level 1
+        assert_eq!(num_bits, 1);
     }
 
     #[test]
-    fn hilbert_curve_params_positive_only() {
-        // Vertices at (0,0), (3,3): max = 3, shift = 0, num_bits = 2 (2^2=4 > 3).
-        let (shift, num_bits) = hilbert_curve_params(&[0, 0, 3, 3]);
+    fn curve_params_positive_only() {
+        // Bounds [0, 3]: shift = 0, num_bits = 2 (2^2=4 > 3).
+        let (shift, num_bits) = hilbert_curve_params_from_bounds(0, 3);
         assert_eq!(shift, 0);
         assert_eq!(num_bits, 2);
     }
 
     #[test]
-    fn hilbert_curve_params_negative_min() {
-        // Vertices spanning [-4, 4]: shift = 4, extent = 4+4 = 8,
-        // num_bits = 4 (2^4=16 > 8).
-        let (shift, num_bits) = hilbert_curve_params(&[-4, -4, 4, 4]);
+    fn curve_params_negative_min() {
+        // Bounds [-4, 4]: shift = 4, extent = 4+4 = 8, num_bits = 4 (2^4=16 > 8).
+        let (shift, num_bits) = hilbert_curve_params_from_bounds(-4, 4);
         assert_eq!(shift, 4);
         assert_eq!(num_bits, 4);
     }
 
     #[test]
-    fn hilbert_curve_params_power_of_two_extent() {
+    fn curve_params_power_of_two_extent() {
         // extent = 8 = 2^3: need level 4 so that 2^4 = 16 > 8.
-        let (shift, num_bits) = hilbert_curve_params(&[0, 0, 8, 8]);
+        let (shift, num_bits) = hilbert_curve_params_from_bounds(0, 8);
         assert_eq!(shift, 0);
         assert_eq!(num_bits, 4);
     }
 
     #[test]
-    fn hilbert_curve_params_single_axis_negative() {
-        // min across all values (x and y interleaved): -2 and 0, max 5.
-        // Global min = -2 → shift = 2; extent = 5 + 2 = 7; num_bits = 3.
-        let (shift, num_bits) = hilbert_curve_params(&[-2, 0, 5, 3]);
+    fn curve_params_single_axis_negative() {
+        // Global min = -2 -> shift = 2; extent = 5 + 2 = 7; num_bits = 3.
+        let (shift, num_bits) = hilbert_curve_params_from_bounds(-2, 5);
         assert_eq!(shift, 2);
         assert_eq!(num_bits, 3);
     }
 
     #[test]
-    fn hilbert_curve_params_clamped_at_16_bits() {
-        // A coordinate of 65535 = 2^16 - 1: extent = 65535, num_bits = 16.
-        let (shift, num_bits) = hilbert_curve_params(&[0, 0, 65535, 65535]);
+    fn curve_params_clamped_at_16_bits() {
+        // extent = 65535 = 2^16 - 1, num_bits = 16.
+        let (shift, num_bits) = hilbert_curve_params_from_bounds(0, 65535);
         assert_eq!(shift, 0);
         assert_eq!(num_bits, 16);
     }

--- a/rust/mlt-core/src/codecs/morton.rs
+++ b/rust/mlt-core/src/codecs/morton.rs
@@ -12,6 +12,7 @@ const LANES: usize = 8;
 /// Even bit positions (0, 2, 4, …) encode `x`; odd positions (1, 3, 5, …)
 /// encode `y`. Spatially adjacent `(x, y)` pairs produce numerically
 /// adjacent codes, giving Z-order locality when used as a sort key.
+#[cfg(any(feature = "sort-coords-iter", test))]
 #[must_use]
 pub fn interleave_bits(x: u32, y: u32) -> u32 {
     // Spread each input's lower 16 bits into every other bit position, then
@@ -42,6 +43,7 @@ pub fn interleave_bits(x: u32, y: u32) -> u32 {
 /// Each shifted component is truncated to 16 bits before interleaving, so
 /// the returned key fits in a `u32` (32 interleaved bits). This is
 /// sufficient for any tile coordinate system with extent ≤ 65 535.
+#[cfg(any(feature = "sort-coords-iter", test))]
 #[must_use]
 pub fn morton_sort_key(x: i32, y: i32, shift: u32, num_bits: u32) -> u32 {
     debug_assert!((1..=16).contains(&num_bits));

--- a/rust/mlt-core/src/encoder/mod.rs
+++ b/rust/mlt-core/src/encoder/mod.rs
@@ -32,7 +32,8 @@ pub(crate) use property::*;
 #[cfg(feature = "__private")]
 pub use property::{StagedProperty, StagedSharedDict};
 pub use sort::SortStrategy;
-pub(crate) use sort::*;
+#[cfg(feature = "sort-coords-iter")]
+pub(crate) use sort::spatial_sort_likely_to_help;
 pub(crate) use stream::*;
 #[cfg(feature = "__private")]
 pub use stream::{IntEncoder, LogicalEncoder, PhysicalEncoder};

--- a/rust/mlt-core/src/encoder/optimizer.rs
+++ b/rust/mlt-core/src/encoder/optimizer.rs
@@ -2,9 +2,9 @@ use crate::MltResult;
 use crate::decoder::TileLayer01;
 use crate::encoder::model::{StagedLayer, StagedLayer01};
 use crate::encoder::property::encode::write_properties;
-use crate::encoder::{
-    Encoder, EncoderConfig, SortStrategy, group_string_properties, spatial_sort_likely_to_help,
-};
+#[cfg(feature = "sort-coords-iter")]
+use crate::encoder::spatial_sort_likely_to_help;
+use crate::encoder::{Encoder, EncoderConfig, SortStrategy, group_string_properties};
 
 impl StagedLayer {
     /// Automatically encode and write `self` to `enc`.
@@ -47,6 +47,7 @@ impl StagedLayer01 {
 
 /// Feature-count threshold above which the spatial trial is subject to the
 /// bounding-box pruning heuristic.
+#[cfg(feature = "sort-coords-iter")]
 const SORT_TRIAL_THRESHOLD: usize = 512;
 
 impl TileLayer01 {
@@ -66,15 +67,19 @@ impl TileLayer01 {
         }
 
         let mut sort_by = vec![SortStrategy::Unsorted];
-        let try_spatial_sort = cfg.try_spatial_morton_sort || cfg.try_spatial_hilbert_sort;
-        if try_spatial_sort
-            && (self.features.len() < SORT_TRIAL_THRESHOLD || spatial_sort_likely_to_help(&self))
+        #[cfg(feature = "sort-coords-iter")]
         {
-            if cfg.try_spatial_morton_sort {
-                sort_by.push(SortStrategy::SpatialMorton);
-            }
-            if cfg.try_spatial_hilbert_sort {
-                sort_by.push(SortStrategy::SpatialHilbert);
+            let try_spatial_sort = cfg.try_spatial_morton_sort || cfg.try_spatial_hilbert_sort;
+            if try_spatial_sort
+                && (self.features.len() < SORT_TRIAL_THRESHOLD
+                    || spatial_sort_likely_to_help(&self))
+            {
+                if cfg.try_spatial_morton_sort {
+                    sort_by.push(SortStrategy::SpatialMorton);
+                }
+                if cfg.try_spatial_hilbert_sort {
+                    sort_by.push(SortStrategy::SpatialHilbert);
+                }
             }
         }
         if cfg.try_id_sort {

--- a/rust/mlt-core/src/encoder/sort.rs
+++ b/rust/mlt-core/src/encoder/sort.rs
@@ -9,9 +9,9 @@ use crate::codecs::hilbert::hilbert_curve_params_from_bounds;
 use crate::codecs::hilbert::hilbert_sort_key;
 #[cfg(feature = "sort-coords-iter")]
 use crate::codecs::morton::morton_sort_key;
-use crate::decoder::TileLayer01;
 #[cfg(feature = "sort-coords-iter")]
 use crate::decoder::TileFeature;
+use crate::decoder::TileLayer01;
 #[cfg(feature = "sort-coords-iter")]
 use crate::geojson::Geom32;
 

--- a/rust/mlt-core/src/encoder/sort.rs
+++ b/rust/mlt-core/src/encoder/sort.rs
@@ -1,11 +1,8 @@
-//! Feature reordering for the optimizer.
-//!
-//! All sorting operates on [`TileLayer01`] — the row-oriented working form
-//! that the optimizer uses.  A sort is a single `Vec::sort_by_cached_key`
-//! call; there is no permutation machinery, no column-by-column scatter, and
-//! no encoded/decoded conversions inside this module.
+//! Feature reordering for the optimizer
 
-use crate::codecs::hilbert::{hilbert_curve_params, hilbert_sort_key};
+use geo::CoordsIter as _;
+
+use crate::codecs::hilbert::{hilbert_curve_params_from_bounds, hilbert_sort_key};
 use crate::codecs::morton::morton_sort_key;
 use crate::decoder::{TileFeature, TileLayer01};
 use crate::geojson::Geom32;
@@ -78,84 +75,17 @@ struct CurveParams {
     num_bits: u32,
 }
 
-/// Collect all vertex coordinates from `features` and compute the Hilbert/Morton
-/// curve parameters (coordinate shift and the bit width).
+/// Compute the Hilbert/Morton curve parameters from all vertex coordinates
+/// in `features` without allocating a temporary vertex buffer.
 fn curve_params_from_features(features: &[TileFeature]) -> CurveParams {
-    // Collect a flat `[x0, y0, x1, y1, …]` vertex array from all features,
-    // then reuse the existing `hilbert_curve_params` utility.
-    let verts: Vec<i32> = features
+    let (min_val, max_val) = features
         .iter()
-        .flat_map(|f| geom_vertices(&f.geometry))
-        .collect();
-
-    let (shift, num_bits) = hilbert_curve_params(&verts);
+        .flat_map(|f| f.geometry.coords_iter())
+        .fold((i32::MAX, i32::MIN), |(min, max), c| {
+            (min.min(c.x).min(c.y), max.max(c.x).max(c.y))
+        });
+    let (shift, num_bits) = hilbert_curve_params_from_bounds(min_val, max_val);
     CurveParams { shift, num_bits }
-}
-
-/// Flatten a geometry into its raw vertex sequence as `[x0, y0, x1, y1, …]`.
-fn geom_vertices(geom: &Geom32) -> Vec<i32> {
-    let mut out = Vec::new();
-    push_geom_vertices(geom, &mut out);
-    out
-}
-
-fn push_geom_vertices(geom: &Geom32, out: &mut Vec<i32>) {
-    match geom {
-        Geom32::Point(p) => {
-            out.push(p.0.x);
-            out.push(p.0.y);
-        }
-        Geom32::Line(l) => {
-            out.extend([l.start.x, l.start.y, l.end.x, l.end.y]);
-        }
-        Geom32::LineString(ls) => {
-            for c in &ls.0 {
-                out.push(c.x);
-                out.push(c.y);
-            }
-        }
-        Geom32::Polygon(p) => {
-            for c in &p.exterior().0 {
-                out.push(c.x);
-                out.push(c.y);
-            }
-        }
-        Geom32::MultiPoint(mp) => {
-            for p in &mp.0 {
-                out.push(p.0.x);
-                out.push(p.0.y);
-            }
-        }
-        Geom32::MultiLineString(mls) => {
-            for ls in &mls.0 {
-                for c in &ls.0 {
-                    out.push(c.x);
-                    out.push(c.y);
-                }
-            }
-        }
-        Geom32::MultiPolygon(mp) => {
-            for poly in &mp.0 {
-                for c in &poly.exterior().0 {
-                    out.push(c.x);
-                    out.push(c.y);
-                }
-            }
-        }
-        Geom32::Triangle(t) => {
-            out.extend([t.0.x, t.0.y, t.1.x, t.1.y, t.2.x, t.2.y]);
-        }
-        Geom32::Rect(r) => {
-            let min = r.min();
-            let max = r.max();
-            out.extend([min.x, min.y, max.x, max.y]);
-        }
-        Geom32::GeometryCollection(gc) => {
-            for g in gc {
-                push_geom_vertices(g, out);
-            }
-        }
-    }
 }
 
 /// Extract the `(x, y)` coordinate of the first vertex of a geometry.

--- a/rust/mlt-core/src/encoder/sort.rs
+++ b/rust/mlt-core/src/encoder/sort.rs
@@ -1,10 +1,18 @@
 //! Feature reordering for the optimizer
 
+#[cfg(feature = "sort-coords-iter")]
 use geo::CoordsIter as _;
 
-use crate::codecs::hilbert::{hilbert_curve_params_from_bounds, hilbert_sort_key};
+#[cfg(feature = "sort-coords-iter")]
+use crate::codecs::hilbert::hilbert_curve_params_from_bounds;
+#[cfg(feature = "sort-coords-iter")]
+use crate::codecs::hilbert::hilbert_sort_key;
+#[cfg(feature = "sort-coords-iter")]
 use crate::codecs::morton::morton_sort_key;
-use crate::decoder::{TileFeature, TileLayer01};
+use crate::decoder::TileLayer01;
+#[cfg(feature = "sort-coords-iter")]
+use crate::decoder::TileFeature;
+#[cfg(feature = "sort-coords-iter")]
 use crate::geojson::Geom32;
 
 /// Controls how features inside a layer are reordered before encoding.
@@ -25,11 +33,17 @@ pub enum SortStrategy {
     /// Fast to compute.  Spatially close features end up adjacent in the
     /// stream, improving RLE run lengths for location-correlated properties
     /// and CPU cache locality during client-side decoding.
+    ///
+    /// Requires the `sort-coords-iter` feature.
+    #[cfg(feature = "sort-coords-iter")]
     SpatialMorton,
 
     /// Sort features by the Hilbert curve index of their first vertex.
     ///
     /// Slower to compute than Morton but achieves superior spatial locality.
+    ///
+    /// Requires the `sort-coords-iter` feature.
+    #[cfg(feature = "sort-coords-iter")]
     SpatialHilbert,
 
     /// Sort features by their feature ID in ascending order.
@@ -44,6 +58,7 @@ impl TileLayer01 {
     #[hotpath::measure]
     pub fn sort(&mut self, strategy: SortStrategy) {
         match strategy {
+            #[cfg(feature = "sort-coords-iter")]
             SortStrategy::SpatialMorton | SortStrategy::SpatialHilbert => {
                 let params = curve_params_from_features(&self.features);
                 let curve_key = if let SortStrategy::SpatialMorton = strategy {
@@ -70,6 +85,7 @@ impl TileLayer01 {
 
 /// Parameters derived from the vertex set of a feature collection, used to
 /// normalize coordinates before space-filling-curve key computation.
+#[cfg(feature = "sort-coords-iter")]
 struct CurveParams {
     shift: u32,
     num_bits: u32,
@@ -77,6 +93,7 @@ struct CurveParams {
 
 /// Compute the Hilbert/Morton curve parameters from all vertex coordinates
 /// in `features` without allocating a temporary vertex buffer.
+#[cfg(feature = "sort-coords-iter")]
 fn curve_params_from_features(features: &[TileFeature]) -> CurveParams {
     let (min_val, max_val) = features
         .iter()
@@ -89,6 +106,7 @@ fn curve_params_from_features(features: &[TileFeature]) -> CurveParams {
 }
 
 /// Extract the `(x, y)` coordinate of the first vertex of a geometry.
+#[cfg(feature = "sort-coords-iter")]
 fn first_vertex(geom: &Geom32) -> Option<(i32, i32)> {
     match geom {
         Geom32::Point(p) => Some((p.0.x, p.0.y)),
@@ -116,6 +134,7 @@ fn first_vertex(geom: &Geom32) -> Option<(i32, i32)> {
 /// `SPATIAL_HELP_COVERAGE` of the layer's tile extent on **both** axes, the
 /// features are too spread-out for locality clustering to help, so spatial
 /// sorting is skipped.
+#[cfg(feature = "sort-coords-iter")]
 pub(crate) fn spatial_sort_likely_to_help(layer: &TileLayer01) -> bool {
     const SPATIAL_HELP_COVERAGE: f64 = 0.8;
 
@@ -329,6 +348,7 @@ mod tests {
 
     // ── spatial Morton sort ───────────────────────────────────────────────────
 
+    #[cfg(feature = "sort-coords-iter")]
     #[test]
     fn point_line_point_morton_sort_roundtrip() {
         assert_sort_roundtrip(
@@ -426,6 +446,7 @@ mod tests {
         geom.vertices().unwrap_or_default().to_vec()
     }
 
+    #[cfg(feature = "sort-coords-iter")]
     #[test]
     fn test_shared_morton_shift() {
         // P1 at (0, -10), P2 at (-10, 0).
@@ -455,6 +476,7 @@ mod tests {
         assert_eq!(verts, vec![1, 1, 0, 0, 2, 2]);
     }
 
+    #[cfg(feature = "sort-coords-iter")]
     #[test]
     fn test_mixed_geometry_morton_sort() {
         // [Point(2,0), LineString(0,0 -> 0,5), Point(1,0)]


### PR DESCRIPTION
Previous version was doing unnesary work, can be rustified