### PR TITLE
feat(rust): mlt UI to browse .mbtiles

### DIFF
--- a/rust/mlt/src/ls.rs
+++ b/rust/mlt/src/ls.rs
@@ -455,6 +455,10 @@ pub(crate) fn is_mlt_extension(path: &Path) -> bool {
     matches!(path.extension().and_then(OsStr::to_str), Some("mlt"))
 }
 
+pub(crate) fn is_mbt_extension(path: &Path) -> bool {
+    matches!(path.extension().and_then(OsStr::to_str), Some("mbtiles"))
+}
+
 fn matches_extension_filter(path: &Path, extensions: &[String]) -> bool {
     let ext = path
         .extension()

--- a/rust/mlt/src/ui/mbt.rs
+++ b/rust/mlt/src/ui/mbt.rs
@@ -1,0 +1,574 @@
+//! `MBTiles` map viewer state and tile loading.
+
+use mlt_core::{Coord32, Geom32};
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::mpsc;
+use std::thread;
+
+use geo_types::Polygon;
+use martin_tile_utils::{decode_gzip, decode_zstd};
+use mbtiles::Mbtiles;
+use mlt_core::geojson::FeatureCollection;
+use mlt_core::mvt::mvt_to_feature_collection;
+use rstar::{AABB, PointDistance, RTree, RTreeObject};
+
+use super::group_by_layer;
+use super::state::LayerGroup;
+
+type DecodedTile = (FeatureCollection, u32, Vec<LayerGroup>, RTree<MbtGeoEntry>);
+type BestHover = Option<(f64, (u8, u32, u32), usize, usize)>;
+
+// ---------------------------------------------------------------------------
+// Tile loading channel types
+// ---------------------------------------------------------------------------
+
+pub(crate) enum TileLoadRequest {
+    Load { z: u8, x: u32, y: u32 },
+}
+
+pub(crate) struct TileLoadResult {
+    pub z: u8,
+    pub x: u32,
+    pub y: u32,
+    pub data: Result<Option<Vec<u8>>, String>,
+}
+
+// ---------------------------------------------------------------------------
+// Geometry index entry (world coordinates)
+// ---------------------------------------------------------------------------
+
+/// Feature entry stored in the per-tile R-tree, using world coordinates.
+/// World coordinate space: x ∈ [0,1] west→east, y ∈ [0,1] north→south.
+pub(crate) struct MbtGeoEntry {
+    pub layer: usize,
+    pub feat: usize,
+    pub vertices: Vec<[f64; 2]>,
+}
+
+impl RTreeObject for MbtGeoEntry {
+    type Envelope = AABB<[f64; 2]>;
+
+    fn envelope(&self) -> Self::Envelope {
+        if self.vertices.is_empty() {
+            return AABB::from_point([0.0, 0.0]);
+        }
+        let (ax, ay, bx, by) = self.vertices.iter().fold(
+            (
+                f64::INFINITY,
+                f64::INFINITY,
+                f64::NEG_INFINITY,
+                f64::NEG_INFINITY,
+            ),
+            |(ax, ay, bx, by), v| (ax.min(v[0]), ay.min(v[1]), bx.max(v[0]), by.max(v[1])),
+        );
+        AABB::from_corners([ax, ay], [bx, by])
+    }
+}
+
+impl PointDistance for MbtGeoEntry {
+    fn distance_2(&self, point: &[f64; 2]) -> f64 {
+        self.vertices
+            .iter()
+            .map(|v| {
+                let dx = v[0] - point[0];
+                let dy = v[1] - point[1];
+                dx * dx + dy * dy
+            })
+            .fold(f64::INFINITY, f64::min)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tile coordinate transform (tile-local → world)
+// ---------------------------------------------------------------------------
+
+/// Transforms coordinates from tile-local space ([0, extent]) to world space ([0, 1]).
+pub(crate) struct TileTransform {
+    n: f64,   // 2^z
+    tx: f64,  // tile x index
+    ty: f64,  // tile y index
+    ext: f64, // tile extent
+}
+
+impl TileTransform {
+    pub(crate) fn new(z: u8, tile_x: u32, tile_y: u32, extent: u32) -> Self {
+        Self {
+            n: f64::from(1u32 << z),
+            tx: f64::from(tile_x),
+            ty: f64::from(tile_y),
+            ext: f64::from(extent),
+        }
+    }
+
+    /// Convert a tile-local coordinate to world coordinates.
+    #[inline]
+    pub(crate) fn to_world(&self, c: Coord32) -> [f64; 2] {
+        [
+            (self.tx + f64::from(c.x) / self.ext) / self.n,
+            (self.ty + f64::from(c.y) / self.ext) / self.n,
+        ]
+    }
+
+    /// Collect world-coordinate vertices from a polygon.
+    pub(crate) fn poly_verts(&self, poly: &Polygon<i32>) -> Vec<[f64; 2]> {
+        poly.exterior()
+            .0
+            .iter()
+            .copied()
+            .chain(poly.interiors().iter().flat_map(|r| r.0.iter().copied()))
+            .map(|c| self.to_world(c))
+            .collect()
+    }
+
+    /// Collect world-coordinate vertices from any geometry.
+    pub(crate) fn geom_verts(&self, geom: &Geom32) -> Vec<[f64; 2]> {
+        match geom {
+            Geom32::Point(p) => vec![self.to_world(p.0)],
+            Geom32::LineString(ls) => ls.0.iter().copied().map(|c| self.to_world(c)).collect(),
+            Geom32::MultiPoint(mp) => mp.iter().map(|p| self.to_world(p.0)).collect(),
+            Geom32::Polygon(poly) => self.poly_verts(poly),
+            Geom32::MultiLineString(mls) => mls
+                .iter()
+                .flat_map(|ls| ls.0.iter().copied().map(|c| self.to_world(c)))
+                .collect(),
+            Geom32::MultiPolygon(mpoly) => mpoly.iter().flat_map(|p| self.poly_verts(p)).collect(),
+            _ => vec![],
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tile cache entry
+// ---------------------------------------------------------------------------
+
+pub(crate) enum MbtTileData {
+    Loading,
+    Empty,
+    #[allow(dead_code)]
+    Error(String),
+    Loaded {
+        fc: FeatureCollection,
+        extent: u32,
+        layer_groups: Vec<LayerGroup>,
+        geo_index: RTree<MbtGeoEntry>,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Hover state
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct MbtHoveredInfo {
+    pub tile: (u8, u32, u32),
+    pub layer_idx: usize,
+    pub feat_idx: usize,
+}
+
+// ---------------------------------------------------------------------------
+// MbtilesState
+// ---------------------------------------------------------------------------
+
+pub(crate) struct MbtilesState {
+    #[allow(dead_code)]
+    pub path: PathBuf,
+    /// Viewport bounds in world coords: x ∈ [0,1] west→east, y ∈ [0,1] north→south.
+    pub vp_x0: f64,
+    pub vp_x1: f64,
+    pub vp_y0: f64,
+    pub vp_y1: f64,
+    /// Cached tile data keyed by (z, x, y) in XYZ scheme.
+    pub tiles: HashMap<(u8, u32, u32), MbtTileData>,
+    /// Currently hovered feature.
+    pub hovered: Option<MbtHoveredInfo>,
+    /// Nominal zoom level (0 = full world width); changes by ±0.5 per scroll step.
+    /// Kept in sync with viewport width after pan (`sync_zoom_f_from_vp`).
+    pub zoom_f: f64,
+    /// Last mouse cell during left-button map drag (`Drag` deltas are applied from here).
+    pub map_drag_last: Option<(u16, u16)>,
+    loading: HashSet<(u8, u32, u32)>,
+    request_tx: mpsc::SyncSender<TileLoadRequest>,
+    pub result_rx: mpsc::Receiver<TileLoadResult>,
+}
+
+impl MbtilesState {
+    pub(crate) fn new(path: PathBuf) -> Self {
+        let (req_tx, req_rx) = mpsc::sync_channel::<TileLoadRequest>(200);
+        let (res_tx, res_rx) = mpsc::sync_channel::<TileLoadResult>(200);
+
+        let path_clone = path.clone();
+        thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_io()
+                .enable_time()
+                .build()
+                .expect("tokio runtime");
+            rt.block_on(async move {
+                let mbt = match Mbtiles::new(&path_clone) {
+                    Ok(m) => m,
+                    Err(e) => {
+                        eprintln!("Failed to open mbtiles: {e}");
+                        return;
+                    }
+                };
+                let mut conn = match mbt.open_readonly().await {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("mbtiles conn error: {e}");
+                        return;
+                    }
+                };
+                while let Ok(TileLoadRequest::Load { z, x, y }) = req_rx.recv() {
+                    let result = mbt
+                        .get_tile(&mut conn, z, x, y)
+                        .await
+                        .map_err(|e| e.to_string());
+                    let _ = res_tx.send(TileLoadResult {
+                        z,
+                        x,
+                        y,
+                        data: result,
+                    });
+                }
+            });
+        });
+
+        Self {
+            path,
+            vp_x0: 0.0,
+            vp_x1: 1.0,
+            vp_y0: 0.0,
+            vp_y1: 1.0,
+            tiles: HashMap::new(),
+            hovered: None,
+            zoom_f: 0.0,
+            map_drag_last: None,
+            loading: HashSet::new(),
+            request_tx: req_tx,
+            result_rx: res_rx,
+        }
+    }
+
+    /// Tile zoom used for loading tiles: floor of `-log2(viewport width)`.
+    pub(crate) fn zoom_level(&self) -> u8 {
+        let vp_w = self.vp_x1 - self.vp_x0;
+        if vp_w <= 0.0 {
+            return 0;
+        }
+        #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        let z = (-(vp_w.log2())).floor().clamp(0.0, 22.0) as u8;
+        z
+    }
+
+    /// `(z, 2^z as f64, 2^z)` for the current view tile grid.
+    fn view_tile_scale(&self) -> (u8, f64, u32) {
+        let z = self.zoom_level();
+        let n = 1u32 << z;
+        (z, f64::from(n), n)
+    }
+
+    /// XYZ tile indices at zoom `z` containing world point `(wx, wy)` (XYZ, clamped).
+    pub(crate) fn world_to_tile_xy(z: u8, wx: f64, wy: f64) -> (u32, u32) {
+        let n = 1u32 << z;
+        let nf = f64::from(n);
+        #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        let tx = (wx * nf).max(0.0).floor() as u32;
+        #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        let ty = (wy * nf).max(0.0).floor() as u32;
+        let tx = tx.min(n.saturating_sub(1));
+        let ty = ty.min(n.saturating_sub(1));
+        (tx, ty)
+    }
+
+    /// Map-area fractions `rx, ry` (0 = left/top of map widget) to world coordinates.
+    pub(crate) fn viewport_world_at_fracs(&self, rx: f64, ry: f64) -> (f64, f64) {
+        let wx = self.vp_x0 + rx * (self.vp_x1 - self.vp_x0);
+        let wy = self.vp_y0 + ry * (self.vp_y1 - self.vp_y0);
+        (wx, wy)
+    }
+
+    fn sync_zoom_f_from_vp(&mut self) {
+        let vp_w = self.vp_x1 - self.vp_x0;
+        if vp_w > 0.0 {
+            self.zoom_f = (-vp_w.log2()).clamp(0.0, 22.0);
+        }
+    }
+
+    /// XYZ tile indices visible in the current viewport at the current zoom.
+    pub(crate) fn visible_tiles(&self) -> Vec<(u8, u32, u32)> {
+        let (z, nf, n) = self.view_tile_scale();
+        #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        let x_min = (self.vp_x0 * nf).max(0.0).floor() as u32;
+        #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        let x_max = ((self.vp_x1 * nf).ceil() as u32)
+            .saturating_sub(1)
+            .min(n.saturating_sub(1));
+        #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        let y_min = (self.vp_y0 * nf).max(0.0).floor() as u32;
+        #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        let y_max = ((self.vp_y1 * nf).ceil() as u32)
+            .saturating_sub(1)
+            .min(n.saturating_sub(1));
+        let mut tiles = Vec::new();
+        for ty in y_min..=y_max {
+            for tx in x_min..=x_max {
+                tiles.push((z, tx, ty));
+            }
+        }
+        tiles
+    }
+
+    /// XYZ tile (at current tile zoom) that contains the viewport center.
+    pub(crate) fn center_tile_xyz(&self) -> (u8, u32, u32) {
+        let z = self.zoom_level();
+        let wx = f64::midpoint(self.vp_x0, self.vp_x1);
+        let wy = f64::midpoint(self.vp_y0, self.vp_y1);
+        let (tx, ty) = Self::world_to_tile_xy(z, wx, wy);
+        (z, tx, ty)
+    }
+
+    /// Fit the viewport exactly to XYZ tile `(z, tx, ty)` and sync `zoom_f`.
+    pub(crate) fn set_viewport_to_tile(&mut self, z: u8, tx: u32, ty: u32) -> Result<(), String> {
+        let n = 1u32
+            .checked_shl(u32::from(z))
+            .ok_or_else(|| format!("zoom z={z} is too large"))?;
+        if tx >= n || ty >= n {
+            return Err(format!(
+                "tile index out of range for z={z}: x={tx} y={ty} (max {})",
+                n.saturating_sub(1)
+            ));
+        }
+        let nf = f64::from(n);
+        self.vp_x0 = f64::from(tx) / nf;
+        self.vp_x1 = f64::from(tx + 1) / nf;
+        self.vp_y0 = f64::from(ty) / nf;
+        self.vp_y1 = f64::from(ty + 1) / nf;
+        self.sync_zoom_f_from_vp();
+        Ok(())
+    }
+
+    /// Enqueue a tile for loading if not already cached or loading.
+    pub(crate) fn request_tile(&mut self, z: u8, x: u32, y: u32) {
+        let key = (z, x, y);
+        if !self.tiles.contains_key(&key) && !self.loading.contains(&key) {
+            self.loading.insert(key);
+            self.tiles.insert(key, MbtTileData::Loading);
+            let _ = self.request_tx.try_send(TileLoadRequest::Load { z, x, y });
+        }
+    }
+
+    /// Request this tile and every XYZ ancestor down to z=0 (for overzoom fallbacks).
+    pub(crate) fn request_tile_with_ancestors(&mut self, z: u8, x: u32, y: u32) {
+        let mut cz = z;
+        let mut cx = x;
+        let mut cy = y;
+        loop {
+            self.request_tile(cz, cx, cy);
+            if cz == 0 {
+                break;
+            }
+            cz -= 1;
+            cx >>= 1;
+            cy >>= 1;
+        }
+    }
+
+    /// First loaded ancestor for overzoom (`k` levels up: tile `(x>>k, y>>k)` at `z-k`), if any.
+    pub(crate) fn find_overzoom_source(&self, z: u8, tx: u32, ty: u32) -> Option<(u8, u32, u32)> {
+        #[expect(clippy::cast_possible_truncation)]
+        let max_k = z as usize;
+        for k in 1..=max_k {
+            let pz = z - k as u8;
+            let px = tx >> k;
+            let py = ty >> k;
+            let key = (pz, px, py);
+            if matches!(self.tiles.get(&key), Some(MbtTileData::Loaded { .. })) {
+                return Some(key);
+            }
+        }
+        None
+    }
+
+    /// Tile to use for data at `(z,tx,ty)`: native if loaded, otherwise first loaded ancestor.
+    pub(crate) fn effective_tile_key(&self, z: u8, tx: u32, ty: u32) -> Option<(u8, u32, u32)> {
+        let key = (z, tx, ty);
+        match self.tiles.get(&key) {
+            Some(MbtTileData::Loaded { .. }) => Some(key),
+            _ => self.find_overzoom_source(z, tx, ty),
+        }
+    }
+
+    /// Drain incoming results and update the tile cache. Returns true if any tiles changed.
+    pub(crate) fn process_results(&mut self) -> bool {
+        let mut changed = false;
+        while let Ok(res) = self.result_rx.try_recv() {
+            let key = (res.z, res.x, res.y);
+            self.loading.remove(&key);
+            let entry = match res.data {
+                Err(e) => MbtTileData::Error(e),
+                Ok(None) => MbtTileData::Empty,
+                Ok(Some(raw)) => match decode_and_parse(res.z, res.x, res.y, raw) {
+                    Ok(Some((fc, extent, layer_groups, geo_index))) => MbtTileData::Loaded {
+                        fc,
+                        extent,
+                        layer_groups,
+                        geo_index,
+                    },
+                    Ok(None) => MbtTileData::Empty,
+                    Err(e) => MbtTileData::Error(e.to_string()),
+                },
+            };
+            self.tiles.insert(key, entry);
+            changed = true;
+        }
+        changed
+    }
+
+    /// Zoom in/out by half a zoom level around `(wx, wy)` (scroll wheel).
+    pub(crate) fn zoom_wheel_at(&mut self, wx: f64, wy: f64, zoom_in: bool) {
+        let dz = if zoom_in { 0.5 } else { -0.5 };
+        let new_z = (self.zoom_f + dz).clamp(0.0, 22.0);
+        if (new_z - self.zoom_f).abs() < 1e-12 {
+            return;
+        }
+        let scale = 2_f64.powf(-(new_z - self.zoom_f));
+        if !self.zoom_viewport_at(wx, wy, scale) {
+            return;
+        }
+        self.sync_zoom_f_from_vp();
+    }
+
+    /// Scale the viewport around `(wx, wy)` by `scale` on both axes (`scale` \< 1 zooms in).
+    fn zoom_viewport_at(&mut self, wx: f64, wy: f64, scale: f64) -> bool {
+        let x0 = wx + (self.vp_x0 - wx) * scale;
+        let x1 = wx + (self.vp_x1 - wx) * scale;
+        let y0 = wy + (self.vp_y0 - wy) * scale;
+        let y1 = wy + (self.vp_y1 - wy) * scale;
+        let min_size = 2_f64.powf(-22.0);
+        if x1 - x0 < min_size || y1 - y0 < min_size {
+            return false;
+        }
+        self.vp_x0 = x0;
+        self.vp_x1 = x1;
+        self.vp_y0 = y0;
+        self.vp_y1 = y1;
+        true
+    }
+
+    /// Pan the viewport by mouse delta in terminal cells (`d_col`/`d_row` = current − previous).
+    pub(crate) fn pan_by_pixels(&mut self, area_w: u16, area_h: u16, d_col: i32, d_row: i32) {
+        if area_w == 0 || area_h == 0 {
+            return;
+        }
+        let wf = f64::from(area_w);
+        let hf = f64::from(area_h);
+        let vp_w = self.vp_x1 - self.vp_x0;
+        let vp_h = self.vp_y1 - self.vp_y0;
+        let dx = f64::from(d_col) / wf * vp_w;
+        let dy = f64::from(d_row) / hf * vp_h;
+        self.vp_x0 -= dx;
+        self.vp_x1 -= dx;
+        self.vp_y0 -= dy;
+        self.vp_y1 -= dy;
+        self.sync_zoom_f_from_vp();
+    }
+
+    /// Find the nearest feature to world point (wx, wy) among visible cells (native or overzoom).
+    pub(crate) fn find_hovered(&mut self, wx: f64, wy: f64) {
+        let z = self.zoom_level();
+        let threshold = (self.vp_x1 - self.vp_x0) * 0.02;
+        let thresh_sq = threshold * threshold;
+        let pt = [wx, wy];
+
+        let mut best: BestHover = None;
+        let visible = self.visible_tiles();
+        for (tz, tx, ty) in visible {
+            if tz != z {
+                continue;
+            }
+            let Some(src_key) = self.effective_tile_key(tz, tx, ty) else {
+                continue;
+            };
+            let Some(MbtTileData::Loaded { geo_index, .. }) = self.tiles.get(&src_key) else {
+                continue;
+            };
+            for e in geo_index.nearest_neighbor_iter(&pt) {
+                let d = e.distance_2(&pt);
+                if d > thresh_sq {
+                    break;
+                }
+                if best.is_none_or(|(bd, ..)| d < bd) {
+                    best = Some((d, src_key, e.layer, e.feat));
+                }
+            }
+        }
+        let new_hov = best.map(|(_, tile, layer, feat)| MbtHoveredInfo {
+            tile,
+            layer_idx: layer,
+            feat_idx: feat,
+        });
+        self.hovered = new_hov;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tile decode & parse helpers
+// ---------------------------------------------------------------------------
+
+fn decode_and_parse(z: u8, tx: u32, ty: u32, raw: Vec<u8>) -> anyhow::Result<Option<DecodedTile>> {
+    let buf = decompress(raw)?;
+    if buf.is_empty() {
+        return Ok(None);
+    }
+    let fc = mvt_to_feature_collection(buf)?;
+    if fc.features.is_empty() {
+        return Ok(None);
+    }
+    let extent = fc
+        .features
+        .first()
+        .and_then(|f| f.properties.get("_extent"))
+        .and_then(serde_json::Value::as_u64)
+        .map_or(4096, |v| u32::try_from(v).unwrap_or(4096));
+    let layer_groups = group_by_layer(&fc);
+    let geo_index = build_world_geo_index(z, tx, ty, &fc, &layer_groups, extent);
+    Ok(Some((fc, extent, layer_groups, geo_index)))
+}
+
+fn decompress(raw: Vec<u8>) -> anyhow::Result<Vec<u8>> {
+    if raw.len() >= 2 && raw[0] == 0x1f && raw[1] == 0x8b {
+        Ok(decode_gzip(&raw)?)
+    } else if raw.len() >= 4 && raw[0] == 0x28 && raw[1] == 0xb5 && raw[2] == 0x2f && raw[3] == 0xfd
+    {
+        Ok(decode_zstd(&raw)?)
+    } else {
+        Ok(raw)
+    }
+}
+
+fn build_world_geo_index(
+    z: u8,
+    tx: u32,
+    ty: u32,
+    fc: &FeatureCollection,
+    layer_groups: &[LayerGroup],
+    extent: u32,
+) -> RTree<MbtGeoEntry> {
+    let transform = TileTransform::new(z, tx, ty, extent);
+    let mut entries = Vec::new();
+    for (li, group) in layer_groups.iter().enumerate() {
+        for (fi, &gi) in group.feature_indices.iter().enumerate() {
+            let geom = &fc.features[gi].geometry;
+            let vertices = transform.geom_verts(geom);
+            if !vertices.is_empty() {
+                entries.push(MbtGeoEntry {
+                    layer: li,
+                    feat: fi,
+                    vertices,
+                });
+            }
+        }
+    }
+    RTree::bulk_load(entries)
+}

--- a/rust/mlt/src/ui/mbt.rs
+++ b/rust/mlt/src/ui/mbt.rs
@@ -1,9 +1,8 @@
 //! `MBTiles` map viewer state and tile loading.
 
-use mlt_core::{Coord32, Geom32};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::sync::mpsc;
+use std::sync::mpsc::{self, TryRecvError};
 use std::thread;
 
 use geo_types::Polygon;
@@ -11,6 +10,7 @@ use martin_tile_utils::{decode_gzip, decode_zstd};
 use mbtiles::Mbtiles;
 use mlt_core::geojson::FeatureCollection;
 use mlt_core::mvt::mvt_to_feature_collection;
+use mlt_core::{Coord32, Geom32};
 use rstar::{AABB, PointDistance, RTree, RTreeObject};
 
 use super::group_by_layer;
@@ -190,12 +190,17 @@ pub(crate) struct MbtilesState {
     loading: HashSet<(u8, u32, u32)>,
     request_tx: mpsc::SyncSender<TileLoadRequest>,
     pub result_rx: mpsc::Receiver<TileLoadResult>,
+    /// Until the loader thread reports success, holds the one-shot init handshake receiver.
+    loader_init_rx: Option<mpsc::Receiver<Result<(), String>>>,
+    /// Fatal error from `MBTiles` open / connection (surfaced to the UI once via `take_loader_fatal`).
+    loader_fatal: Option<String>,
 }
 
 impl MbtilesState {
     pub(crate) fn new(path: PathBuf) -> Self {
         let (req_tx, req_rx) = mpsc::sync_channel::<TileLoadRequest>(200);
         let (res_tx, res_rx) = mpsc::sync_channel::<TileLoadResult>(200);
+        let (init_tx, init_rx) = mpsc::sync_channel::<Result<(), String>>(1);
 
         let path_clone = path.clone();
         thread::spawn(move || {
@@ -208,17 +213,22 @@ impl MbtilesState {
                 let mbt = match Mbtiles::new(&path_clone) {
                     Ok(m) => m,
                     Err(e) => {
-                        eprintln!("Failed to open mbtiles: {e}");
+                        let _ = init_tx.send(Err(format!("Failed to open mbtiles: {e}")));
                         return;
                     }
                 };
                 let mut conn = match mbt.open_readonly().await {
                     Ok(c) => c,
                     Err(e) => {
-                        eprintln!("mbtiles conn error: {e}");
+                        let _ =
+                            init_tx.send(Err(format!("MBTiles read-only connection failed: {e}")));
                         return;
                     }
                 };
+                if init_tx.send(Ok(())).is_err() {
+                    return;
+                }
+                drop(init_tx);
                 while let Ok(TileLoadRequest::Load { z, x, y }) = req_rx.recv() {
                     let result = mbt
                         .get_tile(&mut conn, z, x, y)
@@ -247,7 +257,13 @@ impl MbtilesState {
             loading: HashSet::new(),
             request_tx: req_tx,
             result_rx: res_rx,
+            loader_init_rx: Some(init_rx),
+            loader_fatal: None,
         }
+    }
+
+    pub(crate) fn take_loader_fatal(&mut self) -> Option<String> {
+        self.loader_fatal.take()
     }
 
     /// Tile zoom used for loading tiles: floor of `-log2(viewport width)`.
@@ -354,7 +370,19 @@ impl MbtilesState {
         if !self.tiles.contains_key(&key) && !self.loading.contains(&key) {
             self.loading.insert(key);
             self.tiles.insert(key, MbtTileData::Loading);
-            let _ = self.request_tx.try_send(TileLoadRequest::Load { z, x, y });
+            if self
+                .request_tx
+                .try_send(TileLoadRequest::Load { z, x, y })
+                .is_err()
+            {
+                self.loading.remove(&key);
+                self.tiles.insert(
+                    key,
+                    MbtTileData::Error(
+                        "Could not enqueue tile load (channel full or loader stopped)".into(),
+                    ),
+                );
+            }
         }
     }
 
@@ -376,12 +404,11 @@ impl MbtilesState {
 
     /// First loaded ancestor for overzoom (`k` levels up: tile `(x>>k, y>>k)` at `z-k`), if any.
     pub(crate) fn find_overzoom_source(&self, z: u8, tx: u32, ty: u32) -> Option<(u8, u32, u32)> {
-        #[expect(clippy::cast_possible_truncation)]
-        let max_k = z as usize;
-        for k in 1..=max_k {
-            let pz = z - k as u8;
-            let px = tx >> k;
-            let py = ty >> k;
+        for k in 1..=z {
+            let pz = z - k;
+            let shift = u32::from(k);
+            let px = tx >> shift;
+            let py = ty >> shift;
             let key = (pz, px, py);
             if matches!(self.tiles.get(&key), Some(MbtTileData::Loaded { .. })) {
                 return Some(key);
@@ -402,6 +429,29 @@ impl MbtilesState {
     /// Drain incoming results and update the tile cache. Returns true if any tiles changed.
     pub(crate) fn process_results(&mut self) -> bool {
         let mut changed = false;
+
+        if let Some(rx) = self.loader_init_rx.take() {
+            match rx.try_recv() {
+                Ok(Ok(())) => {
+                    // Init succeeded; drop the receiver so we do not treat later disconnect as init failure.
+                }
+                Ok(Err(msg)) => {
+                    self.loader_fatal = Some(msg);
+                    changed = true;
+                }
+                Err(TryRecvError::Empty) => {
+                    self.loader_init_rx = Some(rx);
+                }
+                Err(TryRecvError::Disconnected) => {
+                    if self.loader_fatal.is_none() {
+                        self.loader_fatal =
+                            Some("MBTiles loader thread exited during initialization".into());
+                    }
+                    changed = true;
+                }
+            }
+        }
+
         while let Ok(res) = self.result_rx.try_recv() {
             let key = (res.z, res.x, res.y);
             self.loading.remove(&key);
@@ -482,6 +532,7 @@ impl MbtilesState {
         let pt = [wx, wy];
 
         let mut best: BestHover = None;
+        let mut seen_src: HashSet<(u8, u32, u32)> = HashSet::new();
         let visible = self.visible_tiles();
         for (tz, tx, ty) in visible {
             if tz != z {
@@ -490,6 +541,9 @@ impl MbtilesState {
             let Some(src_key) = self.effective_tile_key(tz, tx, ty) else {
                 continue;
             };
+            if !seen_src.insert(src_key) {
+                continue;
+            }
             let Some(MbtTileData::Loaded { geo_index, .. }) = self.tiles.get(&src_key) else {
                 continue;
             };
@@ -509,6 +563,69 @@ impl MbtilesState {
             feat_idx: feat,
         });
         self.hovered = new_hov;
+    }
+
+    /// Keys we keep when pruning: visible tiles (with a 1-tile margin) plus every ancestor chain.
+    fn keep_tile_keys(&self) -> HashSet<(u8, u32, u32)> {
+        let z = self.zoom_level();
+        let Some(n) = 1u32.checked_shl(u32::from(z)) else {
+            return HashSet::new();
+        };
+        let mut out = HashSet::new();
+        for (_zv, tx, ty) in self.visible_tiles() {
+            for dx in -1..=1 {
+                for dy in -1..=1 {
+                    #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                    let nx = (i64::from(tx) + i64::from(dx))
+                        .clamp(0, i64::from(n.saturating_sub(1)))
+                        as u32;
+                    #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                    let ny = (i64::from(ty) + i64::from(dy))
+                        .clamp(0, i64::from(n.saturating_sub(1)))
+                        as u32;
+                    let mut cz = z;
+                    let mut cx = nx;
+                    let mut cy = ny;
+                    loop {
+                        out.insert((cz, cx, cy));
+                        if cz == 0 {
+                            break;
+                        }
+                        cz -= 1;
+                        cx >>= 1;
+                        cy >>= 1;
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// Drop cached tiles far from the viewport so panning does not grow memory without bound.
+    pub(crate) fn prune_tile_cache_if_needed(&mut self) {
+        const MAX: usize = 256;
+        if self.tiles.len() <= MAX {
+            return;
+        }
+        let keep = self.keep_tile_keys();
+        let stale: Vec<(u8, u32, u32)> = self
+            .tiles
+            .keys()
+            .filter(|k| !keep.contains(k))
+            .copied()
+            .collect();
+        let stale_set: HashSet<_> = stale.iter().copied().collect();
+        if self
+            .hovered
+            .as_ref()
+            .is_some_and(|h| stale_set.contains(&h.tile))
+        {
+            self.hovered = None;
+        }
+        for k in stale {
+            self.loading.remove(&k);
+            self.tiles.remove(&k);
+        }
     }
 }
 

--- a/rust/mlt/src/ui/mbt.rs
+++ b/rust/mlt/src/ui/mbt.rs
@@ -39,7 +39,7 @@ pub(crate) struct TileLoadResult {
 // ---------------------------------------------------------------------------
 
 /// Feature entry stored in the per-tile R-tree, using world coordinates.
-/// World coordinate space: x ∈ [0,1] west→east, y ∈ [0,1] north→south.
+/// World coordinate space: `x ∈ [0, 1]` west→east, `y ∈ [0, 1]` north→south.
 pub(crate) struct MbtGeoEntry {
     pub layer: usize,
     pub feat: usize,
@@ -173,7 +173,7 @@ pub(crate) struct MbtHoveredInfo {
 pub(crate) struct MbtilesState {
     #[allow(dead_code)]
     pub path: PathBuf,
-    /// Viewport bounds in world coords: x ∈ [0,1] west→east, y ∈ [0,1] north→south.
+    /// Viewport bounds in world coords: `x ∈ [0, 1]` west→east, `y ∈ [0, 1]` north→south.
     pub vp_x0: f64,
     pub vp_x1: f64,
     pub vp_y0: f64,

--- a/rust/mlt/src/ui/mod.rs
+++ b/rust/mlt/src/ui/mod.rs
@@ -71,9 +71,9 @@ const HOVER_REDRAW_THROTTLE: Duration = Duration::from_millis(32);
 
 #[derive(Args)]
 pub struct UiArgs {
-    /// Path to a tile file (.mlt, .mvt, .pbf) or directory
+    /// Path to a tile file (`.mlt`, `.mvt`, `.pbf`, `.mbtiles`) or directory
     path: PathBuf,
-    /// Start MBTiles map centered on this XYZ tile (`z/x/y`, e.g. `6/32/21`). MBTiles only.
+    /// Start `MBTiles` map centered on this XYZ tile (`z/x/y`, e.g. `6/32/21`). `MBTiles` only.
     #[arg(long = "center-tile", value_name = "Z/X/Y")]
     center_tile: Option<String>,
 }
@@ -124,34 +124,34 @@ pub fn ui(args: &UiArgs) -> anyhow::Result<()> {
     run_app(app)
 }
 
-fn parse_center_tile_xyz(s: &str) -> anyhow::Result<(u8, u32, u32)> {
-    let parts: Vec<&str> = s
+fn parse_center_tile_xyz(spec: &str) -> anyhow::Result<(u8, u32, u32)> {
+    let parts: Vec<&str> = spec
         .split('/')
         .map(str::trim)
         .filter(|p| !p.is_empty())
         .collect();
     if parts.len() != 3 {
-        bail!("--center-tile must be z/x/y (three integers), got {s:?}");
+        bail!("--center-tile must be z/x/y (three integers), got {spec:?}");
     }
-    let z: u8 = parts[0]
+    let zoom: u8 = parts[0]
         .parse()
         .map_err(|_| anyhow::anyhow!("invalid zoom z in --center-tile: {:?}", parts[0]))?;
-    let x: u32 = parts[1]
+    let tile_x: u32 = parts[1]
         .parse()
         .map_err(|_| anyhow::anyhow!("invalid tile x in --center-tile: {:?}", parts[1]))?;
-    let y: u32 = parts[2]
+    let tile_y: u32 = parts[2]
         .parse()
         .map_err(|_| anyhow::anyhow!("invalid tile y in --center-tile: {:?}", parts[2]))?;
-    let n = 1u32
-        .checked_shl(u32::from(z))
-        .ok_or_else(|| anyhow::anyhow!("zoom z={z} is too large"))?;
-    if x >= n || y >= n {
+    let grid_n = 1u32
+        .checked_shl(u32::from(zoom))
+        .ok_or_else(|| anyhow::anyhow!("zoom z={zoom} is too large"))?;
+    if tile_x >= grid_n || tile_y >= grid_n {
         bail!(
-            "tile x/y must be < 2^z for z={z} (max index {})",
-            n.saturating_sub(1)
+            "tile x/y must be < 2^z for z={zoom} (max index {})",
+            grid_n.saturating_sub(1)
         );
     }
-    Ok((z, x, y))
+    Ok((zoom, tile_x, tile_y))
 }
 
 // --- Data loading ---
@@ -444,14 +444,19 @@ fn run_app_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> anyho
             if mbt.process_results() {
                 app.needs_redraw = true;
             }
+            if let Some(msg) = mbt.take_loader_fatal() {
+                let title = app
+                    .current_file
+                    .as_ref()
+                    .map_or_else(|| "MBTiles".to_string(), |p| p.display().to_string());
+                app.error_popup = Some((title, msg));
+                app.needs_redraw = true;
+            }
             let visible = mbt.visible_tiles();
             for (z, x, y) in visible {
                 mbt.request_tile_with_ancestors(z, x, y);
             }
-            if app.needs_redraw {
-                // request redraw in 16ms so loading tiles appear as they arrive
-                app.needs_redraw = true;
-            }
+            mbt.prune_tile_cache_if_needed();
         }
 
         if let Some(rows) = app.analysis_rx.as_ref().and_then(|rx| rx.try_recv().ok()) {
@@ -733,21 +738,18 @@ fn run_app_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> anyho
                             app.invalidate();
                             continue;
                         }
-                        if app.mode == ViewMode::MbtilesMap {
-                            if let MouseEventKind::Drag(MouseButton::Left) = mouse.kind {
-                                if let (Some(area), Some(ref mut mbt)) =
-                                    (map_area, app.mbt_state.as_mut())
-                                {
-                                    if let Some((lc, lr)) = mbt.map_drag_last {
-                                        let dc = i32::from(mouse.column) - i32::from(lc);
-                                        let dr = i32::from(mouse.row) - i32::from(lr);
-                                        if dc != 0 || dr != 0 {
-                                            mbt.pan_by_pixels(area.width, area.height, dc, dr);
-                                            mbt.map_drag_last = Some((mouse.column, mouse.row));
-                                            app.needs_redraw = true;
-                                        }
-                                    }
-                                }
+                        if app.mode == ViewMode::MbtilesMap
+                            && let MouseEventKind::Drag(MouseButton::Left) = mouse.kind
+                            && let (Some(area), Some(ref mut mbt)) =
+                                (map_area, app.mbt_state.as_mut())
+                            && let Some((lc, lr)) = mbt.map_drag_last
+                        {
+                            let dc = i32::from(mouse.column) - i32::from(lc);
+                            let dr = i32::from(mouse.row) - i32::from(lr);
+                            if dc != 0 || dr != 0 {
+                                mbt.pan_by_pixels(area.width, area.height, dc, dr);
+                                mbt.map_drag_last = Some((mouse.column, mouse.row));
+                                app.needs_redraw = true;
                             }
                         }
                         let prev = app.hovered.clone();
@@ -888,14 +890,14 @@ fn run_app_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> anyho
                         }
                     }
                     MouseEventKind::Down(btn) => {
-                        if app.mode == ViewMode::MbtilesMap && btn == MouseButton::Left {
-                            if let (Some(area), Some(ref mut mbt)) =
+                        if app.mode == ViewMode::MbtilesMap
+                            && btn == MouseButton::Left
+                            && let (Some(area), Some(ref mut mbt)) =
                                 (map_area, app.mbt_state.as_mut())
-                                && point_in_rect(mouse.column, mouse.row, area)
-                            {
-                                mbt.map_drag_last = Some((mouse.column, mouse.row));
-                                continue;
-                            }
+                            && point_in_rect(mouse.column, mouse.row, area)
+                        {
+                            mbt.map_drag_last = Some((mouse.column, mouse.row));
+                            continue;
                         }
                         if app.mode == ViewMode::FileBrowser {
                             if let Some(fl) = file_left {

--- a/rust/mlt/src/ui/mod.rs
+++ b/rust/mlt/src/ui/mod.rs
@@ -1,5 +1,6 @@
 //! TUI visualizer for MLT files using ratatui
 
+pub(crate) mod mbt;
 mod rendering;
 mod state;
 
@@ -15,7 +16,7 @@ use anyhow::bail;
 use clap::Args;
 use crossterm::event::{
     self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers,
-    MouseEventKind,
+    MouseButton, MouseEventKind,
 };
 use crossterm::execute;
 use geo_types::Polygon;
@@ -29,16 +30,19 @@ use ratatui::widgets::{Block, Borders};
 use rstar::{AABB, PointDistance, RTreeObject};
 
 use crate::ls::{
-    FileAlgorithm, FileSortColumn, LsFlags, LsRow, analyze_tile_files, is_mlt_extension,
-    is_tile_extension,
+    FileAlgorithm, FileSortColumn, LsFlags, LsRow, analyze_tile_files, is_mbt_extension,
+    is_mlt_extension, is_tile_extension,
 };
+use crate::ui::mbt::MbtilesState;
 use crate::ui::rendering::files::{
     render_file_browser, render_file_filter_panel, render_file_info_panel,
     render_tile_preview_panel,
 };
 use crate::ui::rendering::help::{render_error_popup, render_help_overlay};
-use crate::ui::rendering::layers::{render_properties_panel, render_tree_panel};
-use crate::ui::rendering::map::render_map_panel;
+use crate::ui::rendering::layers::{
+    render_mbtiles_hover_panel, render_properties_panel, render_tree_panel,
+};
+use crate::ui::rendering::map::{render_map_panel, render_mbtiles_map_panel};
 use crate::ui::state::{App, HoveredInfo, LayerGroup, ResizeHandle, TreeItem, ViewMode};
 
 pub const CLR_POINT: Color = Color::Magenta;
@@ -69,10 +73,25 @@ const HOVER_REDRAW_THROTTLE: Duration = Duration::from_millis(32);
 pub struct UiArgs {
     /// Path to a tile file (.mlt, .mvt, .pbf) or directory
     path: PathBuf,
+    /// Start MBTiles map centered on this XYZ tile (`z/x/y`, e.g. `6/32/21`). MBTiles only.
+    #[arg(long = "center-tile", value_name = "Z/X/Y")]
+    center_tile: Option<String>,
 }
 
 pub fn ui(args: &UiArgs) -> anyhow::Result<()> {
-    let app = if args.path.is_dir() {
+    if args.center_tile.is_some() && !is_mbt_extension(&args.path) {
+        bail!("--center-tile is only supported when opening an .mbtiles file");
+    }
+    let app = if is_mbt_extension(&args.path) {
+        let mut mbt = MbtilesState::new(args.path.clone());
+        if let Some(ref s) = args.center_tile {
+            let (z, x, y) = parse_center_tile_xyz(s)?;
+            mbt
+                .set_viewport_to_tile(z, x, y)
+                .map_err(|e| anyhow::anyhow!(e))?;
+        }
+        App::new_mbtiles(mbt, args.path.clone())
+    } else if args.path.is_dir() {
         let paths = find_tile_files(&args.path)?;
         if paths.is_empty() {
             bail!(
@@ -104,6 +123,33 @@ pub fn ui(args: &UiArgs) -> anyhow::Result<()> {
         bail!("Path is not a file or directory");
     };
     run_app(app)
+}
+
+fn parse_center_tile_xyz(s: &str) -> anyhow::Result<(u8, u32, u32)> {
+    let parts: Vec<&str> = s
+        .split('/')
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+        .collect();
+    if parts.len() != 3 {
+        bail!("--center-tile must be z/x/y (three integers), got {s:?}");
+    }
+    let z: u8 = parts[0]
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid zoom z in --center-tile: {:?}", parts[0]))?;
+    let x: u32 = parts[1]
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid tile x in --center-tile: {:?}", parts[1]))?;
+    let y: u32 = parts[2]
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid tile y in --center-tile: {:?}", parts[2]))?;
+    let n = 1u32
+        .checked_shl(u32::from(z))
+        .ok_or_else(|| anyhow::anyhow!("zoom z={z} is too large"))?;
+    if x >= n || y >= n {
+        bail!("tile x/y must be < 2^z for z={z} (max index {})", n.saturating_sub(1));
+    }
+    Ok((z, x, y))
 }
 
 // --- Data loading ---
@@ -269,6 +315,13 @@ fn block_with_title(title: impl Into<Line<'static>>) -> Block<'static> {
     Block::default().borders(Borders::ALL).title(title)
 }
 
+/// Area where the map canvas actually draws (inside borders + title).
+/// Must stay in sync with `render_map_panel` and `render_mbtiles_map_panel`, which both use
+/// `block_with_title`.
+fn map_canvas_area(outer: Rect) -> Rect {
+    block_with_title(" ").inner(outer)
+}
+
 /// Helper to build `Span::styled(format!("{name}: "), STYLE_LABEL)` + raw value.
 fn stat_line(name: &str, val: &dyn std::fmt::Display) -> Line<'static> {
     Line::from(vec![
@@ -382,6 +435,22 @@ fn run_app_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> anyho
     let mut last_hover_redraw: Option<Instant> = None;
 
     loop {
+        // Process incoming mbtiles tile results and request visible tiles.
+        if app.mode == ViewMode::MbtilesMap
+            && let Some(ref mut mbt) = app.mbt_state {
+                if mbt.process_results() {
+                    app.needs_redraw = true;
+                }
+                let visible = mbt.visible_tiles();
+                for (z, x, y) in visible {
+                    mbt.request_tile_with_ancestors(z, x, y);
+                }
+                if app.needs_redraw {
+                    // request redraw in 16ms so loading tiles appear as they arrive
+                    app.needs_redraw = true;
+                }
+            }
+
         if let Some(rows) = app.analysis_rx.as_ref().and_then(|rx| rx.try_recv().ok()) {
             if rows.len() == app.files.len() {
                 for (i, row) in rows.into_iter().enumerate() {
@@ -496,7 +565,20 @@ fn run_app_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> anyho
                         props_area = Some(left[1]);
                         geom_area = Some(ga);
                         left_area = Some(cols[0]);
-                        map_area = Some(cols[1]);
+                        map_area = Some(map_canvas_area(cols[1]));
+                    }
+                    ViewMode::MbtilesMap => {
+                        let cols = Layout::default()
+                            .direction(Direction::Horizontal)
+                            .constraints([
+                                Constraint::Percentage(app.left_pct),
+                                Constraint::Percentage(100u16.saturating_sub(app.left_pct)),
+                            ])
+                            .split(f.area());
+                        render_mbtiles_hover_panel(f, cols[0], app);
+                        render_mbtiles_map_panel(f, cols[1], app);
+                        left_area = Some(cols[0]);
+                        map_area = Some(map_canvas_area(cols[1]));
                     }
                 }
                 if app.error_popup.is_some() {
@@ -600,8 +682,13 @@ fn run_app_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> anyho
                     _ => {}
                 },
                 Event::Mouse(mouse) => match mouse.kind {
-                    MouseEventKind::Up(_) if app.resizing.take().is_some() => {
-                        app.invalidate();
+                    MouseEventKind::Up(_) => {
+                        if let Some(ref mut mbt) = app.mbt_state {
+                            mbt.map_drag_last = None;
+                        }
+                        if app.resizing.take().is_some() {
+                            app.invalidate();
+                        }
                     }
                     MouseEventKind::Moved | MouseEventKind::Drag(_) => {
                         if let Some(handle) = app.resizing {
@@ -642,6 +729,23 @@ fn run_app_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> anyho
                             }
                             app.invalidate();
                             continue;
+                        }
+                        if app.mode == ViewMode::MbtilesMap {
+                            if let MouseEventKind::Drag(MouseButton::Left) = mouse.kind {
+                                if let (Some(area), Some(ref mut mbt)) =
+                                    (map_area, app.mbt_state.as_mut())
+                                {
+                                    if let Some((lc, lr)) = mbt.map_drag_last {
+                                        let dc = i32::from(mouse.column) - i32::from(lc);
+                                        let dr = i32::from(mouse.row) - i32::from(lr);
+                                        if dc != 0 || dr != 0 {
+                                            mbt.pan_by_pixels(area.width, area.height, dc, dr);
+                                            mbt.map_drag_last = Some((mouse.column, mouse.row));
+                                            app.needs_redraw = true;
+                                        }
+                                    }
+                                }
+                            }
                         }
                         let prev = app.hovered.clone();
                         app.hovered = None;
@@ -685,11 +789,59 @@ fn run_app_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> anyho
                                 app.invalidate();
                             }
                         }
+
+                        // MbtilesMap: update hover on mouse move over the map.
+                        if app.mode == ViewMode::MbtilesMap
+                            && let Some(area) = map_area
+                            && point_in_rect(mouse.column, mouse.row, area)
+                            && let Some(ref mut mbt) = app.mbt_state
+                        {
+                            let rx = f64::from(mouse.column - area.x) / f64::from(area.width);
+                            let ry = f64::from(mouse.row - area.y) / f64::from(area.height);
+                            let (wx, wy) = mbt.viewport_world_at_fracs(rx, ry);
+                            let prev_hov = mbt.hovered.clone();
+                            mbt.find_hovered(wx, wy);
+                            if mbt.hovered != prev_hov {
+                                let allow = last_hover_redraw
+                                    .is_none_or(|t| t.elapsed() >= HOVER_REDRAW_THROTTLE);
+                                if allow {
+                                    last_hover_redraw = Some(Instant::now());
+                                    app.invalidate();
+                                }
+                            }
+                        }
                     }
                     MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
                         let up = matches!(mouse.kind, MouseEventKind::ScrollUp);
                         let s = app.scroll_step();
                         let step = u16::try_from(s)?;
+
+                        // MbtilesMap: scroll zooms in/out centred on the cursor.
+                        if app.mode == ViewMode::MbtilesMap
+                            && let (Some(area), Some(ref mut mbt)) =
+                                (map_area, app.mbt_state.as_mut())
+                            {
+                                if point_in_rect(mouse.column, mouse.row, area) {
+                                    let rx =
+                                        f64::from(mouse.column - area.x) / f64::from(area.width);
+                                    let ry =
+                                        f64::from(mouse.row - area.y) / f64::from(area.height);
+                                    let (wx, wy) = mbt.viewport_world_at_fracs(rx, ry);
+                                    mbt.zoom_wheel_at(wx, wy, up);
+                                    app.needs_redraw = true;
+                                    continue;
+                                }
+                                // Properties panel scroll
+                                if left_area
+                                    .is_some_and(|a| point_in_rect(mouse.column, mouse.row, a))
+                                {
+                                    app.properties_scroll =
+                                        scroll_by(app.properties_scroll, step, up);
+                                    app.invalidate();
+                                    continue;
+                                }
+                            }
+
                         if app.mode == ViewMode::FileBrowser {
                             if filter_area
                                 .is_some_and(|a| point_in_rect(mouse.column, mouse.row, a))
@@ -736,7 +888,16 @@ fn run_app_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> anyho
                             app.move_down_by(s);
                         }
                     }
-                    MouseEventKind::Down(_) => {
+                    MouseEventKind::Down(btn) => {
+                        if app.mode == ViewMode::MbtilesMap && btn == MouseButton::Left {
+                            if let (Some(area), Some(ref mut mbt)) =
+                                (map_area, app.mbt_state.as_mut())
+                                && point_in_rect(mouse.column, mouse.row, area)
+                            {
+                                mbt.map_drag_last = Some((mouse.column, mouse.row));
+                                continue;
+                            }
+                        }
                         if app.mode == ViewMode::FileBrowser {
                             if let Some(fl) = file_left {
                                 let dx = fl.x + fl.width;

--- a/rust/mlt/src/ui/mod.rs
+++ b/rust/mlt/src/ui/mod.rs
@@ -86,8 +86,7 @@ pub fn ui(args: &UiArgs) -> anyhow::Result<()> {
         let mut mbt = MbtilesState::new(args.path.clone());
         if let Some(ref s) = args.center_tile {
             let (z, x, y) = parse_center_tile_xyz(s)?;
-            mbt
-                .set_viewport_to_tile(z, x, y)
+            mbt.set_viewport_to_tile(z, x, y)
                 .map_err(|e| anyhow::anyhow!(e))?;
         }
         App::new_mbtiles(mbt, args.path.clone())
@@ -147,7 +146,10 @@ fn parse_center_tile_xyz(s: &str) -> anyhow::Result<(u8, u32, u32)> {
         .checked_shl(u32::from(z))
         .ok_or_else(|| anyhow::anyhow!("zoom z={z} is too large"))?;
     if x >= n || y >= n {
-        bail!("tile x/y must be < 2^z for z={z} (max index {})", n.saturating_sub(1));
+        bail!(
+            "tile x/y must be < 2^z for z={z} (max index {})",
+            n.saturating_sub(1)
+        );
     }
     Ok((z, x, y))
 }
@@ -437,19 +439,20 @@ fn run_app_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> anyho
     loop {
         // Process incoming mbtiles tile results and request visible tiles.
         if app.mode == ViewMode::MbtilesMap
-            && let Some(ref mut mbt) = app.mbt_state {
-                if mbt.process_results() {
-                    app.needs_redraw = true;
-                }
-                let visible = mbt.visible_tiles();
-                for (z, x, y) in visible {
-                    mbt.request_tile_with_ancestors(z, x, y);
-                }
-                if app.needs_redraw {
-                    // request redraw in 16ms so loading tiles appear as they arrive
-                    app.needs_redraw = true;
-                }
+            && let Some(ref mut mbt) = app.mbt_state
+        {
+            if mbt.process_results() {
+                app.needs_redraw = true;
             }
+            let visible = mbt.visible_tiles();
+            for (z, x, y) in visible {
+                mbt.request_tile_with_ancestors(z, x, y);
+            }
+            if app.needs_redraw {
+                // request redraw in 16ms so loading tiles appear as they arrive
+                app.needs_redraw = true;
+            }
+        }
 
         if let Some(rows) = app.analysis_rx.as_ref().and_then(|rx| rx.try_recv().ok()) {
             if rows.len() == app.files.len() {
@@ -820,27 +823,23 @@ fn run_app_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> anyho
                         if app.mode == ViewMode::MbtilesMap
                             && let (Some(area), Some(ref mut mbt)) =
                                 (map_area, app.mbt_state.as_mut())
-                            {
-                                if point_in_rect(mouse.column, mouse.row, area) {
-                                    let rx =
-                                        f64::from(mouse.column - area.x) / f64::from(area.width);
-                                    let ry =
-                                        f64::from(mouse.row - area.y) / f64::from(area.height);
-                                    let (wx, wy) = mbt.viewport_world_at_fracs(rx, ry);
-                                    mbt.zoom_wheel_at(wx, wy, up);
-                                    app.needs_redraw = true;
-                                    continue;
-                                }
-                                // Properties panel scroll
-                                if left_area
-                                    .is_some_and(|a| point_in_rect(mouse.column, mouse.row, a))
-                                {
-                                    app.properties_scroll =
-                                        scroll_by(app.properties_scroll, step, up);
-                                    app.invalidate();
-                                    continue;
-                                }
+                        {
+                            if point_in_rect(mouse.column, mouse.row, area) {
+                                let rx = f64::from(mouse.column - area.x) / f64::from(area.width);
+                                let ry = f64::from(mouse.row - area.y) / f64::from(area.height);
+                                let (wx, wy) = mbt.viewport_world_at_fracs(rx, ry);
+                                mbt.zoom_wheel_at(wx, wy, up);
+                                app.needs_redraw = true;
+                                continue;
                             }
+                            // Properties panel scroll
+                            if left_area.is_some_and(|a| point_in_rect(mouse.column, mouse.row, a))
+                            {
+                                app.properties_scroll = scroll_by(app.properties_scroll, step, up);
+                                app.invalidate();
+                                continue;
+                            }
+                        }
 
                         if app.mode == ViewMode::FileBrowser {
                             if filter_area

--- a/rust/mlt/src/ui/rendering/help.rs
+++ b/rust/mlt/src/ui/rendering/help.rs
@@ -60,6 +60,7 @@ pub fn render_help_overlay(f: &mut Frame<'_>, app: &mut App) {
     let lines = match app.mode {
         ViewMode::FileBrowser => help_file_browser(),
         ViewMode::LayerOverview => help_layer_overview(),
+        ViewMode::MbtilesMap => help_mbtiles_map(),
     };
     let height = u16::try_from(lines.len())
         .unwrap_or(u16::MAX)
@@ -124,6 +125,26 @@ fn help_file_browser() -> Vec<Line<'static>> {
         heading("Filter Panel"),
         key("Click checkbox", "Toggle geometry/algorithm filter"),
         key("Click [Reset]", "Clear all filters"),
+    ]
+}
+
+fn help_mbtiles_map() -> Vec<Line<'static>> {
+    vec![
+        heading("Keyboard"),
+        key("?  h  F1", "Toggle this help"),
+        key("q  Ctrl+c  Esc", "Quit"),
+        Line::from(""),
+        heading("Mouse"),
+        key("Scroll on map", "Zoom ±0.5 levels (centred on cursor)"),
+        key("Left-drag on map", "Pan"),
+        key("Hover over map", "Inspect feature properties in left panel"),
+        Line::from(""),
+        heading("Map Colors"),
+        color(CLR_POINT, "Magenta", "Point"),
+        color(CLR_LINE, "Cyan", "LineString"),
+        color(CLR_POLYGON, "Blue", "Polygon"),
+        color(CLR_EXTENT, "Dark gray", "Tile boundaries"),
+        color(CLR_HOVERED, "White", "Hovered feature"),
     ]
 }
 

--- a/rust/mlt/src/ui/rendering/layers.rs
+++ b/rust/mlt/src/ui/rendering/layers.rs
@@ -6,6 +6,7 @@ use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::prelude::{Line, Modifier, Span, Style};
 use ratatui::widgets::{Paragraph, Wrap};
 
+use crate::ui::mbt::MbtTileData;
 use crate::ui::state::{App, TreeItem, ViewMode};
 use crate::ui::{
     CLR_HOVERED_TREE, STYLE_LABEL, STYLE_SELECTED, block_with_title, feature_suffix,
@@ -99,7 +100,7 @@ pub fn render_tree_panel(f: &mut Frame<'_>, area: Rect, app: &mut App) {
                 .unwrap_or("unknown");
             format!("{name} - Enter/+/-:expand, Esc:back, h:help, q:quit")
         }
-        ViewMode::FileBrowser => "Features".into(),
+        ViewMode::FileBrowser | ViewMode::MbtilesMap => "Features".into(),
     };
     let inner = area.height.saturating_sub(2) as usize;
     app.tree_inner_height = inner;
@@ -284,6 +285,57 @@ fn subpart_stats_lines(geom: &Geom32, part: usize) -> Vec<Line<'static>> {
         _ => {}
     }
     lines
+}
+
+// ---------------------------------------------------------------------------
+// MBTiles hover properties panel
+// ---------------------------------------------------------------------------
+
+/// Renders the left panel for `MbtilesMap` mode: shows hovered feature properties only.
+pub fn render_mbtiles_hover_panel(f: &mut Frame<'_>, area: Rect, app: &mut App) {
+    let (title, lines) = mbt_hover_title_and_lines(app);
+    let inner = area.height.saturating_sub(2) as usize;
+    let max = u16::try_from(lines.len().saturating_sub(inner)).unwrap_or(0);
+    app.properties_scroll = app.properties_scroll.min(max);
+    let para = Paragraph::new(lines)
+        .block(block_with_title(title))
+        .wrap(Wrap { trim: true })
+        .scroll((app.properties_scroll, 0));
+    f.render_widget(para, area);
+}
+
+fn mbt_hover_title_and_lines(app: &App) -> (String, Vec<Line<'static>>) {
+    let Some(ref mbt) = app.mbt_state else {
+        return (
+            "Properties".into(),
+            vec![Line::from("No mbtiles loaded")],
+        );
+    };
+    let Some(ref h) = mbt.hovered else {
+        return (
+            "Properties".into(),
+            vec![Line::from("Hover over a feature to inspect properties")],
+        );
+    };
+    let Some(MbtTileData::Loaded { fc, layer_groups, .. }) = mbt.tiles.get(&h.tile) else {
+        return (
+            "Properties".into(),
+            vec![Line::from("Tile loading…")],
+        );
+    };
+    let Some(group) = layer_groups.get(h.layer_idx) else {
+        return ("Properties".into(), vec![Line::from("(feature not found)")]);
+    };
+    let Some(&gi) = group.feature_indices.get(h.feat_idx) else {
+        return ("Properties".into(), vec![Line::from("(feature not found)")]);
+    };
+    let feat = &fc.features[gi];
+    let (z, tx, ty) = h.tile;
+    let title = format!(
+        "Properties — {} feat {} (tile {z}/{tx}/{ty})",
+        group.name, h.feat_idx
+    );
+    (title, feature_property_lines(feat))
 }
 
 fn render_geometry_stats(f: &mut Frame<'_>, area: Rect, app: &App) {

--- a/rust/mlt/src/ui/rendering/layers.rs
+++ b/rust/mlt/src/ui/rendering/layers.rs
@@ -306,10 +306,7 @@ pub fn render_mbtiles_hover_panel(f: &mut Frame<'_>, area: Rect, app: &mut App) 
 
 fn mbt_hover_title_and_lines(app: &App) -> (String, Vec<Line<'static>>) {
     let Some(ref mbt) = app.mbt_state else {
-        return (
-            "Properties".into(),
-            vec![Line::from("No mbtiles loaded")],
-        );
+        return ("Properties".into(), vec![Line::from("No mbtiles loaded")]);
     };
     let Some(ref h) = mbt.hovered else {
         return (
@@ -317,11 +314,11 @@ fn mbt_hover_title_and_lines(app: &App) -> (String, Vec<Line<'static>>) {
             vec![Line::from("Hover over a feature to inspect properties")],
         );
     };
-    let Some(MbtTileData::Loaded { fc, layer_groups, .. }) = mbt.tiles.get(&h.tile) else {
-        return (
-            "Properties".into(),
-            vec![Line::from("Tile loading…")],
-        );
+    let Some(MbtTileData::Loaded {
+        fc, layer_groups, ..
+    }) = mbt.tiles.get(&h.tile)
+    else {
+        return ("Properties".into(), vec![Line::from("Tile loading…")]);
     };
     let Some(group) = layer_groups.get(h.layer_idx) else {
         return ("Properties".into(), vec![Line::from("(feature not found)")]);

--- a/rust/mlt/src/ui/rendering/layers.rs
+++ b/rust/mlt/src/ui/rendering/layers.rs
@@ -314,11 +314,22 @@ fn mbt_hover_title_and_lines(app: &App) -> (String, Vec<Line<'static>>) {
             vec![Line::from("Hover over a feature to inspect properties")],
         );
     };
+    let tile_entry = mbt.tiles.get(&h.tile);
     let Some(MbtTileData::Loaded {
         fc, layer_groups, ..
-    }) = mbt.tiles.get(&h.tile)
+    }) = tile_entry
     else {
-        return ("Properties".into(), vec![Line::from("Tile loading…")]);
+        let msg: String = match tile_entry {
+            Some(MbtTileData::Empty) => "Tile empty (no vector data)".into(),
+            Some(MbtTileData::Error(e)) => {
+                let snippet: String = e.chars().take(160).collect();
+                format!("Tile error: {snippet}")
+            }
+            None | Some(MbtTileData::Loading | MbtTileData::Loaded { .. }) => {
+                "Tile loading…".into()
+            }
+        };
+        return ("Properties".into(), vec![Line::from(msg)]);
     };
     let Some(group) = layer_groups.get(h.layer_idx) else {
         return ("Properties".into(), vec![Line::from("(feature not found)")]);

--- a/rust/mlt/src/ui/rendering/map.rs
+++ b/rust/mlt/src/ui/rendering/map.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use geo_types::Polygon;
 use mlt_core::geojson::FeatureCollection;
 use mlt_core::{Coord32, Geom32};
@@ -7,10 +9,11 @@ use ratatui::prelude::{Span, Style};
 use ratatui::style::Color;
 use ratatui::widgets::canvas::{Canvas, Context, Line as CanvasLine, Rectangle};
 
-use crate::ui::state::{App, TreeItem};
+use crate::ui::mbt::{MbtHoveredInfo, MbtTileData, TileTransform};
+use crate::ui::state::{App, LayerGroup, TreeItem};
 use crate::ui::{
-    CLR_EXTENT, CLR_HOVERED, CLR_INNER_RING, CLR_INNER_RING_SEL, CLR_POLYGON, CLR_SELECTED,
-    block_with_title, coord_f64, geometry_color, is_ring_ccw, part_color,
+    CLR_DIMMED, CLR_EXTENT, CLR_HOVERED, CLR_INNER_RING, CLR_INNER_RING_SEL, CLR_POLYGON,
+    CLR_SELECTED, block_with_title, coord_f64, geometry_color, is_ring_ccw, part_color,
 };
 
 pub fn render_map_panel(f: &mut Frame<'_>, area: Rect, app: &App) {
@@ -172,5 +175,255 @@ fn draw_polygon(ctx: &mut Context<'_>, poly: &Polygon<i32>, highlighted: bool, f
     draw_ring(ctx, ext, ring_color(ext, highlighted, fallback));
     for ring in poly.interiors() {
         draw_ring(ctx, &ring.0, ring_color(&ring.0, highlighted, fallback));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MBTiles world-map rendering
+// ---------------------------------------------------------------------------
+
+/// Draw all layers from a decoded tile (`data_tile` is the MVT source key used for hover match).
+fn draw_mbtiles_loaded_tile_layers(
+    ctx: &mut Context<'_>,
+    hovered: Option<&MbtHoveredInfo>,
+    data_tile: (u8, u32, u32),
+    fc: &FeatureCollection,
+    extent: u32,
+    layer_groups: &[LayerGroup],
+    vy0: f64,
+    vy1: f64,
+) {
+    let (tz, tx, ty) = data_tile;
+    let transform = TileTransform::new(tz, tx, ty, extent);
+    let hov_gi = hovered.and_then(|h| {
+        if h.tile != (tz, tx, ty) {
+            return None;
+        }
+        layer_groups
+            .get(h.layer_idx)
+            .and_then(|g| g.feature_indices.get(h.feat_idx))
+            .copied()
+    });
+    for group in layer_groups {
+        for &gi in &group.feature_indices {
+            let feat = &fc.features[gi];
+            let base = geometry_color(&feat.geometry);
+            let is_hov = hov_gi == Some(gi);
+            let color = if is_hov { CLR_HOVERED } else { base };
+            draw_geom_world(ctx, &feat.geometry, &transform, vy0, vy1, color);
+        }
+    }
+}
+
+/// Render the interactive world map for an .mbtiles file.
+///
+/// World coordinate space: x ∈ [0,1] west→east, y ∈ [0,1] north→south.
+///
+/// `y_bounds` must be `[min_y, max_y]` with `min_y < max_y` for ratatui's `Painter` clip math.
+/// The painter maps **larger** world Y toward the **top** of the widget, so we reflect each
+/// geographic `wy` with [`mbt_screen_y`] to get north-up on screen.
+pub fn render_mbtiles_map_panel(f: &mut Frame<'_>, area: Rect, app: &App) {
+    let Some(ref mbt) = app.mbt_state else {
+        return;
+    };
+    let visible = mbt.visible_tiles();
+    let (cz, cx, cy) = mbt.center_tile_xyz();
+    let title = format!(
+        "World Map — {cz}/{cx}/{cy} — zoom {:.1}  drag=pan  hover=info  q/Esc quit",
+        mbt.zoom_f
+    );
+
+    let canvas = Canvas::default()
+        .block(block_with_title(title))
+        .x_bounds([mbt.vp_x0, mbt.vp_x1])
+        .y_bounds([mbt.vp_y0, mbt.vp_y1])
+        .paint(|ctx| {
+            let vy0 = mbt.vp_y0;
+            let vy1 = mbt.vp_y1;
+
+            // Under native resolution: draw each loaded ancestor at most once (world-aligned).
+            let mut overzoom_drawn: HashSet<(u8, u32, u32)> = HashSet::new();
+            for &(tz, tx, ty) in &visible {
+                if matches!(
+                    mbt.tiles.get(&(tz, tx, ty)),
+                    Some(MbtTileData::Loaded { .. })
+                ) {
+                    continue;
+                }
+                let Some((sz, sx, sy)) = mbt.find_overzoom_source(tz, tx, ty) else {
+                    continue;
+                };
+                if !overzoom_drawn.insert((sz, sx, sy)) {
+                    continue;
+                }
+                let Some(MbtTileData::Loaded {
+                    fc,
+                    extent,
+                    layer_groups,
+                    ..
+                }) = mbt.tiles.get(&(sz, sx, sy))
+                else {
+                    continue;
+                };
+                draw_mbtiles_loaded_tile_layers(
+                    ctx,
+                    mbt.hovered.as_ref(),
+                    (sz, sx, sy),
+                    fc,
+                    *extent,
+                    layer_groups,
+                    vy0,
+                    vy1,
+                );
+            }
+
+            for &(tz, tx, ty) in &visible {
+                let n = f64::from(1u32 << tz);
+                let x0 = f64::from(tx) / n;
+                let y0 = f64::from(ty) / n;
+                let x1 = f64::from(tx + 1) / n;
+                let y1 = f64::from(ty + 1) / n;
+
+                // Draw tile border.
+                draw_world_rect_vp(ctx, vy0, vy1, x0, y0, x1, y1, CLR_EXTENT);
+
+                let Some(tile_data) = mbt.tiles.get(&(tz, tx, ty)) else {
+                    continue;
+                };
+
+                match tile_data {
+                    MbtTileData::Loading => {
+                        let cx = f64::midpoint(x0, x1);
+                        let cy = f64::midpoint(y0, y1);
+                        let sy = mbt_screen_y(vy0, vy1, cy);
+                        ctx.print(cx, sy, Span::styled("…", Style::default().fg(CLR_DIMMED)));
+                    }
+                    MbtTileData::Loaded { fc, extent, layer_groups, .. } => {
+                        draw_mbtiles_loaded_tile_layers(
+                            ctx,
+                            mbt.hovered.as_ref(),
+                            (tz, tx, ty),
+                            fc,
+                            *extent,
+                            layer_groups,
+                            vy0,
+                            vy1,
+                        );
+                    }
+                    MbtTileData::Empty | MbtTileData::Error(_) => {}
+                }
+            }
+        });
+
+    f.render_widget(canvas, area);
+}
+
+/// Map geographic world Y to canvas Y so north is at the top of the map widget.
+#[inline]
+fn mbt_screen_y(vp_y0: f64, vp_y1: f64, wy: f64) -> f64 {
+    vp_y0 + vp_y1 - wy
+}
+
+/// Draw the four edges of a world-coordinate tile rectangle (north-up).
+fn draw_world_rect_vp(
+    ctx: &mut Context<'_>,
+    vp_y0: f64,
+    vp_y1: f64,
+    x0: f64,
+    y0: f64,
+    x1: f64,
+    y1: f64,
+    color: Color,
+) {
+    let s0 = mbt_screen_y(vp_y0, vp_y1, y0);
+    let s1 = mbt_screen_y(vp_y0, vp_y1, y1);
+    ctx.draw(&CanvasLine::new(x0, s0, x1, s0, color));
+    ctx.draw(&CanvasLine::new(x0, s1, x1, s1, color));
+    ctx.draw(&CanvasLine::new(x0, s0, x0, s1, color));
+    ctx.draw(&CanvasLine::new(x1, s0, x1, s1, color));
+}
+
+/// Draw a geometry in world coordinates using the provided tile transform (north-up on canvas).
+fn draw_geom_world(
+    ctx: &mut Context<'_>,
+    geom: &Geom32,
+    t: &TileTransform,
+    vp_y0: f64,
+    vp_y1: f64,
+    color: Color,
+) {
+    match geom {
+        Geom32::Point(p) => {
+            let [wx, wy] = t.to_world(p.0);
+            let sy = mbt_screen_y(vp_y0, vp_y1, wy);
+            ctx.print(wx, sy, Span::styled("×", Style::default().fg(color)));
+        }
+        Geom32::LineString(ls) => draw_world_line(ctx, &ls.0, t, vp_y0, vp_y1, color),
+        Geom32::Polygon(poly) => {
+            draw_world_ring(ctx, &poly.exterior().0, t, vp_y0, vp_y1, color);
+            for ring in poly.interiors() {
+                draw_world_ring(ctx, &ring.0, t, vp_y0, vp_y1, color);
+            }
+        }
+        Geom32::MultiPoint(mp) => {
+            for p in mp.iter() {
+                let [wx, wy] = t.to_world(p.0);
+                let sy = mbt_screen_y(vp_y0, vp_y1, wy);
+                ctx.print(wx, sy, Span::styled("×", Style::default().fg(color)));
+            }
+        }
+        Geom32::MultiLineString(mls) => {
+            for ls in mls.iter() {
+                draw_world_line(ctx, &ls.0, t, vp_y0, vp_y1, color);
+            }
+        }
+        Geom32::MultiPolygon(mpoly) => {
+            for poly in mpoly.iter() {
+                draw_world_ring(ctx, &poly.exterior().0, t, vp_y0, vp_y1, color);
+                for ring in poly.interiors() {
+                    draw_world_ring(ctx, &ring.0, t, vp_y0, vp_y1, color);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn draw_world_line(
+    ctx: &mut Context<'_>,
+    coords: &[Coord32],
+    t: &TileTransform,
+    vp_y0: f64,
+    vp_y1: f64,
+    color: Color,
+) {
+    for w in coords.windows(2) {
+        let [xa, ya] = t.to_world(w[0]);
+        let [xb, yb] = t.to_world(w[1]);
+        let sa = mbt_screen_y(vp_y0, vp_y1, ya);
+        let sb = mbt_screen_y(vp_y0, vp_y1, yb);
+        ctx.draw(&CanvasLine::new(xa, sa, xb, sb, color));
+    }
+}
+
+fn draw_world_ring(
+    ctx: &mut Context<'_>,
+    ring: &[Coord32],
+    t: &TileTransform,
+    vp_y0: f64,
+    vp_y1: f64,
+    color: Color,
+) {
+    draw_world_line(ctx, ring, t, vp_y0, vp_y1, color);
+    if let (Some(&last), Some(&first)) = (ring.last(), ring.first()) {
+        let [lx, ly] = t.to_world(last);
+        let [fx, fy] = t.to_world(first);
+        ctx.draw(&CanvasLine::new(
+            lx,
+            mbt_screen_y(vp_y0, vp_y1, ly),
+            fx,
+            mbt_screen_y(vp_y0, vp_y1, fy),
+            color,
+        ));
     }
 }

--- a/rust/mlt/src/ui/rendering/map.rs
+++ b/rust/mlt/src/ui/rendering/map.rs
@@ -183,6 +183,7 @@ fn draw_polygon(ctx: &mut Context<'_>, poly: &Polygon<i32>, highlighted: bool, f
 // ---------------------------------------------------------------------------
 
 /// Draw all layers from a decoded tile (`data_tile` is the MVT source key used for hover match).
+#[allow(clippy::too_many_arguments)] // Canvas draw context + tile payload + viewport Y range.
 fn draw_mbtiles_loaded_tile_layers(
     ctx: &mut Context<'_>,
     hovered: Option<&MbtHoveredInfo>,
@@ -330,6 +331,7 @@ fn mbt_screen_y(vp_y0: f64, vp_y1: f64, wy: f64) -> f64 {
 }
 
 /// Draw the four edges of a world-coordinate tile rectangle (north-up).
+#[allow(clippy::too_many_arguments)] // Ratatui canvas line API; args map 1:1 to world corners + style.
 fn draw_world_rect_vp(
     ctx: &mut Context<'_>,
     vp_y0: f64,

--- a/rust/mlt/src/ui/rendering/map.rs
+++ b/rust/mlt/src/ui/rendering/map.rs
@@ -298,7 +298,12 @@ pub fn render_mbtiles_map_panel(f: &mut Frame<'_>, area: Rect, app: &App) {
                         let sy = mbt_screen_y(vy0, vy1, cy);
                         ctx.print(cx, sy, Span::styled("…", Style::default().fg(CLR_DIMMED)));
                     }
-                    MbtTileData::Loaded { fc, extent, layer_groups, .. } => {
+                    MbtTileData::Loaded {
+                        fc,
+                        extent,
+                        layer_groups,
+                        ..
+                    } => {
                         draw_mbtiles_loaded_tile_layers(
                             ctx,
                             mbt.hovered.as_ref(),

--- a/rust/mlt/src/ui/rendering/map.rs
+++ b/rust/mlt/src/ui/rendering/map.rs
@@ -218,9 +218,9 @@ fn draw_mbtiles_loaded_tile_layers(
 
 /// Render the interactive world map for an .mbtiles file.
 ///
-/// World coordinate space: x ∈ [0,1] west→east, y ∈ [0,1] north→south.
+/// World coordinate space: `x ∈ [0, 1]` west→east, `y ∈ [0, 1]` north→south.
 ///
-/// `y_bounds` must be `[min_y, max_y]` with `min_y < max_y` for ratatui's `Painter` clip math.
+/// `y_bounds` must be `[min_y, max_y]` with `min_y < max_y` for Ratatui's `Painter` clip math.
 /// The painter maps **larger** world Y toward the **top** of the widget, so we reflect each
 /// geographic `wy` with [`mbt_screen_y`] to get north-up on screen.
 pub fn render_mbtiles_map_panel(f: &mut Frame<'_>, area: Rect, app: &App) {

--- a/rust/mlt/src/ui/state.rs
+++ b/rust/mlt/src/ui/state.rs
@@ -10,6 +10,7 @@ use ratatui::widgets::TableState;
 use rstar::{PointDistance as _, RTree};
 
 use crate::ls::{FileAlgorithm, FileSortColumn, LsRow};
+use crate::ui::mbt::MbtilesState;
 use crate::ui::{
     GeometryIndexEntry, auto_expand, coord_f64, group_by_layer, is_entry_visible, load_fc,
     multi_part_count,
@@ -19,6 +20,8 @@ use crate::ui::{
 pub enum ViewMode {
     FileBrowser,
     LayerOverview,
+    /// Interactive world map viewer for .mbtiles files.
+    MbtilesMap,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -144,6 +147,8 @@ pub struct App {
     pub(crate) preview_extent: u32,
     pub(crate) preview_rx: Option<mpsc::Receiver<PreviewValue>>,
     pub(crate) preview_load_requested: Option<PathBuf>,
+    /// State for the `MbtilesMap` mode (Some only when mode == `MbtilesMap`).
+    pub(crate) mbt_state: Option<Box<MbtilesState>>,
 }
 
 impl Default for App {
@@ -201,6 +206,7 @@ impl Default for App {
             preview_extent: 4096,
             preview_rx: None,
             preview_load_requested: None,
+            mbt_state: None,
         }
     }
 }
@@ -220,6 +226,15 @@ impl App {
             analysis_rx,
             file_browser_base: Some(base_path),
             filtered_file_indices,
+            ..Self::default()
+        }
+    }
+
+    pub(crate) fn new_mbtiles(mbt_state: MbtilesState, path: PathBuf) -> Self {
+        Self {
+            mode: ViewMode::MbtilesMap,
+            current_file: Some(path),
+            mbt_state: Some(Box::new(mbt_state)),
             ..Self::default()
         }
     }
@@ -405,6 +420,7 @@ impl App {
                     self.invalidate_bounds();
                 }
             }
+            ViewMode::MbtilesMap => {}
         }
     }
 
@@ -419,7 +435,7 @@ impl App {
     pub(crate) fn page_size(&self) -> usize {
         match self.mode {
             ViewMode::FileBrowser => self.file_table_inner_height,
-            ViewMode::LayerOverview => self.tree_inner_height,
+            ViewMode::LayerOverview | ViewMode::MbtilesMap => self.tree_inner_height,
         }
     }
 
@@ -468,6 +484,7 @@ impl App {
                 }
                 _ => {}
             },
+            ViewMode::MbtilesMap => {}
         }
     }
 
@@ -538,7 +555,7 @@ impl App {
 
     pub(crate) fn handle_escape(&mut self) -> bool {
         match self.mode {
-            ViewMode::FileBrowser => true,
+            ViewMode::FileBrowser | ViewMode::MbtilesMap => true,
             ViewMode::LayerOverview if self.files.is_empty() => true,
             ViewMode::LayerOverview => {
                 self.mode = ViewMode::FileBrowser;

--- a/rust/mod.just
+++ b/rust/mod.just
@@ -231,7 +231,7 @@ download-benchmark-tiles outdir='/tmp/benchmark-tiles' maxzoom='6': (just 'insta
 
 # Build and open code documentation
 docs *args='--open':
-    DOCS_RS=1 cargo doc --no-deps {{args}} --features arbitrary --package mlt-core
+    DOCS_RS=1 cargo doc --no-deps {{args}} --features arbitrary --workspace
 
 alias f := fmt
 fmt: (_fmt) (_fmt '--manifest-path' 'mlt-core/fuzz/Cargo.toml')


### PR DESCRIPTION
Just browse the .mbtiles file the way you browse a map in a browser.

Note:  All of the `ui` code at this point has been vibed, including this new .mbtiles browser. Eventually I plan to clean it up, but at this stage this is a testing tool that does not need to be as carefully planned as the core code.