### PR TITLE
chore(rust): rework presence to use bitvec

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -345,6 +345,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,6 +1309,12 @@ checksum = "3bf53d7c403a2b76873d4d66ba7d79c54bde2784cdaba6083f223d6e33270708"
 dependencies = [
  "rustc-hash 2.1.2",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -2645,6 +2663,7 @@ name = "mlt-core"
 version = "0.8.0"
 dependencies = [
  "arbitrary",
+ "bitvec",
  "brotli",
  "bytemuck",
  "criterion",
@@ -3602,6 +3621,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -5118,6 +5143,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6628,6 +6659,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "xxhash-rust"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,6 +18,7 @@ rust-version = "1.92"
 [workspace.dependencies]
 anyhow = "1"
 arbitrary = { version = "1.4", features = ["derive"] }
+bitvec = "1"
 brotli = "8"
 bytemuck = "1.25.0"
 clap = { version = "4.6.0", features = ["derive"] }

--- a/rust/mlt-core/Cargo.toml
+++ b/rust/mlt-core/Cargo.toml
@@ -44,6 +44,7 @@ __private = []
 
 [dependencies]
 arbitrary = { workspace = true, optional = true }
+bitvec.workspace = true
 bytemuck.workspace = true
 enum_dispatch.workspace = true
 fastpfor.workspace = true

--- a/rust/mlt-core/src/decoder/id/decode.rs
+++ b/rust/mlt-core/src/decoder/id/decode.rs
@@ -1,6 +1,5 @@
 use crate::decoder::{IdValues, RawId, RawIdValue};
-use crate::utils::decode_presence;
-use crate::utils::presence::Presence;
+use crate::utils::{Presence, decode_presence};
 use crate::{Decode, Decoder, MltResult};
 
 impl Decode<IdValues> for RawId<'_> {

--- a/rust/mlt-core/src/decoder/id/decode.rs
+++ b/rust/mlt-core/src/decoder/id/decode.rs
@@ -1,5 +1,6 @@
 use crate::decoder::{IdValues, RawId, RawIdValue};
-use crate::utils::apply_present;
+use crate::utils::decode_presence;
+use crate::utils::presence::Presence;
 use crate::{Decode, Decoder, MltResult};
 
 impl Decode<IdValues> for RawId<'_> {
@@ -18,6 +19,22 @@ impl Decode<IdValues> for RawId<'_> {
             RawIdValue::Id64(stream) => stream.decode_u64s(dec)?,
         };
 
-        Ok(IdValues(apply_present(presence, ids_u64, dec)?))
+        let decoded_presence = decode_presence(presence, ids_u64.len(), dec)?;
+        let values = match decoded_presence {
+            Presence::AllPresent => {
+                dec.consume_items::<Option<u64>>(ids_u64.len())?;
+                ids_u64.into_iter().map(Some).collect()
+            }
+            Presence::Bits(bits) => {
+                dec.consume_items::<Option<u64>>(bits.len())?;
+                let mut result = Vec::with_capacity(bits.len());
+                let mut dense = ids_u64.into_iter();
+                for present in bits.iter().by_vals() {
+                    result.push(if present { dense.next() } else { None });
+                }
+                result
+            }
+        };
+        Ok(IdValues(values))
     }
 }

--- a/rust/mlt-core/src/decoder/iterators.rs
+++ b/rust/mlt-core/src/decoder/iterators.rs
@@ -256,7 +256,7 @@ where
 {
     #[inline]
     fn value_at(&self, feat_idx: usize) -> Option<PropValueRef<'a>> {
-        self.values[feat_idx].map(|v| PropValueRef::from(v))
+        self.get(feat_idx).map(PropValueRef::from)
     }
 
     #[inline]

--- a/rust/mlt-core/src/decoder/property/decode.rs
+++ b/rust/mlt-core/src/decoder/property/decode.rs
@@ -17,18 +17,14 @@ impl<'a, T: Copy + PartialEq> ParsedScalar<'a, T> {
         })
     }
 
-    /// Returns the column name.
-    #[inline]
-    #[must_use]
-    pub fn name(&self) -> &'a str {
-        self.name
-    }
-
     /// Total number of features (present and absent).
     #[inline]
     #[must_use]
     pub fn feature_count(&self) -> usize {
-        self.presence.feature_count(self.values.len())
+        match &self.presence {
+            Presence::AllPresent => self.values.len(),
+            Presence::Bits(bits) => bits.len(),
+        }
     }
 
     /// Returns the value for feature `idx`, or `None` if absent or out of bounds.
