### PR TITLE
fix(rust) from_tile tessellates when appropriate

### DIFF
--- a/rust/mlt-core/benches/encoding_e2e.rs
+++ b/rust/mlt-core/benches/encoding_e2e.rs
@@ -65,7 +65,10 @@ fn bench_encode(c: &mut Criterion) {
                 for logical in limit(LogicalEncoder::iter()) {
                     let int_enc = IntEncoder::new(logical, physical);
                     group.bench_with_input(
-                        BenchmarkId::new(format!("{logical:?}-{physical:?}/tessellate: {tessellate:?}"), zoom),
+                        BenchmarkId::new(
+                            format!("{logical:?}-{physical:?}/tessellate: {tessellate:?}"),
+                            zoom,
+                        ),
                         &tiles,
                         |b, tiles| {
                             b.iter_batched(

--- a/rust/mlt-core/benches/encoding_e2e.rs
+++ b/rust/mlt-core/benches/encoding_e2e.rs
@@ -3,7 +3,7 @@ use std::hint::black_box;
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use mlt_core::__private::{dec, parser};
 use mlt_core::Layer;
-use mlt_core::encoder::{LogicalEncoder, SortStrategy};
+use mlt_core::encoder::{EncoderConfig, LogicalEncoder, SortStrategy};
 use strum::IntoEnumIterator as _;
 
 #[path = "bench_utils.rs"]
@@ -25,7 +25,7 @@ fn limit<T>(values: impl Iterator<Item = T>) -> impl Iterator<Item = T> {
 ///
 /// Goes through `Layer01 → TileLayer01 → StagedLayer01`, which is the correct
 /// encode-pipeline entry point per CONTRIBUTING.md.
-fn decode_to_owned(tiles: &[(String, Vec<u8>)]) -> Vec<StagedLayer> {
+fn decode_to_owned(tiles: &[(String, Vec<u8>)], tessellate: bool) -> Vec<StagedLayer> {
     tiles
         .iter()
         .flat_map(|(_, data)| {
@@ -42,6 +42,7 @@ fn decode_to_owned(tiles: &[(String, Vec<u8>)]) -> Vec<StagedLayer> {
                         tile,
                         SortStrategy::Unsorted,
                         &[],
+                        tessellate,
                     )))
                 })
                 .collect::<Vec<_>>()
@@ -51,36 +52,40 @@ fn decode_to_owned(tiles: &[(String, Vec<u8>)]) -> Vec<StagedLayer> {
 
 fn bench_encode(c: &mut Criterion) {
     let mut group = c.benchmark_group("mlt encode");
-
     for zoom in BENCHMARKED_ZOOM_LEVELS {
         let tiles = load_mlt_tiles(zoom);
         let total_bytes: usize = tiles.iter().map(|(_, d)| d.len()).sum();
         group.throughput(Throughput::Bytes(total_bytes as u64));
-
-        for physical in limit(PhysicalEncoder::iter()) {
-            for logical in limit(LogicalEncoder::iter()) {
-                let int_enc = IntEncoder::new(logical, physical);
-                group.bench_with_input(
-                    BenchmarkId::new(format!("{logical:?}-{physical:?}"), zoom),
-                    &tiles,
-                    |b, tiles| {
-                        b.iter_batched(
-                            || decode_to_owned(tiles),
-                            |layers| {
-                                for layer in layers {
-                                    if let StagedLayer::Tag01(l) = layer {
-                                        let enc = Encoder::with_explicit(
-                                            Encoder::default().cfg,
-                                            ExplicitEncoder::all(int_enc),
-                                        );
-                                        black_box(l.encode_into(enc).expect("encode failed"));
+        for tessellate in [true, false] {
+            let enc_config = EncoderConfig {
+                tessellate,
+                ..Default::default()
+            };
+            for physical in limit(PhysicalEncoder::iter()) {
+                for logical in limit(LogicalEncoder::iter()) {
+                    let int_enc = IntEncoder::new(logical, physical);
+                    group.bench_with_input(
+                        BenchmarkId::new(format!("{logical:?}-{physical:?}/tessellate: {tessellate:?}"), zoom),
+                        &tiles,
+                        |b, tiles| {
+                            b.iter_batched(
+                                || decode_to_owned(tiles, enc_config.tessellate),
+                                |layers| {
+                                    for layer in layers {
+                                        if let StagedLayer::Tag01(l) = layer {
+                                            let enc = Encoder::with_explicit(
+                                                enc_config,
+                                                ExplicitEncoder::all(int_enc),
+                                            );
+                                            black_box(l.encode_into(enc).expect("encode failed"));
+                                        }
                                     }
-                                }
-                            },
-                            BatchSize::SmallInput,
-                        );
-                    },
-                );
+                                },
+                                BatchSize::SmallInput,
+                            );
+                        },
+                    );
+                }
             }
         }
     }

--- a/rust/mlt-core/benches/encoding_from_mvt.rs
+++ b/rust/mlt-core/benches/encoding_from_mvt.rs
@@ -32,7 +32,10 @@ fn parse_mvt_to_tile_layers(mvt_files: &[(String, Vec<u8>)]) -> Vec<TileLayer01>
 
 fn bench_encode_from_mvt(c: &mut Criterion) {
     let mut group = c.benchmark_group("mlt encode from mvt");
-    let cfg = EncoderConfig::default();
+    let cfg = EncoderConfig {
+        tessellate: true,
+        ..Default::default()
+    };
 
     for zoom in BENCHMARKED_ZOOM_LEVELS {
         let mvt_files = load_mvt_tiles(zoom);

--- a/rust/mlt-core/fuzz/src/decoded_layer.rs
+++ b/rust/mlt-core/fuzz/src/decoded_layer.rs
@@ -24,13 +24,15 @@ impl DecodedLayerInput {
 
         // Canonical roundtrip per CONTRIBUTING.md:
         // Tile → Staged → bytes → Tile
-        let tile2 = encode_decode(StagedLayer01::from_tile(tile1, SortStrategy::Unsorted, &[]));
+        let tile2 =
+            encode_decode(StagedLayer01::from_tile(tile1, SortStrategy::Unsorted, &[], false));
 
         // Same roundtrip again — must be a fixpoint.
         let tile3 = encode_decode(StagedLayer01::from_tile(
             tile2.clone(),
             SortStrategy::Unsorted,
             &[],
+            false,
         ));
 
         assert_eq!(tile2, tile3, "canonical roundtrip is not idempotent");

--- a/rust/mlt-core/src/encoder/optimizer.rs
+++ b/rust/mlt-core/src/encoder/optimizer.rs
@@ -89,24 +89,25 @@ impl TileLayer01 {
 
         let (last, init) = sort_by.split_last().expect("at least one strategy");
         if init.is_empty() {
-            StagedLayer01::from_tile(self, *last, &groups).encode_into(Encoder::new(cfg))?
+            StagedLayer01::from_tile(self, *last, &groups, cfg.tessellate)
+                .encode_into(Encoder::new(cfg))?
         } else {
             let mut enc: Encoder = {
                 let first = init[0];
-                StagedLayer01::from_tile(self.clone(), first, &groups)
+                StagedLayer01::from_tile(self.clone(), first, &groups, cfg.tessellate)
                     .encode_into(Encoder::new(cfg))?
             };
             let mut best = enc.preserve_results();
             // Clone for all-but-last strategies
             for &sort in &init[1..] {
-                let layer = StagedLayer01::from_tile(self.clone(), sort, &groups);
+                let layer = StagedLayer01::from_tile(self.clone(), sort, &groups, cfg.tessellate);
                 enc = layer.encode_into(enc)?;
                 if enc.total_len() < best.total_len() {
                     best = enc.preserve_results();
                 }
             }
             // Last strategy: consume self, no clone
-            let layer = StagedLayer01::from_tile(self, *last, &groups);
+            let layer = StagedLayer01::from_tile(self, *last, &groups, cfg.tessellate);
             enc = layer.encode_into(enc)?;
             if enc.total_len() < best.total_len() {
                 best = enc.preserve_results();

--- a/rust/mlt-core/src/encoder/property/tests.rs
+++ b/rust/mlt-core/src/encoder/property/tests.rs
@@ -644,7 +644,7 @@ fn str_vals(values: &[&str]) -> Vec<PropValue> {
 /// Stage a [`TileLayer01`] with `MinHash` grouping and return its properties.
 fn stage_props(tile: TileLayer01) -> Vec<StagedProperty> {
     let groups = group_string_properties(&tile);
-    StagedLayer01::from_tile(tile, SortStrategy::Unsorted, &groups).properties
+    StagedLayer01::from_tile(tile, SortStrategy::Unsorted, &groups, false).properties
 }
 
 #[test]

--- a/rust/mlt-core/src/encoder/sort.rs
+++ b/rust/mlt-core/src/encoder/sort.rs
@@ -385,11 +385,12 @@ mod tests {
     /// Encode the layer with a given sort strategy, decode it back, and return the `TileLayer01`.
     /// This tests the full encode→decode roundtrip, verifying that sorting was applied.
     fn sort_encode_decode(tile: TileLayer01, sort: SortStrategy) -> TileLayer01 {
+        let enc_cfg = Encoder::default().cfg;
         let enc = Encoder::with_explicit(
-            Encoder::default().cfg,
+            enc_cfg,
             ExplicitEncoder::for_id(IntEncoder::varint(), IdWidth::Id32),
         );
-        let enc = StagedLayer01::from_tile(tile, sort, &[])
+        let enc = StagedLayer01::from_tile(tile, sort, &[], enc_cfg.tessellate)
             .encode_into(enc)
             .expect("encode failed");
 

--- a/rust/mlt-core/src/encoder/tile.rs
+++ b/rust/mlt-core/src/encoder/tile.rs
@@ -24,12 +24,24 @@ impl StagedLayer01 {
     /// `groups` should be the output of `group_string_properties` called on the
     /// same [`TileLayer01`] source.  Because unique-value membership is
     /// row-order-independent, the same groups can be reused across sort trials.
+    ///
+    /// When `tessellate` is `true`, polygon and multi-polygon geometries have
+    /// their triangulation stored alongside the geometry.
     #[must_use]
     #[hotpath::measure]
-    pub fn from_tile(mut source: TileLayer01, sort: SortStrategy, groups: &[StringGroup]) -> Self {
+    pub fn from_tile(
+        mut source: TileLayer01,
+        sort: SortStrategy,
+        groups: &[StringGroup],
+        tessellate: bool,
+    ) -> Self {
         assert!(!source.features.is_empty(), "empty tile");
         source.sort(sort);
-        let mut geometry = GeometryValues::default();
+        let mut geometry = if tessellate {
+            GeometryValues::new_tessellated()
+        } else {
+            GeometryValues::default()
+        };
         for f in &source.features {
             geometry.push_geom(&f.geometry);
         }

--- a/rust/mlt-synthetics/src/layer.rs
+++ b/rust/mlt-synthetics/src/layer.rs
@@ -372,7 +372,12 @@ impl Layer {
             ids,
         } = self;
 
-        let mut geometry = if tessellate {
+        let enc_cfg = EncoderConfig {
+            tessellate,
+            ..EncoderConfig::default()
+        };
+
+        let mut geometry = if enc_cfg.tessellate {
             GeometryValues::new_tessellated()
         } else {
             GeometryValues::default()
@@ -427,10 +432,6 @@ impl Layer {
             override_presence: Box::new(move |_| force_presence),
         };
 
-        let enc_cfg = EncoderConfig {
-            tessellate,
-            ..EncoderConfig::default()
-        };
         StagedLayer01 {
             name: "layer1".to_string(),
             extent: extent.unwrap_or(80),


### PR DESCRIPTION
Currently tessellation only happens when building synthetics, not when building from_tile.