### PR TITLE
refactor(rust): update geo, simplify tessellation

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1032,12 +1032,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "earcutr"
-version = "0.4.3"
+name = "earcut"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79127ed59a85d7687c409e9978547cffb7dc79675355ed22da6b66fd5f6ead01"
+checksum = "88459a2a8e3a514b6e6de38cf3aaa9250a894cb098f74a932db77fcc8341b6d0"
 dependencies = [
- "itertools 0.11.0",
  "num-traits",
 ]
 
@@ -1230,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "float_next_after"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+checksum = "37007738a80ea34f969af54a3390dd72cacdef654974cfd449c9f6f72dbaac10"
 
 [[package]]
 name = "flume"
@@ -1425,18 +1424,19 @@ dependencies = [
 
 [[package]]
 name = "geo"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3901269ec6d4f6068d3f09e5f02f995bd076398dcd1dfec407cd230b02d11b"
+checksum = "d1f7044733d8570f68c486cd200318322c09a3f123893ae8cfd1543dd0ea3185"
 dependencies = [
- "earcutr",
+ "earcut",
  "float_next_after",
  "geo-types",
  "geographiclib-rs",
  "i_overlay",
  "log",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.10.1",
+ "rand_pcg",
  "robust",
  "rstar",
  "sif-itree",
@@ -1444,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f8647af4005fa11da47cd56252c6ef030be8fa97bdbf355e7dfb6348f0a82c"
+checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
 dependencies = [
  "approx",
  "arbitrary",
@@ -1889,24 +1889,24 @@ dependencies = [
 
 [[package]]
 name = "i_float"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010025c2c532c8d82e42d0b8bb5184afa449fa6f06c709ea9adcb16c49ae405b"
+checksum = "813145bb0ad5b60f55cbbf3c74cdceda1c0a9d253b35c4cc36ae0df7887cb78f"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "i_key_sort"
-version = "0.6.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9190f86706ca38ac8add223b2aed8b1330002b5cdbbce28fb58b10914d38fc27"
+checksum = "3c4d36ff9fb73dc62e163e25a07523ca5c2126660fb2485cdecf063e59b58f29"
 
 [[package]]
 name = "i_overlay"
-version = "4.0.7"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413183068e6e0289e18d7d0a1f661b81546e6918d5453a44570b9ab30cbed1b3"
+checksum = "934cba666ad1bf60436a190af6eaa3f58f57b5bad28268ce3fb45d9185862232"
 dependencies = [
  "i_float",
  "i_key_sort",
@@ -1916,18 +1916,18 @@ dependencies = [
 
 [[package]]
 name = "i_shape"
-version = "1.14.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea154b742f7d43dae2897fcd5ead86bc7b5eefcedd305a7ebf9f69d44d61082"
+checksum = "bfa9eac533d7509a8ab87672b60ac610c17240f9ea4851d26227689fdfe349c8"
 dependencies = [
  "i_float",
 ]
 
 [[package]]
 name = "i_tree"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e6d558e6d4c7b82bc51d9c771e7a927862a161a7d87bf2b0541450e0e20915"
+checksum = "4804bdc1dc124eb7e1aa9e144ecc04096bcf787a10a15fa44af682b51f0f6cce"
 
 [[package]]
 name = "iana-time-zone"
@@ -2689,7 +2689,6 @@ dependencies = [
 name = "mlt-wasm"
 version = "0.1.4"
 dependencies = [
- "getrandom 0.2.17",
  "js-sys",
  "mlt-core",
  "wasm-bindgen",
@@ -3626,6 +3625,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3683,12 +3691,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,9 +28,8 @@ fastpfor = { version = "0.9", features = ["rust"] }
 flate2 = "1"
 fsst-rs = "0.5"
 futures = "0.3"
-geo = { version = "0.32.0", default-features = false }
-geo-types = "0.7.18"
-getrandom = { version = "0.2.17" }
+geo = { version = "0.33.0", default-features = false }
+geo-types = "0.7.19"
 glob = "0.3"
 globset = "0.4"
 hex = "0.4.3"

--- a/rust/mlt-core/Cargo.toml
+++ b/rust/mlt-core/Cargo.toml
@@ -48,7 +48,7 @@ bytemuck.workspace = true
 enum_dispatch.workspace = true
 fastpfor.workspace = true
 fsst-rs.workspace = true
-geo = { workspace = true, features = ["earcutr"] }
+geo = { workspace = true, features = ["earcut"] }
 geo-types.workspace = true
 hex.workspace = true
 hilbert_2d.workspace = true

--- a/rust/mlt-core/src/encoder/geometry/geotype.rs
+++ b/rust/mlt-core/src/encoder/geometry/geotype.rs
@@ -62,7 +62,8 @@ impl GeometryValues {
     /// `self.index_buffer` and `self.triangles`.
     fn tessellate_polygon(&mut self, polygon: &Polygon<i32>) {
         if let Some(triangles) = self.triangles.as_mut() {
-            let (num_triangles, _) = earcut_into(polygon, 0, self.index_buffer.get_or_insert_with(Vec::new));
+            let (num_triangles, _) =
+                earcut_into(polygon, 0, self.index_buffer.get_or_insert_with(Vec::new));
             triangles.push(num_triangles);
         }
     }

--- a/rust/mlt-core/src/encoder/geometry/geotype.rs
+++ b/rust/mlt-core/src/encoder/geometry/geotype.rs
@@ -25,52 +25,23 @@ impl TryFrom<&Geom32> for GeometryType {
     }
 }
 
-/// Run the Earcut algorithm on `polygon`, append the remapped triangle indices (shifted by
-/// `vertex_offset`) into `index_buf`, and return the number of triangles produced.
-///
-/// Geo's earcut includes the closing vertex of each ring; MLT (and Java's `earcut4j`) omit it.
-/// Any index that would refer to a ring's closing vertex is remapped to that ring's start index,
-/// producing identical index buffers to Java.
-fn earcut_into(polygon: &Polygon<i32>, vertex_offset: u32, index_buf: &mut Vec<u32>) -> u32 {
+/// Run the Earcut algorithm on `polygon`, append triangle indices (shifted by `vertex_offset`)
+/// into `index_buf`, and return `(num_triangles, num_vertices)`.
+fn earcut_into(polygon: &Polygon<i32>, vertex_offset: u32, index_buf: &mut Vec<u32>) -> (u32, u32) {
     let polygon_f64: Polygon<f64> = polygon.convert();
     let raw = polygon_f64.earcut_triangles_raw();
     let num_triangles = u32::try_from(raw.triangle_indices.len() / 3).expect("too many triangles");
-
-    let mut geo_to_mlt = Vec::with_capacity(raw.vertices.len() / 2);
-    let mut mlt_offset = 0usize;
-
-    let mut push_ring = |ring: &LineString<i32>| {
-        let len = ring.0.len();
-        let mlt_len = if len > 1 && ring.0.first() == ring.0.last() {
-            len - 1
-        } else {
-            len
-        };
-        for i in 0..len {
-            geo_to_mlt.push(if i == len - 1 && mlt_len < len {
-                mlt_offset
-            } else {
-                mlt_offset + i
-            });
-        }
-        mlt_offset += mlt_len;
-    };
-
-    push_ring(polygon.exterior());
-    for interior in polygon.interiors() {
-        push_ring(interior);
-    }
+    let num_vertices = u32::try_from(raw.vertices.len()).expect("too many vertices");
 
     for i in raw.triangle_indices {
-        let mlt_idx = geo_to_mlt.get(i).copied().unwrap_or(i);
-        let base = u32::try_from(mlt_idx).expect("mlt vertex index overflow");
+        let base = u32::try_from(i).expect("mlt vertex index overflow");
         let idx = base
             .checked_add(vertex_offset)
             .expect("vertex index overflow");
         index_buf.push(idx);
     }
 
-    num_triangles
+    (num_triangles, num_vertices)
 }
 
 impl GeometryValues {
@@ -89,16 +60,10 @@ impl GeometryValues {
 
     /// Tessellate `polygon` using the Earcut algorithm and append the results directly into
     /// `self.index_buffer` and `self.triangles`.
-    ///
-    /// Geo's earcut includes the closing vertex in each ring; MLT (and Java's `earcut4j`) omit it.
-    /// Triangle indices that would refer to a ring's closing vertex are remapped to that ring's
-    /// start index, producing identical index buffers to Java's `earcut4j`.
-    ///
-    /// The per-feature triangle count is pushed into `self.triangles`.
     fn tessellate_polygon(&mut self, polygon: &Polygon<i32>) {
         if let Some(triangles) = self.triangles.as_mut() {
-            let val = earcut_into(polygon, 0, self.index_buffer.get_or_insert_with(Vec::new));
-            triangles.push(val);
+            let (num_triangles, _) = earcut_into(polygon, 0, self.index_buffer.get_or_insert_with(Vec::new));
+            triangles.push(num_triangles);
         }
     }
 
@@ -115,14 +80,9 @@ impl GeometryValues {
             let mut vertex_offset = 0u32;
             let index_buffer = self.index_buffer.get_or_insert_with(Vec::new);
             for poly in &mp.0 {
-                total_triangles += earcut_into(poly, vertex_offset, index_buffer);
-                let ext_verts = poly.exterior().0.len().saturating_sub(1);
-                let int_verts: usize = poly
-                    .interiors()
-                    .iter()
-                    .map(|r| r.0.len().saturating_sub(1))
-                    .sum();
-                vertex_offset += u32::try_from(ext_verts + int_verts).expect("vertex overflow");
+                let (num_triangles, num_verts) = earcut_into(poly, vertex_offset, index_buffer);
+                total_triangles += num_triangles;
+                vertex_offset += num_verts;
             }
             triangles.push(total_triangles);
         }
@@ -148,7 +108,7 @@ impl GeometryValues {
             Geom32::MultiLineString(mls) => self.push_multi_linestring(mls),
             Geom32::MultiPolygon(mp) => self.push_multi_polygon(mp),
             Geom32::Triangle(t) => {
-                self.push_polygon(&Polygon::new(LineString(vec![t.0, t.1, t.2]), vec![]));
+                self.push_polygon(&t.to_polygon());
             }
             Geom32::Rect(r) => self.push_polygon(&r.to_polygon()),
             Geom32::GeometryCollection(gc) => {
@@ -645,7 +605,7 @@ mod tests {
         use crate::geojson::Geom32;
 
         #[test]
-        fn earcut_closing_vertex_index_remap() {
+        fn earcut_polygon_indices_in_range() {
             let exterior = LineString::from(vec![(0_i32, 0), (10, 0), (10, 10), (0, 10), (0, 0)]);
             let polygon = Polygon::new(exterior, vec![]);
             let mut g = GeometryValues::new_tessellated();

--- a/rust/mlt-core/src/encoder/sort.rs
+++ b/rust/mlt-core/src/encoder/sort.rs
@@ -105,7 +105,7 @@ fn first_vertex(geom: &Geom32) -> Option<(i32, i32)> {
             mp.0.first()
                 .and_then(|p| p.exterior().0.first().map(|c| (c.x, c.y)))
         }
-        Geom32::Triangle(t) => Some((t.0.x, t.0.y)),
+        Geom32::Triangle(t) => Some((t.v1().x, t.v1().y)),
         Geom32::Rect(r) => Some((r.min().x, r.min().y)),
         Geom32::GeometryCollection(gc) => gc.0.first().and_then(first_vertex),
     }

--- a/rust/mlt-wasm/Cargo.toml
+++ b/rust/mlt-wasm/Cargo.toml
@@ -18,7 +18,6 @@ wasm-opt = ["-O3", "--enable-simd", "--enable-bulk-memory"]
 crate-type = ["cdylib"]
 
 [dependencies]
-getrandom = { workspace = true, features = ["js"] }
 js-sys.workspace = true
 mlt-core = { workspace = true }
 wasm-bindgen.workspace = true


### PR DESCRIPTION
- adapt to deprecations in geo::Triangle accessors
- simplify tessellation now that geo triangulation omits the redundant "closing" coordintae
  - See https://github.com/georust/geo/pull/1507
  - See https://github.com/georust/geo/pull/1508
- getrandom no longer required by geo