### PR TITLE
fix(rust): geo builds on wasm, remove unnecessary feature gates

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1451,7 +1451,6 @@ dependencies = [
  "approx",
  "arbitrary",
  "num-traits",
- "rayon",
  "rstar",
  "serde",
 ]
@@ -1913,7 +1912,6 @@ dependencies = [
  "i_key_sort",
  "i_shape",
  "i_tree",
- "rayon",
 ]
 
 [[package]]
@@ -2691,6 +2689,7 @@ dependencies = [
 name = "mlt-wasm"
 version = "0.1.4"
 dependencies = [
+ "getrandom 0.2.17",
  "js-sys",
  "mlt-core",
  "wasm-bindgen",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,7 +30,7 @@ fsst-rs = "0.5"
 futures = "0.3"
 geo = { version = "0.32.0", default-features = false }
 geo-types = "0.7.18"
-getrandom = { version = "0.2.17"}
+getrandom = { version = "0.2.17" }
 glob = "0.3"
 globset = "0.4"
 hex = "0.4.3"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,6 +30,7 @@ fsst-rs = "0.5"
 futures = "0.3"
 geo = { version = "0.32.0", default-features = false }
 geo-types = "0.7.18"
+getrandom = { version = "0.2.17"}
 glob = "0.3"
 globset = "0.4"
 hex = "0.4.3"
@@ -41,7 +42,7 @@ integer-encoding = "4.0.2"
 js-sys = "0.3"
 martin-tile-utils = "0.6"
 mbtiles = { version = "0.15", default-features = false }
-mlt-core = { version = "0.7.0", path = "mlt-core", default-features = false }  # TODO: rm default-features = false after geo 0.33+ is released
+mlt-core = { version = "0.7.0", path = "mlt-core" }
 mvt-reader = "2.3.0"
 num-traits = "0.2.19"
 num_enum = "0.7.6"

--- a/rust/mlt-core/Cargo.toml
+++ b/rust/mlt-core/Cargo.toml
@@ -37,15 +37,7 @@ harness = false
 required-features = ["__private"]
 
 [features]
-# Workaround until new WASM-compatible geo is released: both `tessellate` and
-# `sort-coords-iter` transitively depend on the `geo` crate, which does not
-# yet build on `wasm32-unknown-unknown`. Remove the feature gating once a
-# WASM-capable `geo` release is available.
-default = ["sort-coords-iter", "tessellate"]
-tessellate = ["dep:geo", "geo/earcutr", "geo/multithreading"]
-# Enables feature sort strategies (`SpatialMorton`, `SpatialHilbert`) which
-# use `geo::CoordsIter` for bounds computation. Disable on WASM.
-sort-coords-iter = ["dep:geo"]
+default = []
 arbitrary = ["dep:arbitrary", "geo-types/arbitrary"]
 # Used internally for testing and benchmarking, not intended for public use
 __private = []
@@ -56,8 +48,7 @@ bytemuck.workspace = true
 enum_dispatch.workspace = true
 fastpfor.workspace = true
 fsst-rs.workspace = true
-# Only used for tessellation; remove the `optional = true` once `geo` is WASM-capable.
-geo = { workspace = true, optional = true }
+geo = { workspace = true, features = ["earcutr"] }
 geo-types.workspace = true
 hex.workspace = true
 hilbert_2d.workspace = true

--- a/rust/mlt-core/src/codecs/hilbert.rs
+++ b/rust/mlt-core/src/codecs/hilbert.rs
@@ -3,7 +3,6 @@
 /// The grid has side `2^level`; both `x` and `y` must be in `[0, 2^level)`,
 /// and `level` must be in `[1, 16]`.  The returned index is in
 /// `[0, 4^level)` and fits in a `u32` for all valid levels.
-#[cfg(any(feature = "sort-coords-iter", test))]
 #[must_use]
 pub fn hilbert_xy_to_index(level: u32, x: u32, y: u32) -> u32 {
     debug_assert!((1..=16).contains(&level), "level must be in [1, 16]");
@@ -22,7 +21,6 @@ pub fn hilbert_xy_to_index(level: u32, x: u32, y: u32) -> u32 {
 ///
 /// Use [`hilbert_curve_params_from_bounds`] to compute `shift` and `num_bits`
 /// from global min/max coordinates.
-#[cfg(any(feature = "sort-coords-iter", test))]
 #[must_use]
 pub fn hilbert_sort_key(x: i32, y: i32, shift: u32, num_bits: u32) -> u32 {
     debug_assert!((1..=16).contains(&num_bits));
@@ -52,7 +50,6 @@ pub fn hilbert_sort_key(x: i32, y: i32, shift: u32, num_bits: u32) -> u32 {
 ///   shifted values fit in `[0, 2^l)`.
 ///
 /// If `min > max` (empty input), returns `(0, 1)`.
-#[cfg(any(feature = "sort-coords-iter", test))]
 #[must_use]
 pub fn hilbert_curve_params_from_bounds(min_val: i32, max_val: i32) -> (u32, u32) {
     if min_val > max_val {

--- a/rust/mlt-core/src/codecs/morton.rs
+++ b/rust/mlt-core/src/codecs/morton.rs
@@ -12,7 +12,6 @@ const LANES: usize = 8;
 /// Even bit positions (0, 2, 4, …) encode `x`; odd positions (1, 3, 5, …)
 /// encode `y`. Spatially adjacent `(x, y)` pairs produce numerically
 /// adjacent codes, giving Z-order locality when used as a sort key.
-#[cfg(any(feature = "sort-coords-iter", test))]
 #[must_use]
 pub fn interleave_bits(x: u32, y: u32) -> u32 {
     // Spread each input's lower 16 bits into every other bit position, then
@@ -43,7 +42,6 @@ pub fn interleave_bits(x: u32, y: u32) -> u32 {
 /// Each shifted component is truncated to 16 bits before interleaving, so
 /// the returned key fits in a `u32` (32 interleaved bits). This is
 /// sufficient for any tile coordinate system with extent ≤ 65 535.
-#[cfg(any(feature = "sort-coords-iter", test))]
 #[must_use]
 pub fn morton_sort_key(x: i32, y: i32, shift: u32, num_bits: u32) -> u32 {
     debug_assert!((1..=16).contains(&num_bits));

--- a/rust/mlt-core/src/encoder/geometry/geotype.rs
+++ b/rust/mlt-core/src/encoder/geometry/geotype.rs
@@ -1,5 +1,3 @@
-// geo crate is not supported with WASM until next version
-#[cfg(feature = "tessellate")]
 use geo::{Convert as _, TriangulateEarcut as _};
 use geo_types::{LineString, MultiLineString, MultiPoint, MultiPolygon, Polygon};
 
@@ -33,7 +31,6 @@ impl TryFrom<&Geom32> for GeometryType {
 /// Geo's earcut includes the closing vertex of each ring; MLT (and Java's `earcut4j`) omit it.
 /// Any index that would refer to a ring's closing vertex is remapped to that ring's start index,
 /// producing identical index buffers to Java.
-#[cfg(feature = "tessellate")]
 fn earcut_into(polygon: &Polygon<i32>, vertex_offset: u32, index_buf: &mut Vec<u32>) -> u32 {
     let polygon_f64: Polygon<f64> = polygon.convert();
     let raw = polygon_f64.earcut_triangles_raw();
@@ -98,16 +95,12 @@ impl GeometryValues {
     /// start index, producing identical index buffers to Java's `earcut4j`.
     ///
     /// The per-feature triangle count is pushed into `self.triangles`.
-    #[cfg(feature = "tessellate")]
     fn tessellate_polygon(&mut self, polygon: &Polygon<i32>) {
         if let Some(triangles) = self.triangles.as_mut() {
             let val = earcut_into(polygon, 0, self.index_buffer.get_or_insert_with(Vec::new));
             triangles.push(val);
         }
     }
-    #[cfg(not(feature = "tessellate"))]
-    #[allow(unused_variables, clippy::unused_self)]
-    fn tessellate_polygon(&mut self, polygon: &Polygon<i32>) {}
 
     /// Tessellate all polygons in `mp` and append the combined results into
     /// `self.index_buffer` and `self.triangles`.
@@ -116,7 +109,6 @@ impl GeometryValues {
     /// preceding polygons so they reference the correct positions in the shared vertex buffer.
     /// A single total triangle count (summed over all constituent polygons) is pushed into
     /// `self.triangles`.
-    #[cfg(feature = "tessellate")]
     fn tessellate_multi_polygon(&mut self, mp: &MultiPolygon<i32>) {
         if let Some(triangles) = self.triangles.as_mut() {
             let mut total_triangles = 0u32;
@@ -135,10 +127,6 @@ impl GeometryValues {
             triangles.push(total_triangles);
         }
     }
-
-    #[cfg(not(feature = "tessellate"))]
-    #[allow(unused_variables, clippy::unused_self)]
-    fn tessellate_multi_polygon(&mut self, _mp: &MultiPolygon<i32>) {}
 
     /// Add a geometry to this decoded geometry collection.
     /// This is the reverse of `to_geojson` - it converts a `Geom32`
@@ -649,53 +637,52 @@ mod tests {
         let geom = decoded.to_geojson(0).unwrap();
         assert_eq!(geom, wkt!(LINESTRING(0 0,4 0,0 4,4 0)).into());
     }
-}
 
-#[cfg(all(test, feature = "tessellate"))]
-mod tessellation_tests {
-    use geo_types::{LineString, MultiPolygon, Polygon};
+    mod tessellation_tests {
+        use geo_types::{LineString, MultiPolygon, Polygon};
 
-    use crate::decoder::GeometryValues;
-    use crate::geojson::Geom32;
+        use crate::decoder::GeometryValues;
+        use crate::geojson::Geom32;
 
-    #[test]
-    fn earcut_closing_vertex_index_remap() {
-        let exterior = LineString::from(vec![(0_i32, 0), (10, 0), (10, 10), (0, 10), (0, 0)]);
-        let polygon = Polygon::new(exterior, vec![]);
-        let mut g = GeometryValues::new_tessellated();
-        g.push_geom(&Geom32::Polygon(polygon));
-        let tris = g.triangles().expect("triangles");
-        let n = tris[0];
-        assert!(n > 0, "expected at least one triangle");
-        let ib = g.index_buffer().expect("index buffer");
-        assert_eq!(ib.len(), usize::try_from(n).unwrap() * 3);
-        // 4 unique (non-closing) vertices → indices in 0..4
-        assert!(ib.iter().all(|&i| i < 4));
-    }
+        #[test]
+        fn earcut_closing_vertex_index_remap() {
+            let exterior = LineString::from(vec![(0_i32, 0), (10, 0), (10, 10), (0, 10), (0, 0)]);
+            let polygon = Polygon::new(exterior, vec![]);
+            let mut g = GeometryValues::new_tessellated();
+            g.push_geom(&Geom32::Polygon(polygon));
+            let tris = g.triangles().expect("triangles");
+            let n = tris[0];
+            assert!(n > 0, "expected at least one triangle");
+            let ib = g.index_buffer().expect("index buffer");
+            assert_eq!(ib.len(), usize::try_from(n).unwrap() * 3);
+            // 4 unique (non-closing) vertices → indices in 0..4
+            assert!(ib.iter().all(|&i| i < 4));
+        }
 
-    #[test]
-    fn earcut_vertex_offset_for_multi_polygon_parts() {
-        let exterior1 = LineString::from(vec![(0_i32, 0), (10, 0), (10, 10), (0, 10), (0, 0)]);
-        let poly1 = Polygon::new(exterior1, vec![]);
-        let exterior2 = LineString::from(vec![(20, 0), (30, 0), (30, 10), (20, 10), (20, 0)]);
-        let poly2 = Polygon::new(exterior2, vec![]);
-        let mut g = GeometryValues::new_tessellated();
-        g.push_geom(&Geom32::MultiPolygon(MultiPolygon(vec![poly1, poly2])));
-        let ib = g.index_buffer().expect("index buffer");
-        let tris = g.triangles().expect("triangles");
-        assert_eq!(tris.len(), 1);
-        let total = usize::try_from(tris[0]).unwrap();
-        assert_eq!(ib.len(), total * 3);
-        // First quad: 4 verts → 2 triangles, 6 indices
-        let split = 6;
-        let (first, second) = ib.split_at(split);
-        assert!(
-            first.iter().all(|&i| i < 4),
-            "first polygon indices should reference verts 0..4: {first:?}"
-        );
-        assert!(
-            second.iter().all(|&i| (4..8).contains(&i)),
-            "second polygon indices should reference verts 4..8: {second:?}"
-        );
+        #[test]
+        fn earcut_vertex_offset_for_multi_polygon_parts() {
+            let exterior1 = LineString::from(vec![(0_i32, 0), (10, 0), (10, 10), (0, 10), (0, 0)]);
+            let poly1 = Polygon::new(exterior1, vec![]);
+            let exterior2 = LineString::from(vec![(20, 0), (30, 0), (30, 10), (20, 10), (20, 0)]);
+            let poly2 = Polygon::new(exterior2, vec![]);
+            let mut g = GeometryValues::new_tessellated();
+            g.push_geom(&Geom32::MultiPolygon(MultiPolygon(vec![poly1, poly2])));
+            let ib = g.index_buffer().expect("index buffer");
+            let tris = g.triangles().expect("triangles");
+            assert_eq!(tris.len(), 1);
+            let total = usize::try_from(tris[0]).unwrap();
+            assert_eq!(ib.len(), total * 3);
+            // First quad: 4 verts → 2 triangles, 6 indices
+            let split = 6;
+            let (first, second) = ib.split_at(split);
+            assert!(
+                first.iter().all(|&i| i < 4),
+                "first polygon indices should reference verts 0..4: {first:?}"
+            );
+            assert!(
+                second.iter().all(|&i| (4..8).contains(&i)),
+                "second polygon indices should reference verts 4..8: {second:?}"
+            );
+        }
     }
 }

--- a/rust/mlt-core/src/encoder/mod.rs
+++ b/rust/mlt-core/src/encoder/mod.rs
@@ -32,7 +32,6 @@ pub(crate) use property::*;
 #[cfg(feature = "__private")]
 pub use property::{StagedProperty, StagedSharedDict};
 pub use sort::SortStrategy;
-#[cfg(feature = "sort-coords-iter")]
 pub(crate) use sort::spatial_sort_likely_to_help;
 pub(crate) use stream::*;
 #[cfg(feature = "__private")]

--- a/rust/mlt-core/src/encoder/optimizer.rs
+++ b/rust/mlt-core/src/encoder/optimizer.rs
@@ -65,19 +65,6 @@ impl TileLayer01 {
         }
 
         let mut sort_by = vec![SortStrategy::Unsorted];
-        {
-            let try_spatial_sort = cfg.try_spatial_morton_sort || cfg.try_spatial_hilbert_sort;
-            if try_spatial_sort
-                && (self.features.len() < SORT_TRIAL_THRESHOLD
-                    || spatial_sort_likely_to_help(&self))
-            {
-                if cfg.try_spatial_morton_sort {
-                    sort_by.push(SortStrategy::SpatialMorton);
-                }
-                if cfg.try_spatial_hilbert_sort {
-                    sort_by.push(SortStrategy::SpatialHilbert);
-                }
-            }
 let try_spatial_sort = cfg.try_spatial_morton_sort || cfg.try_spatial_hilbert_sort;
 if try_spatial_sort
 && (self.features.len() < SORT_TRIAL_THRESHOLD

--- a/rust/mlt-core/src/encoder/optimizer.rs
+++ b/rust/mlt-core/src/encoder/optimizer.rs
@@ -65,18 +65,17 @@ impl TileLayer01 {
         }
 
         let mut sort_by = vec![SortStrategy::Unsorted];
-let try_spatial_sort = cfg.try_spatial_morton_sort || cfg.try_spatial_hilbert_sort;
-if try_spatial_sort
-&& (self.features.len() < SORT_TRIAL_THRESHOLD
-|| spatial_sort_likely_to_help(&self))
-{
-if cfg.try_spatial_morton_sort {
-sort_by.push(SortStrategy::SpatialMorton);
-}
-if cfg.try_spatial_hilbert_sort {
-sort_by.push(SortStrategy::SpatialHilbert);
-}
-}
+        let try_spatial_sort = cfg.try_spatial_morton_sort || cfg.try_spatial_hilbert_sort;
+        if try_spatial_sort
+            && (self.features.len() < SORT_TRIAL_THRESHOLD || spatial_sort_likely_to_help(&self))
+        {
+            if cfg.try_spatial_morton_sort {
+                sort_by.push(SortStrategy::SpatialMorton);
+            }
+            if cfg.try_spatial_hilbert_sort {
+                sort_by.push(SortStrategy::SpatialHilbert);
+            }
+        }
         if cfg.try_id_sort {
             sort_by.push(SortStrategy::Id);
         }

--- a/rust/mlt-core/src/encoder/optimizer.rs
+++ b/rust/mlt-core/src/encoder/optimizer.rs
@@ -78,7 +78,18 @@ impl TileLayer01 {
                     sort_by.push(SortStrategy::SpatialHilbert);
                 }
             }
-        }
+let try_spatial_sort = cfg.try_spatial_morton_sort || cfg.try_spatial_hilbert_sort;
+if try_spatial_sort
+&& (self.features.len() < SORT_TRIAL_THRESHOLD
+|| spatial_sort_likely_to_help(&self))
+{
+if cfg.try_spatial_morton_sort {
+sort_by.push(SortStrategy::SpatialMorton);
+}
+if cfg.try_spatial_hilbert_sort {
+sort_by.push(SortStrategy::SpatialHilbert);
+}
+}
         if cfg.try_id_sort {
             sort_by.push(SortStrategy::Id);
         }

--- a/rust/mlt-core/src/encoder/optimizer.rs
+++ b/rust/mlt-core/src/encoder/optimizer.rs
@@ -2,7 +2,6 @@ use crate::MltResult;
 use crate::decoder::TileLayer01;
 use crate::encoder::model::{StagedLayer, StagedLayer01};
 use crate::encoder::property::encode::write_properties;
-#[cfg(feature = "sort-coords-iter")]
 use crate::encoder::spatial_sort_likely_to_help;
 use crate::encoder::{Encoder, EncoderConfig, SortStrategy, group_string_properties};
 
@@ -47,7 +46,6 @@ impl StagedLayer01 {
 
 /// Feature-count threshold above which the spatial trial is subject to the
 /// bounding-box pruning heuristic.
-#[cfg(feature = "sort-coords-iter")]
 const SORT_TRIAL_THRESHOLD: usize = 512;
 
 impl TileLayer01 {
@@ -67,7 +65,6 @@ impl TileLayer01 {
         }
 
         let mut sort_by = vec![SortStrategy::Unsorted];
-        #[cfg(feature = "sort-coords-iter")]
         {
             let try_spatial_sort = cfg.try_spatial_morton_sort || cfg.try_spatial_hilbert_sort;
             if try_spatial_sort

--- a/rust/mlt-core/src/encoder/sort.rs
+++ b/rust/mlt-core/src/encoder/sort.rs
@@ -1,18 +1,10 @@
 //! Feature reordering for the optimizer
 
-#[cfg(feature = "sort-coords-iter")]
 use geo::CoordsIter as _;
 
-#[cfg(feature = "sort-coords-iter")]
-use crate::codecs::hilbert::hilbert_curve_params_from_bounds;
-#[cfg(feature = "sort-coords-iter")]
-use crate::codecs::hilbert::hilbert_sort_key;
-#[cfg(feature = "sort-coords-iter")]
+use crate::codecs::hilbert::{hilbert_curve_params_from_bounds, hilbert_sort_key};
 use crate::codecs::morton::morton_sort_key;
-#[cfg(feature = "sort-coords-iter")]
-use crate::decoder::TileFeature;
-use crate::decoder::TileLayer01;
-#[cfg(feature = "sort-coords-iter")]
+use crate::decoder::{TileFeature, TileLayer01};
 use crate::geojson::Geom32;
 
 /// Controls how features inside a layer are reordered before encoding.
@@ -34,16 +26,11 @@ pub enum SortStrategy {
     /// stream, improving RLE run lengths for location-correlated properties
     /// and CPU cache locality during client-side decoding.
     ///
-    /// Requires the `sort-coords-iter` feature.
-    #[cfg(feature = "sort-coords-iter")]
     SpatialMorton,
 
     /// Sort features by the Hilbert curve index of their first vertex.
     ///
     /// Slower to compute than Morton but achieves superior spatial locality.
-    ///
-    /// Requires the `sort-coords-iter` feature.
-    #[cfg(feature = "sort-coords-iter")]
     SpatialHilbert,
 
     /// Sort features by their feature ID in ascending order.
@@ -58,7 +45,6 @@ impl TileLayer01 {
     #[hotpath::measure]
     pub fn sort(&mut self, strategy: SortStrategy) {
         match strategy {
-            #[cfg(feature = "sort-coords-iter")]
             SortStrategy::SpatialMorton | SortStrategy::SpatialHilbert => {
                 let params = curve_params_from_features(&self.features);
                 let curve_key = if let SortStrategy::SpatialMorton = strategy {
@@ -85,7 +71,6 @@ impl TileLayer01 {
 
 /// Parameters derived from the vertex set of a feature collection, used to
 /// normalize coordinates before space-filling-curve key computation.
-#[cfg(feature = "sort-coords-iter")]
 struct CurveParams {
     shift: u32,
     num_bits: u32,
@@ -93,7 +78,6 @@ struct CurveParams {
 
 /// Compute the Hilbert/Morton curve parameters from all vertex coordinates
 /// in `features` without allocating a temporary vertex buffer.
-#[cfg(feature = "sort-coords-iter")]
 fn curve_params_from_features(features: &[TileFeature]) -> CurveParams {
     let (min_val, max_val) = features
         .iter()
@@ -106,7 +90,6 @@ fn curve_params_from_features(features: &[TileFeature]) -> CurveParams {
 }
 
 /// Extract the `(x, y)` coordinate of the first vertex of a geometry.
-#[cfg(feature = "sort-coords-iter")]
 fn first_vertex(geom: &Geom32) -> Option<(i32, i32)> {
     match geom {
         Geom32::Point(p) => Some((p.0.x, p.0.y)),
@@ -134,7 +117,6 @@ fn first_vertex(geom: &Geom32) -> Option<(i32, i32)> {
 /// `SPATIAL_HELP_COVERAGE` of the layer's tile extent on **both** axes, the
 /// features are too spread-out for locality clustering to help, so spatial
 /// sorting is skipped.
-#[cfg(feature = "sort-coords-iter")]
 pub(crate) fn spatial_sort_likely_to_help(layer: &TileLayer01) -> bool {
     const SPATIAL_HELP_COVERAGE: f64 = 0.8;
 
@@ -348,7 +330,6 @@ mod tests {
 
     // ── spatial Morton sort ───────────────────────────────────────────────────
 
-    #[cfg(feature = "sort-coords-iter")]
     #[test]
     fn point_line_point_morton_sort_roundtrip() {
         assert_sort_roundtrip(
@@ -446,7 +427,6 @@ mod tests {
         geom.vertices().unwrap_or_default().to_vec()
     }
 
-    #[cfg(feature = "sort-coords-iter")]
     #[test]
     fn test_shared_morton_shift() {
         // P1 at (0, -10), P2 at (-10, 0).
@@ -476,7 +456,6 @@ mod tests {
         assert_eq!(verts, vec![1, 1, 0, 0, 2, 2]);
     }
 
-    #[cfg(feature = "sort-coords-iter")]
     #[test]
     fn test_mixed_geometry_morton_sort() {
         // [Point(2,0), LineString(0,0 -> 0,5), Point(1,0)]

--- a/rust/mlt-synthetics/Cargo.toml
+++ b/rust/mlt-synthetics/Cargo.toml
@@ -14,7 +14,6 @@ publish = false
 [dependencies]
 clap.workspace = true
 geo-types.workspace = true
-# Workspace pins mlt-core with default-features = false; synthetics need Earcut.
 mlt-core = { workspace = true, features = ["__private"] }
 serde_json.workspace = true
 thiserror.workspace = true

--- a/rust/mlt-synthetics/Cargo.toml
+++ b/rust/mlt-synthetics/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 clap.workspace = true
 geo-types.workspace = true
 # Workspace pins mlt-core with default-features = false; synthetics need Earcut.
-mlt-core = { workspace = true, features = ["tessellate", "__private"] }
+mlt-core = { workspace = true, features = ["__private"] }
 serde_json.workspace = true
 thiserror.workspace = true
 

--- a/rust/mlt-wasm/Cargo.toml
+++ b/rust/mlt-wasm/Cargo.toml
@@ -19,8 +19,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 js-sys.workspace = true
-# Once geo supports wasm, use default mlt-core
-mlt-core = { workspace = true, default-features = false }
+mlt-core = { workspace = true }
+getrandom = { version = "0.2.17", features = ["js"] }
 wasm-bindgen.workspace = true
 
 [lints]

--- a/rust/mlt-wasm/Cargo.toml
+++ b/rust/mlt-wasm/Cargo.toml
@@ -18,7 +18,7 @@ wasm-opt = ["-O3", "--enable-simd", "--enable-bulk-memory"]
 crate-type = ["cdylib"]
 
 [dependencies]
-getrandom = { version = "0.2.17", features = ["js"] }
+getrandom = { workspace = true, features = ["js"] }
 js-sys.workspace = true
 mlt-core = { workspace = true }
 wasm-bindgen.workspace = true

--- a/rust/mlt-wasm/Cargo.toml
+++ b/rust/mlt-wasm/Cargo.toml
@@ -18,9 +18,9 @@ wasm-opt = ["-O3", "--enable-simd", "--enable-bulk-memory"]
 crate-type = ["cdylib"]
 
 [dependencies]
+getrandom = { version = "0.2.17", features = ["js"] }
 js-sys.workspace = true
 mlt-core = { workspace = true }
-getrandom = { version = "0.2.17", features = ["js"] }
 wasm-bindgen.workspace = true
 
 [lints]


### PR DESCRIPTION
I was reviewing the `geo` usage and noticed some comments about geo not building on wasm. 

> Note that geo crate is not WASM compatible until next release, so had to workaround it

The next release will happen soon, but the current version of `geo` also builds on wasm. 

I wonder if you were hitting https://github.com/georust/geo/pull/1476 ?

If so, the issue is that the maintainers of `rand` expect wasm clients using the `rand` crate to explicitly depend on `getrandom` for their leaf (binary/application) crates. 

For context, see:
https://github.com/rust-random/rand/issues/886?issue=rust-random%7Crand%7C1694

I assume (correct me if Im wrong) that this build issue was why the `mlt-core/tessellate` and `mlt-core/sort-coords-iter` feature flags were introduced, so I've also removed those and made `geo` mandatory. 

Let me know if I'm misunderstanding the situation, or if there's some other way to see the specific error message you're getting when trying to build for wasm.