### PR TITLE
ci: add collector workflow with path-based filtering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,94 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      java: ${{ steps.filter.outputs.java }}
+      ts:   ${{ steps.filter.outputs.ts }}
+      cpp:  ${{ steps.filter.outputs.cpp }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            rust:
+              - 'justfile'
+              - 'rust/mod.just'
+              - '.github/**'
+              - 'rust/**'
+              - 'test/**'
+            java:
+              - 'justfile'
+              - 'java/mod.just'
+              - '.github/**'
+              - 'java/**'
+              - 'test/**'
+            ts:
+              - 'justfile'
+              - 'ts/mod.just'
+              - '.github/**'
+              - 'ts/**'
+              - 'test/**'
+            cpp:
+              - 'justfile'
+              - 'cpp/mod.just'
+              - '.github/**'
+              - 'cpp/**'
+              - 'test/**'
+
+  rust:
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    uses: ./.github/workflows/rust.yml
+    with:
+      run-release: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    secrets: inherit
+    permissions:
+      contents: write
+      id-token: write
+
+  java:
+    needs: changes
+    if: needs.changes.outputs.java == 'true'
+    uses: ./.github/workflows/java.yml
+    permissions:
+      id-token: write
+      contents: read
+
+  ts:
+    needs: changes
+    if: needs.changes.outputs.ts == 'true'
+    uses: ./.github/workflows/ts.yml
+    permissions:
+      contents: read
+
+  cpp:
+    needs: changes
+    if: needs.changes.outputs.cpp == 'true'
+    uses: ./.github/workflows/cpp.yml
+    permissions:
+      id-token: write
+      contents: read
+
+  docs:
+    uses: ./.github/workflows/gh-pages.yml
+    permissions:
+      contents: write
+
+  ci-passed:
+    needs: [rust, java, ts, cpp, docs]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ toJSON(needs) }}"
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -1,16 +1,7 @@
 name: C++ CI
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    paths:
-      - 'justfile'
-      - 'cpp/mod.just'
-      - '.github/**'
-      - 'cpp/**'
-      - 'test/**'
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,9 +1,7 @@
 name: Publish docs
 
 on:
-  push:
-    branches: [main]
-  pull_request:
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -1,16 +1,7 @@
 name: Java CI
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    paths:
-      - 'justfile'
-      - 'java/mod.just'
-      - '.github/**'
-      - 'java/**'
-      - 'test/**'
+  workflow_call:
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,16 +1,11 @@
 name: Rust CI
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    paths:
-      - "justfile"
-      - "rust/mod.just"
-      - ".github/**"
-      - "rust/**"
-      - "test/**"
+  workflow_call:
+    inputs:
+      run-release:
+        type: boolean
+        default: false
   workflow_dispatch:
 
 jobs:
@@ -202,8 +197,7 @@ jobs:
     if: |
       always()
       && needs.ci-passed-rust.result == 'success'
-      && github.event_name == 'push'
-      && github.ref == 'refs/heads/main'
+      && inputs.run-release
       && github.repository_owner == 'maplibre'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -1,16 +1,7 @@
 name: TypeScript CI
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    paths:
-      - 'justfile'
-      - 'ts/mod.just'
-      - '.github/**'
-      - 'ts/**'
-      - 'test/**'
+  workflow_call:
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
Replace per-language workflow triggers (push/pull_request) with workflow_call, and add a single ci.yml orchestrator that uses dorny/paths-filter to conditionally fan out to each language CI. The ci-passed job serves as the sole required status check, treating skipped jobs as OK and failing only on failure/cancelled.

Kind of vibed, but
- it passes CI on my path, 
- the require steps are the same and
- **now has a consistent job that we can require for automerge/..**