@@ -55,11 +51,6 @@ impl<'a, T: Copy + PartialEq> ParsedScalar<'a, T> {
         (0..self.feature_count()).map(|i| self.get(i)).collect()
     }
 
-    /// Iterate over values as `Option<T>`, one per feature.
-    pub fn iter_optional(&self) -> impl Iterator<Item = Option<T>> + '_ {
-        (0..self.feature_count()).map(move |i| self.get(i))
-    }
-
     /// Return the backing dense values slice (present entries only).
     #[inline]
     #[must_use]
@@ -76,7 +67,7 @@ impl<'a> Decode<ParsedProperty<'a>> for RawProperty<'a> {
     /// columns the exact decoded size depends on compression, so the budget is
     /// charged *after* decoding based on actual allocation sizes.
     fn decode(self, dec: &mut Decoder) -> MltResult<ParsedProperty<'a>> {
-        /// Charge for the final `Vec<Option<T>>`, then decode the dense stream.
+        /// Decode the dense value stream and wrap it with the presence bitmap.
         /// `$decode_method` is the typed `RawStream` method for element type `$ty`.
         macro_rules! scalar_decode {
             ($variant:ident, $ty:ty, $decode_method:ident, $v:expr, $dec:expr) => {{

--- a/rust/mlt-core/src/decoder/property/decode.rs
+++ b/rust/mlt-core/src/decoder/property/decode.rs
@@ -48,7 +48,16 @@ impl<'a, T: Copy + PartialEq> ParsedScalar<'a, T> {
     /// Allocates a new vector; prefer [`ParsedScalar::get`] for single-feature access.
     #[must_use]
     pub fn materialize(&self) -> Vec<Option<T>> {
-        (0..self.feature_count()).map(|i| self.get(i)).collect()
+        match &self.presence {
+            Presence::AllPresent => self.values.iter().copied().map(Some).collect(),
+            Presence::Bits(bits) => {
+                let mut dense = self.values.iter().copied();
+                bits.iter()
+                    .by_vals()
+                    .map(|present| if present { dense.next() } else { None })
+                    .collect()
+            }
+        }
     }
 
     /// Return the backing dense values slice (present entries only).

--- a/rust/mlt-core/src/decoder/property/decode.rs
+++ b/rust/mlt-core/src/decoder/property/decode.rs
@@ -1,5 +1,5 @@
 use crate::decoder::{ParsedProperty, ParsedScalar, RawPresence, RawProperty};
-use crate::utils::apply_present;
+use crate::utils::{Presence, decode_presence};
 use crate::{Decode, Decoder, MltResult};
 
 impl<'a, T: Copy + PartialEq> ParsedScalar<'a, T> {
@@ -9,10 +9,62 @@ impl<'a, T: Copy + PartialEq> ParsedScalar<'a, T> {
         values: Vec<T>,
         dec: &mut Decoder,
     ) -> MltResult<Self> {
+        let presence = decode_presence(presence, values.len(), dec)?;
         Ok(Self {
             name,
-            values: apply_present(presence, values, dec)?,
+            presence,
+            values,
         })
+    }
+
+    /// Returns the column name.
+    #[inline]
+    #[must_use]
+    pub fn name(&self) -> &'a str {
+        self.name
+    }
+
+    /// Total number of features (present and absent).
+    #[inline]
+    #[must_use]
+    pub fn feature_count(&self) -> usize {
+        self.presence.feature_count(self.values.len())
+    }
+
+    /// Returns the value for feature `idx`, or `None` if absent or out of bounds.
+    #[inline]
+    #[must_use]
+    pub fn get(&self, idx: usize) -> Option<T> {
+        match &self.presence {
+            Presence::AllPresent => self.values.get(idx).copied(),
+            Presence::Bits(bits) => {
+                if *bits.get(idx)? {
+                    Some(self.values[bits[..idx].count_ones()])
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    /// Expand into a `Vec<Option<T>>` with one entry per feature.
+    ///
+    /// Allocates a new vector; prefer [`ParsedScalar::get`] for single-feature access.
+    #[must_use]
+    pub fn materialize(&self) -> Vec<Option<T>> {
+        (0..self.feature_count()).map(|i| self.get(i)).collect()
+    }
+
+    /// Iterate over values as `Option<T>`, one per feature.
+    pub fn iter_optional(&self) -> impl Iterator<Item = Option<T>> + '_ {
+        (0..self.feature_count()).map(move |i| self.get(i))
+    }
+
+    /// Return the backing dense values slice (present entries only).
+    #[inline]
+    #[must_use]
+    pub fn dense_values(&self) -> &[T] {
+        &self.values
     }
 }
 

--- a/rust/mlt-core/src/decoder/property/fmt.rs
+++ b/rust/mlt-core/src/decoder/property/fmt.rs
@@ -10,47 +10,47 @@ impl fmt::Debug for ParsedProperty<'_> {
             Self::Bool(v) => f
                 .debug_tuple("Bool")
                 .field(&v.name)
-                .field(&FmtOptVec(&v.values))
+                .field(&FmtOptVec(&v.materialize()))
                 .finish(),
             Self::I8(v) => f
                 .debug_tuple("I8")
                 .field(&v.name)
-                .field(&FmtOptVec(&v.values))
+                .field(&FmtOptVec(&v.materialize()))
                 .finish(),
             Self::U8(v) => f
                 .debug_tuple("U8")
                 .field(&v.name)
-                .field(&FmtOptVec(&v.values))
+                .field(&FmtOptVec(&v.materialize()))
                 .finish(),
             Self::I32(v) => f
                 .debug_tuple("I32")
                 .field(&v.name)
-                .field(&FmtOptVec(&v.values))
+                .field(&FmtOptVec(&v.materialize()))
                 .finish(),
             Self::U32(v) => f
                 .debug_tuple("U32")
                 .field(&v.name)
-                .field(&FmtOptVec(&v.values))
+                .field(&FmtOptVec(&v.materialize()))
                 .finish(),
             Self::I64(v) => f
                 .debug_tuple("I64")
                 .field(&v.name)
-                .field(&FmtOptVec(&v.values))
+                .field(&FmtOptVec(&v.materialize()))
                 .finish(),
             Self::U64(v) => f
                 .debug_tuple("U64")
                 .field(&v.name)
-                .field(&FmtOptVec(&v.values))
+                .field(&FmtOptVec(&v.materialize()))
                 .finish(),
             Self::F32(v) => f
                 .debug_tuple("F32")
                 .field(&v.name)
-                .field(&FmtOptVec(&v.values))
+                .field(&FmtOptVec(&v.materialize()))
                 .finish(),
             Self::F64(v) => f
                 .debug_tuple("F64")
                 .field(&v.name)
-                .field(&FmtOptVec(&v.values))
+                .field(&FmtOptVec(&v.materialize()))
                 .finish(),
             Self::Str(v) => f
                 .debug_tuple("Str")

--- a/rust/mlt-core/src/decoder/property/model.rs
+++ b/rust/mlt-core/src/decoder/property/model.rs
@@ -112,7 +112,7 @@ pub enum ParsedProperty<'a> {
 ///
 /// For a non-optional column, `presence` is [`Presence::AllPresent`] and
 /// `values.len()` equals the feature count.  For an optional column, `presence`
-/// is [`Presence::Bits`] with `presence.count_ones() == values.len()`.
+/// is [`Presence::Bits(bits)`][`Presence::Bits`] with `bits.count_ones() == values.len()`.
 #[derive(Clone, PartialEq)]
 pub struct ParsedScalar<'a, T: Copy + PartialEq> {
     pub(crate) name: &'a str,

--- a/rust/mlt-core/src/decoder/property/model.rs
+++ b/rust/mlt-core/src/decoder/property/model.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use enum_dispatch::enum_dispatch;
 
 use crate::decoder::RawStream;
+use crate::utils::Presence;
 use crate::{DecodeState, Lazy};
 
 /// Property column representation, parameterized by decode state.
@@ -104,11 +105,20 @@ pub enum ParsedProperty<'a> {
     SharedDict(ParsedSharedDict<'a>),
 }
 
+/// Decoded scalar property column (bool, integer, or float).
+///
+/// `presence` indicates which features have a value; `values` holds only the
+/// non-null (present) entries in dense order.
+///
+/// For a non-optional column, `presence` is [`Presence::AllPresent`] and
+/// `values.len()` equals the feature count.  For an optional column, `presence`
+/// is [`Presence::Bits`] with `presence.count_ones() == values.len()`.
 #[derive(Clone, PartialEq)]
-#[cfg_attr(all(not(test), feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub struct ParsedScalar<'a, T: Copy + PartialEq> {
     pub(crate) name: &'a str,
-    pub(crate) values: Vec<Option<T>>,
+    pub(crate) presence: Presence<'a>,
+    /// Dense values: only entries where the corresponding presence bit is set.
+    pub(crate) values: Vec<T>,
 }
 
 /// Per-feature byte range into a shared dictionary corpus.

--- a/rust/mlt-core/src/decoder/stream/decode.rs
+++ b/rust/mlt-core/src/decoder/stream/decode.rs
@@ -10,42 +10,32 @@ use crate::codecs::rle::decode_byte_rle;
 use crate::codecs::varint::parse_varint_vec;
 use crate::decoder::{LogicalEncoding, LogicalValue, PhysicalEncoding, RawStream};
 use crate::errors::{AsMltError as _, fail_if_invalid_stream_size};
-use crate::utils::{AsUsize as _, Presence};
+use crate::utils::AsUsize as _;
 use crate::{Decoder, MltError, MltResult};
 
 impl<'a> RawStream<'a> {
-    /// Decode a presence/nullability stream to a packed bitvector.
+    /// Decode a presence/nullability stream into a packed bitvector.
     ///
-    /// Returns [`Presence::Bits`] with a `Cow` that is:
-    /// - **Borrowed** directly from the tile bytes when neither logical nor physical
-    ///   compression is applied (both encodings are `None`), avoiding any copy.
-    /// - **Owned** (`BitVec`) after byte-RLE decompression in all other cases.
-    ///
-    /// The returned `Presence` is always truncated to exactly `num_values` bits.
-    ///
-    /// Note: currently all presence streams produced by this encoder use
-    /// `LogicalEncoding::Rle`, so the zero-copy path is reserved for future
-    /// uncompressed presence streams.
-    pub fn decode_presence(self, dec: &mut Decoder) -> MltResult<Presence<'a>> {
+    /// Borrows directly from tile bytes (zero-copy) when both logical and physical
+    /// encodings are `None`; otherwise decompresses byte-RLE into an owned `BitVec`.
+    /// The result is always truncated to exactly `num_values` bits.
+    pub(crate) fn decode_bitvec(self, dec: &mut Decoder) -> MltResult<Cow<'a, BitSlice<u8, Lsb0>>> {
         let num_values = self.meta.num_values.as_usize();
         if self.meta.encoding.physical == PhysicalEncoding::VarInt {
             return Err(MltError::NotImplemented("varint presence decoding"));
         }
-        let bits: Cow<'a, BitSlice<u8, Lsb0>> = if self.meta.encoding.logical
-            == LogicalEncoding::None
+        if self.meta.encoding.logical == LogicalEncoding::None
             && self.meta.encoding.physical == PhysicalEncoding::None
         {
-            // Zero-copy: the raw tile bytes ARE the packed bitvector — borrow directly.
-            Cow::Borrowed(&self.data.view_bits::<Lsb0>()[..num_values])
+            // Zero-copy: raw tile bytes are the packed bitvector.
+            Ok(Cow::Borrowed(&self.data.view_bits::<Lsb0>()[..num_values]))
         } else {
-            // Byte-RLE (or other encoding): decompress into Vec<u8>, wrap as BitVec.
             let num_bytes = num_values.div_ceil(8);
             let bytes = decode_byte_rle(self.data, num_bytes, dec)?;
             let mut bvec = BitVec::<u8, Lsb0>::from_vec(bytes);
             bvec.truncate(num_values);
-            Cow::Owned(bvec)
-        };
-        Ok(Presence::Bits(bits))
+            Ok(Cow::Owned(bvec))
+        }
     }
 
     /// Decode a boolean data stream: byte-RLE → packed bitmap → `Vec<bool>`, charging `dec`.

--- a/rust/mlt-core/src/decoder/stream/decode.rs
+++ b/rust/mlt-core/src/decoder/stream/decode.rs
@@ -1,4 +1,8 @@
+use std::borrow::Cow;
 use std::mem;
+
+use bitvec::prelude::{BitSlice, BitVec, Lsb0};
+use bitvec::view::BitView as _;
 
 use crate::codecs::bytes::{decode_bytes_to_bools, decode_bytes_to_u32s, decode_bytes_to_u64s};
 use crate::codecs::fastpfor::decode_fastpfor;
@@ -6,11 +10,45 @@ use crate::codecs::rle::decode_byte_rle;
 use crate::codecs::varint::parse_varint_vec;
 use crate::decoder::{LogicalEncoding, LogicalValue, PhysicalEncoding, RawStream};
 use crate::errors::{AsMltError as _, fail_if_invalid_stream_size};
-use crate::utils::AsUsize as _;
+use crate::utils::{AsUsize as _, Presence};
 use crate::{Decoder, MltError, MltResult};
 
-impl RawStream<'_> {
-    /// Decode a boolean stream: byte-RLE → packed bitmap → `Vec<bool>`, charging `dec`.
+impl<'a> RawStream<'a> {
+    /// Decode a presence/nullability stream to a packed bitvector.
+    ///
+    /// Returns [`Presence::Bits`] with a `Cow` that is:
+    /// - **Borrowed** directly from the tile bytes when neither logical nor physical
+    ///   compression is applied (both encodings are `None`), avoiding any copy.
+    /// - **Owned** (`BitVec`) after byte-RLE decompression in all other cases.
+    ///
+    /// The returned `Presence` is always truncated to exactly `num_values` bits.
+    ///
+    /// Note: currently all presence streams produced by this encoder use
+    /// `LogicalEncoding::Rle`, so the zero-copy path is reserved for future
+    /// uncompressed presence streams.
+    pub fn decode_presence(self, dec: &mut Decoder) -> MltResult<Presence<'a>> {
+        let num_values = self.meta.num_values.as_usize();
+        if self.meta.encoding.physical == PhysicalEncoding::VarInt {
+            return Err(MltError::NotImplemented("varint presence decoding"));
+        }
+        let bits: Cow<'a, BitSlice<u8, Lsb0>> = if self.meta.encoding.logical
+            == LogicalEncoding::None
+            && self.meta.encoding.physical == PhysicalEncoding::None
+        {
+            // Zero-copy: the raw tile bytes ARE the packed bitvector — borrow directly.
+            Cow::Borrowed(&self.data.view_bits::<Lsb0>()[..num_values])
+        } else {
+            // Byte-RLE (or other encoding): decompress into Vec<u8>, wrap as BitVec.
+            let num_bytes = num_values.div_ceil(8);
+            let bytes = decode_byte_rle(self.data, num_bytes, dec)?;
+            let mut bvec = BitVec::<u8, Lsb0>::from_vec(bytes);
+            bvec.truncate(num_values);
+            Cow::Owned(bvec)
+        };
+        Ok(Presence::Bits(bits))
+    }
+
+    /// Decode a boolean data stream: byte-RLE → packed bitmap → `Vec<bool>`, charging `dec`.
     pub fn decode_bools(self, dec: &mut Decoder) -> MltResult<Vec<bool>> {
         if self.meta.encoding.physical == PhysicalEncoding::VarInt {
             return Err(MltError::NotImplemented("varint bool decoding"));

--- a/rust/mlt-core/src/decoder/stream/decode.rs
+++ b/rust/mlt-core/src/decoder/stream/decode.rs
@@ -28,6 +28,8 @@ impl<'a> RawStream<'a> {
             && self.meta.encoding.physical == PhysicalEncoding::None
         {
             // Zero-copy: raw tile bytes are the packed bitvector.
+            let num_bytes = num_values.div_ceil(8);
+            fail_if_invalid_stream_size(self.data.len(), num_bytes)?;
             Ok(Cow::Borrowed(&self.data.view_bits::<Lsb0>()[..num_values]))
         } else {
             let num_bytes = num_values.div_ceil(8);

--- a/rust/mlt-core/src/encoder/analyze.rs
+++ b/rust/mlt-core/src/encoder/analyze.rs
@@ -1,5 +1,6 @@
 use crate::decoder::{ParsedScalar, ParsedSharedDict, ParsedStrings, StreamMeta};
 use crate::encoder::EncodedStream;
+use crate::utils::Presence;
 use crate::{Analyze, StatType};
 
 impl Analyze for EncodedStream {
@@ -15,7 +16,11 @@ impl<T: Analyze + Copy + PartialEq> Analyze for ParsedScalar<'_, T> {
         } else {
             0
         };
-        meta + self.values.collect_statistic(stat)
+        let presence_bytes = match &self.presence {
+            Presence::AllPresent => 0,
+            Presence::Bits(bits) => bits.len().div_ceil(8),
+        };
+        meta + presence_bytes + self.values.collect_statistic(stat)
     }
 }
 

--- a/rust/mlt-core/src/encoder/property/compare.rs
+++ b/rust/mlt-core/src/encoder/property/compare.rs
@@ -5,16 +5,13 @@ use crate::encoder::{
     StagedOptScalar, StagedProperty, StagedScalar, StagedSharedDict, StagedSharedDictItem,
     StagedStrings,
 };
+use crate::utils::Presence;
 
 impl<T: Copy + PartialEq> PartialEq<StagedScalar<T>> for ParsedScalar<'_, T> {
     fn eq(&self, other: &StagedScalar<T>) -> bool {
         self.name == other.name
-            && self.values.len() == other.values.len()
-            && self
-                .values
-                .iter()
-                .zip(&other.values)
-                .all(|(opt, &val)| *opt == Some(val))
+            && matches!(self.presence, Presence::AllPresent)
+            && self.values == other.values
     }
 }
 
@@ -24,27 +21,31 @@ impl<T: Copy + PartialEq> PartialEq<ParsedScalar<'_, T>> for StagedScalar<T> {
     }
 }
 
-// ── StagedOptScalar: expand dense values using presence ──────────────────────
+// ── StagedOptScalar: compare dense values using presence ─────────────────────
 
 impl<T: Copy + PartialEq> PartialEq<StagedOptScalar<T>> for ParsedScalar<'_, T> {
     fn eq(&self, other: &StagedOptScalar<T>) -> bool {
-        if self.name != other.name || self.values.len() != other.presence.len() {
+        if self.name != other.name {
+            return false;
+        }
+        let feat_count = self.feature_count();
+        if feat_count != other.presence.len() || self.values.len() != other.values.len() {
             return false;
         }
         let mut dense_idx = 0usize;
-        for (parsed_opt, &present) in self.values.iter().zip(&other.presence) {
-            match (parsed_opt, present) {
-                (None, false) => {}
-                (Some(v), true) => {
-                    if other.values.get(dense_idx) != Some(v) {
-                        return false;
-                    }
-                    dense_idx += 1;
+        for (i, &staged_present) in other.presence.iter().enumerate() {
+            let parsed_present = self.presence.is_present(i);
+            if parsed_present != staged_present {
+                return false;
+            }
+            if parsed_present {
+                if self.values[dense_idx] != other.values[dense_idx] {
+                    return false;
                 }
-                _ => return false,
+                dense_idx += 1;
             }
         }
-        dense_idx == other.values.len()
+        true
     }
 }
 

--- a/rust/mlt-core/src/utils/mod.rs
+++ b/rust/mlt-core/src/utils/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod extensions;
 pub(crate) mod formatter;
 pub(crate) mod lazy_state;
 mod parse;
+pub mod presence;
 mod serialize;
 #[cfg(any(test, feature = "__private"))]
 pub mod test_helpers;
@@ -10,4 +11,5 @@ pub mod test_helpers;
 pub use extensions::*;
 pub(crate) use formatter::{FmtOptVec, OptSeq, OptSeqOpt};
 pub(crate) use parse::*;
+pub use presence::*;
 pub use serialize::*;

--- a/rust/mlt-core/src/utils/parse.rs
+++ b/rust/mlt-core/src/utils/parse.rs
@@ -1,4 +1,5 @@
 use crate::codecs::varint::parse_varint;
+use crate::utils::Presence;
 use crate::{Decoder, MltError, MltRefResult, MltResult, RawPresence};
 
 #[inline]
@@ -26,37 +27,26 @@ pub fn parse_u8(input: &[u8]) -> MltRefResult<'_, u8> {
     }
 }
 
-/// Apply an optional present bitmap to a vector of values.
-/// If the presence stream is absent (non-optional column), all values are wrapped in Some.
-/// If present, values are interleaved with None according to the bitmap.
-pub fn apply_present<T>(
-    presence: RawPresence<'_>,
-    values: Vec<T>,
+/// Decode an optional presence stream, validating it against a dense value count.
+///
+/// If `presence.0` is `None` (non-optional column) returns [`Presence::AllPresent`].
+/// Otherwise decodes the bitvector and checks that the number of set bits equals
+/// `dense_count` (the number of non-null values that have already been decoded).
+pub fn decode_presence<'a>(
+    presence: RawPresence<'a>,
+    dense_count: usize,
     dec: &mut Decoder,
-) -> MltResult<Vec<Option<T>>> {
-    let present: Vec<bool> = if let Some(p) = presence.0 {
-        p.decode_bools(dec)?
-    } else {
-        let mut result = dec.alloc::<Option<T>>(values.len())?;
-        result.extend(values.into_iter().map(Some));
-        return Ok(result);
+) -> MltResult<Presence<'a>> {
+    let Some(raw) = presence.0 else {
+        return Ok(Presence::AllPresent);
     };
-    let present_bit_count = present.iter().filter(|&&b| b).count();
-    if present_bit_count != values.len() {
-        return Err(MltError::PresenceValueCountMismatch(
-            present_bit_count,
-            values.len(),
-        ));
+    let decoded = raw.decode_presence(dec)?;
+    let Presence::Bits(ref bits) = decoded else {
+        unreachable!("decode_presence always returns Presence::Bits")
+    };
+    let set_count = bits.count_ones();
+    if set_count != dense_count {
+        return Err(MltError::PresenceValueCountMismatch(set_count, dense_count));
     }
-    debug_assert!(
-        values.len() <= present.len(),
-        "Since the number of present bits is an upper bound on the number of values and equals values.len(), there cannot be more values than entries in the present bitmap"
-    );
-
-    let mut result = dec.alloc::<Option<T>>(present.len())?;
-    let mut val_iter = values.into_iter();
-    for p in present {
-        result.push(if p { val_iter.next() } else { None });
-    }
-    Ok(result)
+    Ok(decoded)
 }

--- a/rust/mlt-core/src/utils/parse.rs
+++ b/rust/mlt-core/src/utils/parse.rs
@@ -29,9 +29,9 @@ pub fn parse_u8(input: &[u8]) -> MltRefResult<'_, u8> {
 
 /// Decode an optional presence stream, validating it against a dense value count.
 ///
-/// If `presence.0` is `None` (non-optional column) returns [`Presence::AllPresent`].
+/// Returns [`Presence::AllPresent`] when `presence.0` is `None` (non-optional column).
 /// Otherwise decodes the bitvector and checks that the number of set bits equals
-/// `dense_count` (the number of non-null values that have already been decoded).
+/// `dense_count` (the number of non-null values already decoded).
 pub fn decode_presence<'a>(
     presence: RawPresence<'a>,
     dense_count: usize,
@@ -40,13 +40,10 @@ pub fn decode_presence<'a>(
     let Some(raw) = presence.0 else {
         return Ok(Presence::AllPresent);
     };
-    let decoded = raw.decode_presence(dec)?;
-    let Presence::Bits(ref bits) = decoded else {
-        unreachable!("decode_presence always returns Presence::Bits")
-    };
+    let bits = raw.decode_bitvec(dec)?;
     let set_count = bits.count_ones();
     if set_count != dense_count {
         return Err(MltError::PresenceValueCountMismatch(set_count, dense_count));
     }
-    Ok(decoded)
+    Ok(Presence::Bits(bits))
 }

--- a/rust/mlt-core/src/utils/presence.rs
+++ b/rust/mlt-core/src/utils/presence.rs
@@ -1,0 +1,61 @@
+use std::borrow::Cow;
+
+use bitvec::order::Lsb0;
+use bitvec::slice::BitSlice;
+
+/// Per-column feature presence bitvector for decoded scalar properties.
+///
+/// Bit order matches the wire format: bit `i` is `(byte[i/8] >> (i%8)) & 1`,
+/// which is exactly `bitvec`'s `Lsb0` ordering.
+///
+/// When the stream has no compression (`PhysicalEncoding::None`), the inner
+/// `Cow` borrows directly from the tile bytes (`Cow::Borrowed`) without
+/// copying.  Otherwise it holds an owned `BitVec` produced after RLE
+/// decompression (`Cow::Owned`).
+#[derive(Clone, PartialEq, Debug)]
+pub enum Presence<'a> {
+    /// No presence stream — every feature has a value.
+    AllPresent,
+    /// Per-feature packed bitvector: bit `i` is set iff feature `i` has a value.
+    Bits(Cow<'a, BitSlice<u8, Lsb0>>),
+}
+
+impl Presence<'_> {
+    /// Returns `true` if feature `idx` is present.
+    ///
+    /// Always returns `true` for [`Presence::AllPresent`].
+    /// Returns `false` when `idx` is out of bounds for [`Presence::Bits`].
+    #[inline]
+    #[must_use]
+    pub fn is_present(&self, idx: usize) -> bool {
+        match self {
+            Self::AllPresent => true,
+            Self::Bits(bits) => bits.get(idx).as_deref().copied().unwrap_or(false),
+        }
+    }
+
+    /// Returns the number of present features before `idx` (i.e. the dense offset).
+    ///
+    /// For `AllPresent` this is just `idx`.  For `Bits` it counts set bits in `0..idx`.
+    #[inline]
+    #[must_use]
+    pub fn dense_offset(&self, idx: usize) -> usize {
+        match self {
+            Self::AllPresent => idx,
+            Self::Bits(bits) => bits[..idx].count_ones(),
+        }
+    }
+
+    /// Total number of features covered by this presence descriptor.
+    ///
+    /// For [`Presence::AllPresent`] this equals `dense_len` (the dense values length).
+    /// Passing the wrong `dense_len` for the `AllPresent` case is a bug.
+    #[inline]
+    #[must_use]
+    pub fn feature_count(&self, dense_len: usize) -> usize {
+        match self {
+            Self::AllPresent => dense_len,
+            Self::Bits(bits) => bits.len(),
+        }
+    }
+}

--- a/rust/mlt-core/src/utils/presence.rs
+++ b/rust/mlt-core/src/utils/presence.rs
@@ -5,13 +5,8 @@ use bitvec::slice::BitSlice;
 
 /// Per-column feature presence bitvector for decoded scalar properties.
 ///
-/// Bit order matches the wire format: bit `i` is `(byte[i/8] >> (i%8)) & 1`,
-/// which is exactly `bitvec`'s `Lsb0` ordering.
-///
-/// When the stream has no compression (`PhysicalEncoding::None`), the inner
-/// `Cow` borrows directly from the tile bytes (`Cow::Borrowed`) without
-/// copying.  Otherwise it holds an owned `BitVec` produced after RLE
-/// decompression (`Cow::Owned`).
+/// Bit order matches the wire format (`bitvec`'s `Lsb0`): bit `i` corresponds to
+/// `(byte[i/8] >> (i%8)) & 1`.
 #[derive(Clone, PartialEq, Debug)]
 pub enum Presence<'a> {
     /// No presence stream — every feature has a value.
@@ -23,39 +18,13 @@ pub enum Presence<'a> {
 impl Presence<'_> {
     /// Returns `true` if feature `idx` is present.
     ///
-    /// Always returns `true` for [`Presence::AllPresent`].
-    /// Returns `false` when `idx` is out of bounds for [`Presence::Bits`].
+    /// Always `true` for [`Presence::AllPresent`]; `false` when out of bounds.
     #[inline]
     #[must_use]
     pub fn is_present(&self, idx: usize) -> bool {
         match self {
             Self::AllPresent => true,
             Self::Bits(bits) => bits.get(idx).as_deref().copied().unwrap_or(false),
-        }
-    }
-
-    /// Returns the number of present features before `idx` (i.e. the dense offset).
-    ///
-    /// For `AllPresent` this is just `idx`.  For `Bits` it counts set bits in `0..idx`.
-    #[inline]
-    #[must_use]
-    pub fn dense_offset(&self, idx: usize) -> usize {
-        match self {
-            Self::AllPresent => idx,
-            Self::Bits(bits) => bits[..idx].count_ones(),
-        }
-    }
-
-    /// Total number of features covered by this presence descriptor.
-    ///
-    /// For [`Presence::AllPresent`] this equals `dense_len` (the dense values length).
-    /// Passing the wrong `dense_len` for the `AllPresent` case is a bug.
-    #[inline]
-    #[must_use]
-    pub fn feature_count(&self, dense_len: usize) -> usize {
-        match self {
-            Self::AllPresent => dense_len,
-            Self::Bits(bits) => bits.len(),
         }
     }
 }


### PR DESCRIPTION
* keep presence as uncompressed bit vector if possible
* use less space even if decode is needed