### PR TITLE
fix(ts): fixes optional presense stream in string decoding

### DIFF
--- a/ts/src/decoding/decodingTestUtils.ts
+++ b/ts/src/decoding/decodingTestUtils.ts
@@ -59,7 +59,7 @@ export function createRleMetadata(
  */
 export function createColumnMetadataForStruct(
     columnName: string,
-    childFields: Array<{ name: string; type?: number, nullable?: boolean }>,
+    childFields: Array<{ name: string; type?: number; nullable?: boolean }>,
 ): Column {
     const children: Field[] = childFields.map((fieldConfig) => ({
         name: fieldConfig.name,

--- a/ts/src/decoding/decodingTestUtils.ts
+++ b/ts/src/decoding/decodingTestUtils.ts
@@ -59,11 +59,11 @@ export function createRleMetadata(
  */
 export function createColumnMetadataForStruct(
     columnName: string,
-    childFields: Array<{ name: string; type?: number }>,
+    childFields: Array<{ name: string; type?: number, nullable?: boolean }>,
 ): Column {
     const children: Field[] = childFields.map((fieldConfig) => ({
         name: fieldConfig.name,
-        nullable: true,
+        nullable: fieldConfig.nullable ?? true,
         scalarField: {
             physicalType: fieldConfig.type ?? ScalarType.STRING,
             type: "physicalType" as const,

--- a/ts/src/decoding/propertyDecoder.ts
+++ b/ts/src/decoding/propertyDecoder.ts
@@ -57,7 +57,7 @@ export function decodePropertyColumn(
         return null;
     }
 
-    return decodeSharedDictionary(data, offset, columnMetadata, numFeatures, propertyColumnNames);
+    return decodeSharedDictionary(data, offset, columnMetadata, propertyColumnNames);
 }
 
 function decodeScalarPropertyColumn(

--- a/ts/src/decoding/stringDecoder.spec.ts
+++ b/ts/src/decoding/stringDecoder.spec.ts
@@ -282,8 +282,7 @@ describe("decodeSharedDictionary", () => {
             const result = decodeSharedDictionary(
                 completeencodedStrings,
                 new IntWrapper(0),
-                columnMetaencodedStrings,
-                4,
+                columnMetaencodedStrings
             );
 
             expect(result).toHaveLength(1);
@@ -306,8 +305,7 @@ describe("decodeSharedDictionary", () => {
             const result = decodeSharedDictionary(
                 completeencodedStrings,
                 new IntWrapper(0),
-                columnMetaencodedStrings,
-                3,
+                columnMetaencodedStrings
             );
 
             expect(result).toHaveLength(1);
@@ -328,7 +326,7 @@ describe("decodeSharedDictionary", () => {
             const complete = concatenateBuffers(lengthStream, dataStream, field1, field2, field3);
             const metadata = createColumnMetadataForStruct("name", [{ name: "" }, { name: ":en" }, { name: ":de" }]);
 
-            const result = decodeSharedDictionary(complete, new IntWrapper(0), metadata, 1);
+            const result = decodeSharedDictionary(complete, new IntWrapper(0), metadata);
 
             expect(result).toHaveLength(3);
             expect(result[0].name).toBe("name");
@@ -349,8 +347,7 @@ describe("decodeSharedDictionary", () => {
             const result = decodeSharedDictionary(
                 completeencodedStrings,
                 new IntWrapper(0),
-                columnMetaencodedStrings,
-                4,
+                columnMetaencodedStrings
             );
 
             expect(result).toHaveLength(1);
@@ -372,8 +369,7 @@ describe("decodeSharedDictionary", () => {
             const result = decodeSharedDictionary(
                 completeencodedStrings,
                 new IntWrapper(0),
-                columnMetaencodedStrings,
-                4,
+                columnMetaencodedStrings
             );
 
             expect(result).toHaveLength(1);
@@ -405,8 +401,7 @@ describe("decodeSharedDictionary", () => {
             const result = decodeSharedDictionary(
                 completeencodedStrings,
                 new IntWrapper(0),
-                columnMetaencodedStrings,
-                2,
+                columnMetaencodedStrings
             );
 
             expect(result).toHaveLength(1);
@@ -442,8 +437,7 @@ describe("decodeSharedDictionary", () => {
                 completeencodedStrings,
                 new IntWrapper(0),
                 columnMetaencodedStrings,
-                1,
-                propertyColumnNames,
+                propertyColumnNames
             );
 
             expect(result).toHaveLength(2);
@@ -475,8 +469,7 @@ describe("decodeSharedDictionary", () => {
             const result = decodeSharedDictionary(
                 completeencodedStrings,
                 new IntWrapper(0),
-                columnMetaencodedStrings,
-                1,
+                columnMetaencodedStrings
             );
 
             expect(result).toHaveLength(2);
@@ -510,8 +503,7 @@ describe("decodeSharedDictionary", () => {
                 completeencodedStrings,
                 new IntWrapper(0),
                 columnMetaencodedStrings,
-                1,
-                propertyColumnNames,
+                propertyColumnNames
             );
 
             expect(result).toHaveLength(1);
@@ -531,7 +523,7 @@ describe("decodeSharedDictionary", () => {
             ]);
 
             expect(() => {
-                decodeSharedDictionary(completeEncodedStrings, new IntWrapper(0), columnMetaencodedStrings, 1);
+                decodeSharedDictionary(completeEncodedStrings, new IntWrapper(0), columnMetaencodedStrings);
             }).toThrow("Currently only scalar string fields are implemented for a struct.");
         });
 
@@ -546,7 +538,7 @@ describe("decodeSharedDictionary", () => {
             ]);
 
             expect(() => {
-                decodeSharedDictionary(completeEncodedStrings, new IntWrapper(0), columnMetaencodedStrings, 1);
+                decodeSharedDictionary(completeEncodedStrings, new IntWrapper(0), columnMetaencodedStrings);
             }).toThrow(
                 "The number of streams for the child field field1 does not match its nullability. nullibilty: false, numStreams: 2",
             );
@@ -569,7 +561,7 @@ describe("decodeSharedDictionary", () => {
 
             const offset = new IntWrapper(0);
             const initialOffset = offset.get();
-            const result = decodeSharedDictionary(completeencodedStrings, offset, columnMetaencodedStrings, 2);
+            const result = decodeSharedDictionary(completeencodedStrings, offset, columnMetaencodedStrings);
 
             expect(result).toHaveLength(2);
             expect(offset.get()).toBeGreaterThan(initialOffset);

--- a/ts/src/decoding/stringDecoder.spec.ts
+++ b/ts/src/decoding/stringDecoder.spec.ts
@@ -524,15 +524,32 @@ describe("decodeSharedDictionary", () => {
             const dictionaryStrings = ["value"];
             const { lengthStream, dataStream } = encodeSharedDictionary(dictionaryStrings);
             const fieldStreams = encodeStructField([0], [true]);
-            const completeencodedStrings = concatenateBuffers(lengthStream, dataStream, fieldStreams);
+            const completeEncodedStrings = concatenateBuffers(lengthStream, dataStream, fieldStreams);
 
             const columnMetaencodedStrings = createColumnMetadataForStruct("invalid", [
                 { name: "field1", type: ScalarType.INT_32 },
             ]);
 
             expect(() => {
-                decodeSharedDictionary(completeencodedStrings, new IntWrapper(0), columnMetaencodedStrings, 1);
-            }).toThrow("Currently only optional string fields are implemented for a struct.");
+                decodeSharedDictionary(completeEncodedStrings, new IntWrapper(0), columnMetaencodedStrings, 1);
+            }).toThrow("Currently only scalar string fields are implemented for a struct.");
+        });
+
+        it("should throw error for mismatched nullability and numStreams", () => {
+            const dictionaryStrings = ["value"];
+            const { lengthStream, dataStream } = encodeSharedDictionary(dictionaryStrings);
+            const fieldStreams = encodeStructField([0], [true]);
+            const completeEncodedStrings = concatenateBuffers(lengthStream, dataStream, fieldStreams);
+
+            const columnMetaencodedStrings = createColumnMetadataForStruct("invalidNullability", [
+                { name: "field1", type: ScalarType.STRING, nullable: false },
+            ]);
+
+            expect(() => {
+                decodeSharedDictionary(completeEncodedStrings, new IntWrapper(0), columnMetaencodedStrings, 1);
+            }).toThrow(
+                "The number of streams for the child field field1 does not match its nullability. nullibilty: false, numStreams: 2",
+            );
         });
     });
 

--- a/ts/src/decoding/stringDecoder.spec.ts
+++ b/ts/src/decoding/stringDecoder.spec.ts
@@ -279,11 +279,7 @@ describe("decodeSharedDictionary", () => {
             const completeencodedStrings = concatenateBuffers(lengthStream, dataStream, fieldStreams);
             const columnMetaencodedStrings = createColumnMetadataForStruct("address:", [{ name: "street" }]);
 
-            const result = decodeSharedDictionary(
-                completeencodedStrings,
-                new IntWrapper(0),
-                columnMetaencodedStrings
-            );
+            const result = decodeSharedDictionary(completeencodedStrings, new IntWrapper(0), columnMetaencodedStrings);
 
             expect(result).toHaveLength(1);
             expect(result[0]).toBeInstanceOf(StringDictionaryVector);
@@ -302,11 +298,7 @@ describe("decodeSharedDictionary", () => {
 
             const columnMetaencodedStrings = createColumnMetadataForStruct("name", [{ name: "" }]);
 
-            const result = decodeSharedDictionary(
-                completeencodedStrings,
-                new IntWrapper(0),
-                columnMetaencodedStrings
-            );
+            const result = decodeSharedDictionary(completeencodedStrings, new IntWrapper(0), columnMetaencodedStrings);
 
             expect(result).toHaveLength(1);
             expect(result[0].name).toBe("name");
@@ -344,11 +336,7 @@ describe("decodeSharedDictionary", () => {
             const completeencodedStrings = concatenateBuffers(lengthStream, dataStream, fieldStreams);
             const columnMetaencodedStrings = createColumnMetadataForStruct("colors:", [{ name: "primary" }]);
 
-            const result = decodeSharedDictionary(
-                completeencodedStrings,
-                new IntWrapper(0),
-                columnMetaencodedStrings
-            );
+            const result = decodeSharedDictionary(completeencodedStrings, new IntWrapper(0), columnMetaencodedStrings);
 
             expect(result).toHaveLength(1);
             const expected = ["red", null, "blue", null];
@@ -366,11 +354,7 @@ describe("decodeSharedDictionary", () => {
             const completeencodedStrings = concatenateBuffers(lengthStream, dataStream, fieldStreams);
             const columnMetaencodedStrings = createColumnMetadataForStruct("greek:", [{ name: "letter" }]);
 
-            const result = decodeSharedDictionary(
-                completeencodedStrings,
-                new IntWrapper(0),
-                columnMetaencodedStrings
-            );
+            const result = decodeSharedDictionary(completeencodedStrings, new IntWrapper(0), columnMetaencodedStrings);
 
             expect(result).toHaveLength(1);
             const expected = ["alpha", null, null, "beta"];
@@ -398,11 +382,7 @@ describe("decodeSharedDictionary", () => {
             );
             const columnMetaencodedStrings = createColumnMetadataForStruct("encodedStrings:", [{ name: "value" }]);
 
-            const result = decodeSharedDictionary(
-                completeencodedStrings,
-                new IntWrapper(0),
-                columnMetaencodedStrings
-            );
+            const result = decodeSharedDictionary(completeencodedStrings, new IntWrapper(0), columnMetaencodedStrings);
 
             expect(result).toHaveLength(1);
             expect(result[0]).toBeInstanceOf(StringFsstDictionaryVector);
@@ -437,7 +417,7 @@ describe("decodeSharedDictionary", () => {
                 completeencodedStrings,
                 new IntWrapper(0),
                 columnMetaencodedStrings,
-                propertyColumnNames
+                propertyColumnNames,
             );
 
             expect(result).toHaveLength(2);
@@ -466,11 +446,7 @@ describe("decodeSharedDictionary", () => {
                 { name: "field3" },
             ]);
 
-            const result = decodeSharedDictionary(
-                completeencodedStrings,
-                new IntWrapper(0),
-                columnMetaencodedStrings
-            );
+            const result = decodeSharedDictionary(completeencodedStrings, new IntWrapper(0), columnMetaencodedStrings);
 
             expect(result).toHaveLength(2);
             expect(result[0].name).toBe("test:field1");
@@ -503,7 +479,7 @@ describe("decodeSharedDictionary", () => {
                 completeencodedStrings,
                 new IntWrapper(0),
                 columnMetaencodedStrings,
-                propertyColumnNames
+                propertyColumnNames,
             );
 
             expect(result).toHaveLength(1);

--- a/ts/src/decoding/stringDecoder.ts
+++ b/ts/src/decoding/stringDecoder.ts
@@ -222,21 +222,24 @@ export function decodeSharedDictionary(
             }
         }
 
-        if (
-            numStreams !== 2 ||
-            childField.type !== "scalarField" ||
-            childField.scalarField.physicalType !== ScalarType.STRING
-        ) {
-            throw new Error("Currently only optional string fields are implemented for a struct.");
+        if (childField.type !== "scalarField" || childField.scalarField.physicalType !== ScalarType.STRING) {
+            throw new Error("Currently only scalar string fields are implemented for a struct.");
+        }
+        if ((numStreams > 1 && !childField.nullable) || (numStreams === 1 && childField.nullable)) {
+            throw new Error(`The number of streams for the child field ${childField.name} does not match its nullability. nullibilty: ${childField.nullable}, numStreams: ${numStreams}`);
         }
 
-        const presentStreamMetadata = decodeStreamMetadata(data, offset);
-        const presentStream = decodeBooleanRle(
-            data,
-            presentStreamMetadata.numValues,
-            presentStreamMetadata.byteLength,
-            offset,
-        );
+        let presentStreamBitVector: BitVector | undefined;
+        if (childField.nullable) {
+            const presentStreamMetadata = decodeStreamMetadata(data, offset);
+            const presentStream = decodeBooleanRle(
+                data,
+                presentStreamMetadata.numValues,
+                presentStreamMetadata.byteLength,
+                offset,
+            );
+            presentStreamBitVector = new BitVector(presentStream, presentStreamMetadata.numValues);
+        }
         const offsetStreamMetadata = decodeStreamMetadata(data, offset);
         const offsetCount = offsetStreamMetadata.decompressedCount;
         const isNullable = offsetCount !== numFeatures;
@@ -245,7 +248,7 @@ export function decodeSharedDictionary(
             offset,
             offsetStreamMetadata,
             undefined,
-            isNullable ? new BitVector(presentStream, presentStreamMetadata.numValues) : undefined,
+            isNullable ? presentStreamBitVector : undefined,
         );
 
         stringDictionaryVectors[i++] = symbolTableBuffer
@@ -256,14 +259,14 @@ export function decodeSharedDictionary(
                   dictionaryBuffer,
                   symbolOffsetBuffer,
                   symbolTableBuffer,
-                  new BitVector(presentStream, presentStreamMetadata.numValues),
+                  presentStreamBitVector,
               )
             : new StringDictionaryVector(
                   columnName,
                   offsetStream,
                   dictionaryOffsetBuffer,
                   dictionaryBuffer,
-                  new BitVector(presentStream, presentStreamMetadata.numValues),
+                  presentStreamBitVector,
               );
     }
 

--- a/ts/src/decoding/stringDecoder.ts
+++ b/ts/src/decoding/stringDecoder.ts
@@ -226,7 +226,9 @@ export function decodeSharedDictionary(
             throw new Error("Currently only scalar string fields are implemented for a struct.");
         }
         if ((numStreams > 1 && !childField.nullable) || (numStreams === 1 && childField.nullable)) {
-            throw new Error(`The number of streams for the child field ${childField.name} does not match its nullability. nullibilty: ${childField.nullable}, numStreams: ${numStreams}`);
+            throw new Error(
+                `The number of streams for the child field ${childField.name} does not match its nullability. nullibilty: ${childField.nullable}, numStreams: ${numStreams}`,
+            );
         }
 
         let presentStreamBitVector: BitVector | undefined;

--- a/ts/src/decoding/stringDecoder.ts
+++ b/ts/src/decoding/stringDecoder.ts
@@ -169,7 +169,6 @@ export function decodeSharedDictionary(
     data: Uint8Array,
     offset: IntWrapper,
     column: Column,
-    _numFeatures: number,
     propertyColumnNames?: Set<string>,
 ): Vector[] {
     let dictionaryOffsetBuffer: Uint32Array = null;

--- a/ts/src/decoding/stringDecoder.ts
+++ b/ts/src/decoding/stringDecoder.ts
@@ -169,7 +169,7 @@ export function decodeSharedDictionary(
     data: Uint8Array,
     offset: IntWrapper,
     column: Column,
-    numFeatures: number,
+    _numFeatures: number,
     propertyColumnNames?: Set<string>,
 ): Vector[] {
     let dictionaryOffsetBuffer: Uint32Array = null;

--- a/ts/src/decoding/stringDecoder.ts
+++ b/ts/src/decoding/stringDecoder.ts
@@ -243,14 +243,12 @@ export function decodeSharedDictionary(
             presentStreamBitVector = new BitVector(presentStream, presentStreamMetadata.numValues);
         }
         const offsetStreamMetadata = decodeStreamMetadata(data, offset);
-        const offsetCount = offsetStreamMetadata.decompressedCount;
-        const isNullable = offsetCount !== numFeatures;
         const offsetStream = decodeUnsignedInt32Stream(
             data,
             offset,
             offsetStreamMetadata,
             undefined,
-            isNullable ? presentStreamBitVector : undefined,
+            presentStreamBitVector,
         );
 
         stringDictionaryVectors[i++] = symbolTableBuffer

--- a/ts/src/synthetic.spec.ts
+++ b/ts/src/synthetic.spec.ts
@@ -10,18 +10,6 @@ import type FeatureTable from "./vector/featureTable";
 const EARCUT_MAX_RINGS = 500;
 
 const UNIMPLEMENTED_SYNTHETICS: string[] = [
-    "0x01-rust/props_offset_str_fsst_np",
-    "0x01-rust/props_shared_dict_2_same_prefix_np",
-    "0x01-rust/props_shared_dict_fsst_np",
-    "0x01-rust/props_shared_dict_no_child_name_fsst_np",
-    "0x01-rust/props_shared_dict_no_child_name_np",
-    "0x01-rust/props_shared_dict_no_struct_name_fsst_np",
-    "0x01-rust/props_shared_dict_no_struct_name_np",
-    "0x01-rust/props_shared_dict_np",
-    "0x01-rust/props_shared_dict_one_child_fsst_np",
-    "0x01-rust/props_shared_dict_one_child_np",
-    "0x01-rust/props_shared_dict_presence_variants_np",
-    "0x01-rust/props_str_fsst_np",
     "0x01/multipoint_morton",
     "0x01/poly_morton_hole_morton",
     "0x01/poly_multi_morton_hole_morton",

--- a/ts/src/vector/fsst-dictionary/stringFsstDictionaryVector.ts
+++ b/ts/src/vector/fsst-dictionary/stringFsstDictionaryVector.ts
@@ -17,7 +17,7 @@ export class StringFsstDictionaryVector extends VariableSizeVector<Uint8Array, s
         private readonly symbolTableBuffer: Uint8Array,
         nullabilityBuffer: BitVector,
     ) {
-        super(name, offsetBuffer, dictionaryBuffer, nullabilityBuffer);
+        super(name, offsetBuffer, dictionaryBuffer, nullabilityBuffer ?? indexBuffer.length);
     }
 
     protected getValueFromBuffer(index: number): string {


### PR DESCRIPTION
- Replaces #1234
- Fixes #1238
- Related to #1233

This adds the relevant logic to typescript, is it heavily inspired by the java decoder code.
It removes the skipped synthetic tests and also add some unit tests.



