### PR TITLE
docs(rust) Fix broken doc links

### DIFF
--- a/rust/mlt-core/src/encoder/geometry/encode.rs
+++ b/rust/mlt-core/src/encoder/geometry/encode.rs
@@ -283,7 +283,7 @@ fn normalize_part_offsets_for_rings(
 /// - The uniqueness ratio is below the threshold, meaning enough vertices are
 ///   repeated that the dictionary overhead is worthwhile.
 ///
-/// Calls [`Encoder::get_z_order_params`] so the [`MortonMeta`] is cached on the encoder
+/// Calls `get_z_order_params` so the [`MortonMeta`] is cached on the encoder
 /// and can be retrieved again in the Morton encoding branch without a second vertex scan.
 #[hotpath::measure]
 fn select_vertex_strategy(vertices: &[i32], enc: &mut Encoder) -> VertexBufferType {

--- a/rust/mlt-core/src/encoder/writer.rs
+++ b/rust/mlt-core/src/encoder/writer.rs
@@ -117,8 +117,8 @@ pub struct Encoder {
     /// Regardless of the sort, these values should be identical
     pub(crate) vertex_buffer_type_cache: Option<VertexBufferType>,
 
-    /// Cached result of [`z_order_params`] for the geometry column currently
-    /// being encoded.  Cleared at the start of each [`GeometryValues::write_to`]
+    /// Cached result of `z_order_params` for the geometry column currently
+    /// being encoded.  Cleared at the start of each [`GeometryValues::write_to`](crate::encoder::GeometryValues::write_to)
     /// call so it never leaks across columns.
     pub(crate) morton_meta_cache: Option<MortonMeta>,
 


### PR DESCRIPTION
1. `z_order_params` is a private method, so we can't link to it.
2. `GeometryValues` is not in scope, so use an absolute path.