### PR TITLE
chore(just): Make system info less platform-dependent

### DIFF
--- a/rust/mod.just
+++ b/rust/mod.just
@@ -87,7 +87,7 @@ ci-env-info:
     echo "::endgroup::"
 
     # Linux
-    if [ command -v lscpu &>/dev/null ]; then
+    if command -v lscpu &>/dev/null; then
         echo "::group::lscpu"
         lscpu
         echo "::endgroup::"
@@ -99,7 +99,7 @@ ci-env-info:
     fi
 
     # MacOS
-    if [[ ! $(command -v sysctl &>/dev/null) && ! $(command -v egrep &>/dev/null) ]]; then
+    if command -v sysctl &>/dev/null && command -v egrep &>/dev/null; then
         echo "::group::sysctl"
         sysctl -a 2>/dev/null | egrep "^hw" || true # ignore permission denied to some sysctl entries
         echo "::endgroup::"

--- a/rust/mod.just
+++ b/rust/mod.just
@@ -72,25 +72,38 @@ ci-check: ci-env-info check
 
 # Print environment info for CI
 ci-env-info:
-    @echo "::group::General environment Information"
-    @echo "Running for '{{main_crate}}' crate {{if ci_mode == '1' {'in CI mode'} else {'in dev mode'} }} on {{os()}} / {{arch()}}"
-    @echo "PWD {{justfile_directory()}}"
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "::group::General environment Information"
+    echo "Running for '{{main_crate}}' crate {{if ci_mode == '1' {'in CI mode'} else {'in dev mode'} }} on {{os()}} / {{arch()}}"
+    echo "PWD {{justfile_directory()}}"
     {{just}} --version
     rustc --version
     cargo --version
     rustup --version
-    @echo "RUSTFLAGS='$RUSTFLAGS'"
-    @echo "RUSTDOCFLAGS='$RUSTDOCFLAGS'"
-    @echo "RUST_BACKTRACE='$RUST_BACKTRACE'"
-    @echo "::endgroup::"
+    echo "RUSTFLAGS='$RUSTFLAGS'"
+    echo "RUSTDOCFLAGS='$RUSTDOCFLAGS'"
+    echo "RUST_BACKTRACE='$RUST_BACKTRACE'"
+    echo "::endgroup::"
 
-    @echo "::group::lscpu"
-    lscpu
-    @echo "::endgroup::"
+    # Linux
+    if [ command -v lscpu &>/dev/null ]; then
+        echo "::group::lscpu"
+        lscpu
+        echo "::endgroup::"
+    fi
+    if [ -f /proc/cpuinfo ]; then
+        echo "::group::/proc/cpuinfo"
+        cat /proc/cpuinfo
+        echo "::endgroup::"
+    fi
 
-    @echo "::group::/proc/cpuinfo"
-    cat /proc/cpuinfo
-    @echo "::endgroup::"
+    # MacOS
+    if [[ ! $(command -v sysctl &>/dev/null) && ! $(command -v egrep &>/dev/null) ]]; then
+        echo "::group::sysctl"
+        sysctl -a | egrep "^hw"
+        echo "::endgroup::"
+    fi
 
 # Run linting as expected by CI
 ci-lint: ci-env-info test-fmt clippy

--- a/rust/mod.just
+++ b/rust/mod.just
@@ -101,7 +101,7 @@ ci-env-info:
     # MacOS
     if [[ ! $(command -v sysctl &>/dev/null) && ! $(command -v egrep &>/dev/null) ]]; then
         echo "::group::sysctl"
-        sysctl -a | egrep "^hw"
+        sysctl -a 2>/dev/null | egrep "^hw" || true # ignore permission denied to some sysctl entries
         echo "::endgroup::"
     fi
 


### PR DESCRIPTION
Handle no `lscpu` or `/proc/cpuinfo`, use `sysctl` instead, if present
