### PR TITLE
refactor(rust): compute more stats before sort to enable deduplicating presence in v2

### DIFF
--- a/.cursor/rules/karpathy-guidelines.mdc
+++ b/.cursor/rules/karpathy-guidelines.mdc
@@ -1,5 +1,5 @@
 ---
-description:
+description: 
 alwaysApply: true
 ---
 

--- a/.cursor/rules/karpathy-guidelines.mdc
+++ b/.cursor/rules/karpathy-guidelines.mdc
@@ -1,5 +1,5 @@
 ---
-description: 
+description:
 alwaysApply: true
 ---
 

--- a/rust/mlt-core/benches/decoding_strings.rs
+++ b/rust/mlt-core/benches/decoding_strings.rs
@@ -3,8 +3,8 @@ use std::hint::black_box;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use geo_types::Point;
 use mlt_core::encoder::{
-    Encoder, EncoderConfig, ExplicitEncoder, IntEncoder, LogicalEncoder, PhysicalEncoder, StagedId,
-    StagedLayer, StagedProperty, StagedSharedDict, StrEncoding,
+    Encoder, EncoderConfig, ExplicitEncoder, IntEncoder, LogicalEncoder, PhysicalEncoder, Presence,
+    StagedId, StagedLayer, StagedProperty, StagedSharedDict, StrEncoding,
 };
 use mlt_core::test_helpers::{dec, parser};
 use mlt_core::{GeometryValues, LendingIterator, ParsedLayer01, PropValueRef};
@@ -360,7 +360,10 @@ fn bench_vs_shared_dict(c: &mut Criterion) {
         let make_sd = || {
             StagedSharedDict::new(
                 "place:",
-                [("type", col_opt.clone()), ("subtype", col2.clone())],
+                [
+                    ("type", col_opt.clone(), Presence::AllPresent),
+                    ("subtype", col2.clone(), Presence::Mixed),
+                ],
             )
             .expect("StagedSharedDict::new failed")
         };

--- a/rust/mlt-core/benches/encoding_e2e.rs
+++ b/rust/mlt-core/benches/encoding_e2e.rs
@@ -3,15 +3,14 @@ use std::hint::black_box;
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use mlt_core::__private::{dec, parser};
 use mlt_core::Layer;
-use mlt_core::encoder::{EncoderConfig, LogicalEncoder, SortStrategy};
+use mlt_core::encoder::{EncoderConfig, LogicalEncoder, stage_tile};
 use strum::IntoEnumIterator as _;
 
 #[path = "bench_utils.rs"]
 mod bench_utils;
 use bench_utils::{BENCHMARKED_ZOOM_LEVELS, load_mlt_tiles};
-use mlt_core::encoder::{
-    Encoder, ExplicitEncoder, IntEncoder, PhysicalEncoder, StagedLayer, analyze_layer,
-};
+use mlt_core::encoder::SortStrategy::Unsorted;
+use mlt_core::encoder::{Encoder, ExplicitEncoder, IntEncoder, PhysicalEncoder, StagedLayer};
 
 fn limit<T>(values: impl Iterator<Item = T>) -> impl Iterator<Item = T> {
     if cfg!(debug_assertions) {
@@ -38,13 +37,7 @@ fn decode_to_owned(tiles: &[(String, Vec<u8>)], tessellate: bool) -> Vec<StagedL
                         return None;
                     };
                     let tile = layer01.into_tile(&mut d).ok()?;
-                    let analysis = analyze_layer(&tile, false);
-                    Some(StagedLayer::from_tile(
-                        tile,
-                        SortStrategy::Unsorted,
-                        &analysis,
-                        tessellate,
-                    ))
+                    Some(stage_tile(tile, Unsorted, false, tessellate))
                 })
                 .collect::<Vec<_>>()
         })

--- a/rust/mlt-core/benches/encoding_e2e.rs
+++ b/rust/mlt-core/benches/encoding_e2e.rs
@@ -9,7 +9,9 @@ use strum::IntoEnumIterator as _;
 #[path = "bench_utils.rs"]
 mod bench_utils;
 use bench_utils::{BENCHMARKED_ZOOM_LEVELS, load_mlt_tiles};
-use mlt_core::encoder::{Encoder, ExplicitEncoder, IntEncoder, PhysicalEncoder, StagedLayer};
+use mlt_core::encoder::{
+    Encoder, ExplicitEncoder, IntEncoder, PhysicalEncoder, StagedLayer, analyze_layer,
+};
 
 fn limit<T>(values: impl Iterator<Item = T>) -> impl Iterator<Item = T> {
     if cfg!(debug_assertions) {
@@ -36,10 +38,11 @@ fn decode_to_owned(tiles: &[(String, Vec<u8>)], tessellate: bool) -> Vec<StagedL
                         return None;
                     };
                     let tile = layer01.into_tile(&mut d).ok()?;
+                    let analysis = analyze_layer(&tile, false);
                     Some(StagedLayer::from_tile(
                         tile,
                         SortStrategy::Unsorted,
-                        &[],
+                        &analysis,
                         tessellate,
                     ))
                 })

--- a/rust/mlt-core/fuzz/src/decoded_layer.rs
+++ b/rust/mlt-core/fuzz/src/decoded_layer.rs
@@ -1,4 +1,5 @@
-use mlt_core::encoder::{Encoder, SortStrategy, StagedLayer, analyze_layer};
+use mlt_core::encoder::SortStrategy::Unsorted;
+use mlt_core::encoder::{Encoder, StagedLayer, stage_tile};
 use mlt_core::{Decoder, Layer, Parser, TileLayer};
 
 /// Fuzz input that starts from a staged layer and tests encode → decode roundtrip.
@@ -21,26 +22,10 @@ impl DecodedLayerInput {
         // Normalize: encode the fuzzed StagedLayer and decode to TileLayer.
         // This drops all-null columns, etc. — expected encoder behavior.
         let tile1 = encode_decode(self.layer);
-
-        // Canonical roundtrip per CONTRIBUTING.md:
-        // Tile → Staged → bytes → Tile
-        let analysis = analyze_layer(&tile1, false);
-        let tile2 = encode_decode(StagedLayer::from_tile(
-            tile1,
-            SortStrategy::Unsorted,
-            &analysis,
-            false,
-        ));
+        let tile2 = encode_decode(stage_tile(tile1, Unsorted, false, false));
 
         // Same roundtrip again — must be a fixpoint.
-        let analysis = analyze_layer(&tile2, false);
-        let tile3 = encode_decode(StagedLayer::from_tile(
-            tile2.clone(),
-            SortStrategy::Unsorted,
-            &analysis,
-            false,
-        ));
-
+        let tile3 = encode_decode(stage_tile(tile2.clone(), Unsorted, false, false));
         assert_eq!(tile2, tile3, "canonical roundtrip is not idempotent");
     }
 }

--- a/rust/mlt-core/fuzz/src/decoded_layer.rs
+++ b/rust/mlt-core/fuzz/src/decoded_layer.rs
@@ -1,4 +1,4 @@
-use mlt_core::encoder::{Encoder, SortStrategy, StagedLayer};
+use mlt_core::encoder::{Encoder, SortStrategy, StagedLayer, analyze_layer};
 use mlt_core::{Decoder, Layer, Parser, TileLayer};
 
 /// Fuzz input that starts from a staged layer and tests encode → decode roundtrip.
@@ -24,18 +24,20 @@ impl DecodedLayerInput {
 
         // Canonical roundtrip per CONTRIBUTING.md:
         // Tile → Staged → bytes → Tile
+        let analysis = analyze_layer(&tile1, false);
         let tile2 = encode_decode(StagedLayer::from_tile(
             tile1,
             SortStrategy::Unsorted,
-            &[],
+            &analysis,
             false,
         ));
 
         // Same roundtrip again — must be a fixpoint.
+        let analysis = analyze_layer(&tile2, false);
         let tile3 = encode_decode(StagedLayer::from_tile(
             tile2.clone(),
             SortStrategy::Unsorted,
-            &[],
+            &analysis,
             false,
         ));
 

--- a/rust/mlt-core/src/decoder/iterators.rs
+++ b/rust/mlt-core/src/decoder/iterators.rs
@@ -514,7 +514,7 @@ mod tests {
     use crate::Layer;
     use crate::decoder::GeometryValues;
     use crate::encoder::model::StagedLayer;
-    use crate::encoder::{Encoder, StagedId, StagedProperty, StagedSharedDict};
+    use crate::encoder::{Encoder, Presence, StagedId, StagedProperty, StagedSharedDict};
     use crate::test_helpers::{dec, parser};
 
     fn layer_buf(staged: StagedLayer) -> Vec<u8> {
@@ -895,8 +895,16 @@ mod tests {
         let shared_dict = StagedSharedDict::new(
             "addr:",
             [
-                ("city", vec![Some("Paris"), Some("Rome"), None]),
-                ("zip", vec![Some("75001"), None, Some("00100")]),
+                (
+                    "city",
+                    vec![Some("Paris"), Some("Rome"), None],
+                    Presence::Mixed,
+                ),
+                (
+                    "zip",
+                    vec![Some("75001"), None, Some("00100")],
+                    Presence::Mixed,
+                ),
             ],
         )
         .unwrap();

--- a/rust/mlt-core/src/decoder/mod.rs
+++ b/rust/mlt-core/src/decoder/mod.rs
@@ -27,8 +27,8 @@ pub use iterators::{
 };
 pub(crate) use model::Column;
 pub use model::{
-    ColumnType, Layer, Layer01, ParsedLayer, ParsedLayer01, PropValue, TileFeature, TileLayer,
-    Unknown,
+    ColumnType, Layer, Layer01, ParsedLayer, ParsedLayer01, PropKind, PropValue, TileFeature,
+    TileLayer, Unknown,
 };
 // Re-export strings sub-module so encoder can use `crate::decoder::strings::*`
 pub(crate) use property::strings;

--- a/rust/mlt-core/src/decoder/model.rs
+++ b/rust/mlt-core/src/decoder/model.rs
@@ -203,3 +203,33 @@ pub enum PropValue {
     F64(Option<f64>),
     Str(Option<String>),
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PropKind {
+    Bool,
+    I8,
+    U8,
+    I32,
+    U32,
+    I64,
+    U64,
+    F32,
+    F64,
+    Str,
+}
+impl From<&PropValue> for PropKind {
+    fn from(prop: &PropValue) -> Self {
+        match prop {
+            PropValue::Bool(_) => Self::Bool,
+            PropValue::I8(_) => Self::I8,
+            PropValue::U8(_) => Self::U8,
+            PropValue::I32(_) => Self::I32,
+            PropValue::U32(_) => Self::U32,
+            PropValue::I64(_) => Self::I64,
+            PropValue::U64(_) => Self::U64,
+            PropValue::F32(_) => Self::F32,
+            PropValue::F64(_) => Self::F64,
+            PropValue::Str(_) => Self::Str,
+        }
+    }
+}

--- a/rust/mlt-core/src/decoder/model.rs
+++ b/rust/mlt-core/src/decoder/model.rs
@@ -204,7 +204,8 @@ pub enum PropValue {
     Str(Option<String>),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::IntoStaticStr)]
+#[strum(serialize_all = "lowercase")]
 pub enum PropKind {
     Bool,
     I8,

--- a/rust/mlt-core/src/encoder/fuzzing.rs
+++ b/rust/mlt-core/src/encoder/fuzzing.rs
@@ -2,6 +2,7 @@ use arbitrary::Error::IncorrectFormat;
 use arbitrary::{Arbitrary, Result, Unstructured};
 
 use crate::encoder::model::StagedLayer;
+use crate::encoder::optimizer::Presence;
 use crate::encoder::{StagedId, StagedProperty, StagedSharedDict, StagedStrings};
 
 impl Arbitrary<'_> for StagedId {
@@ -63,8 +64,16 @@ impl<'a> Arbitrary<'a> for StagedSharedDict {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
         // Bound item count and string sizes to prevent OOM
         let item_count = u.int_in_range(0..=8u8)? as usize;
-        let items_raw: Vec<(String, Vec<Option<String>>)> = (0..item_count)
-            .map(|_| Ok((bounded_string(u, 32)?, generate_strings(u)?)))
+        let items_raw: Vec<(String, Vec<Option<String>>, Presence)> = (0..item_count)
+            .map(|_| {
+                let values = generate_strings(u)?;
+                let presence = if values.iter().all(Option::is_some) {
+                    Presence::AllPresent
+                } else {
+                    Presence::Mixed
+                };
+                Ok((bounded_string(u, 32)?, values, presence))
+            })
             .collect::<Result<_>>()?;
         if items_raw.is_empty() {
             return Ok(Self {

--- a/rust/mlt-core/src/encoder/id/staged_id.rs
+++ b/rust/mlt-core/src/encoder/id/staged_id.rs
@@ -1,5 +1,6 @@
 use crate::MltResult;
 use crate::decoder::ColumnType;
+use crate::encoder::optimizer::{Presence, PropertyStats};
 use crate::encoder::{
     Encoder, StagedOptScalar, StagedScalar, write_opt_u32_scalar_col, write_opt_u64_scalar_col,
     write_u32_scalar_col, write_u64_scalar_col,
@@ -75,6 +76,69 @@ impl StagedId {
             Self::u64(values64)
         } else {
             Self::u32(values)
+        }
+    }
+
+    /// Construct from sparse IDs using a precomputed presence classification.
+    #[must_use]
+    pub(crate) fn from_optional_with_presence(
+        ids: impl IntoIterator<Item = Option<u64>>,
+        analysis: Option<&PropertyStats>,
+    ) -> Self {
+        let Some(analysis) = analysis else {
+            return Self::None;
+        };
+        match analysis.presence {
+            Presence::AllNull => Self::None,
+            Presence::AllPresent => {
+                Self::from_dense(ids.into_iter().flatten(), analysis.stats.values_fit_u32())
+            }
+            Presence::Mixed => Self::from_optional_sparse(ids, analysis.stats.values_fit_u32()),
+        }
+    }
+
+    fn from_dense(ids: impl IntoIterator<Item = u64>, values_fit_u32: bool) -> Self {
+        if values_fit_u32 {
+            Self::u32(
+                ids.into_iter()
+                    .map(|id| {
+                        u32::try_from(id).expect("ID analysis guarantees u32-compatible values")
+                    })
+                    .collect(),
+            )
+        } else {
+            Self::u64(ids.into_iter().collect())
+        }
+    }
+
+    fn from_optional_sparse(
+        ids: impl IntoIterator<Item = Option<u64>>,
+        values_fit_u32: bool,
+    ) -> Self {
+        let ids = ids.into_iter();
+        let (lower, upper) = ids.size_hint();
+        let capacity = upper.unwrap_or(lower);
+        let mut presence = Vec::with_capacity(capacity);
+        if values_fit_u32 {
+            let mut values = Vec::with_capacity(capacity);
+            for id in ids {
+                presence.push(id.is_some());
+                if let Some(id) = id {
+                    values.push(
+                        u32::try_from(id).expect("ID analysis guarantees u32-compatible values"),
+                    );
+                }
+            }
+            Self::OptU32(StagedOptScalar::from_parts(String::new(), presence, values))
+        } else {
+            let mut values = Vec::with_capacity(capacity);
+            for id in ids {
+                presence.push(id.is_some());
+                if let Some(id) = id {
+                    values.push(id);
+                }
+            }
+            Self::OptU64(StagedOptScalar::from_parts(String::new(), presence, values))
         }
     }
 

--- a/rust/mlt-core/src/encoder/mod.rs
+++ b/rust/mlt-core/src/encoder/mod.rs
@@ -24,6 +24,8 @@ pub use model::{ColumnKind, ExplicitEncoder, StagedLayer, StrEncoding, StreamCtx
 pub use model::{EncodedUnknown, EncoderConfig};
 #[cfg(all(test, not(feature = "__private")))]
 pub(crate) use model::{ExplicitEncoder, StagedLayer, StrEncoding};
+#[cfg(any(test, feature = "__private"))]
+pub use optimizer::Presence;
 pub(crate) use property::*;
 #[cfg(feature = "__private")]
 pub use property::{StagedProperty, StagedSharedDict};

--- a/rust/mlt-core/src/encoder/mod.rs
+++ b/rust/mlt-core/src/encoder/mod.rs
@@ -24,8 +24,6 @@ pub use model::{ColumnKind, ExplicitEncoder, StagedLayer, StrEncoding, StreamCtx
 pub use model::{EncodedUnknown, EncoderConfig};
 #[cfg(all(test, not(feature = "__private")))]
 pub(crate) use model::{ExplicitEncoder, StagedLayer, StrEncoding};
-#[cfg(any(test, feature = "__private"))]
-pub use optimizer::analyze_layer;
 pub(crate) use property::*;
 #[cfg(feature = "__private")]
 pub use property::{StagedProperty, StagedSharedDict};
@@ -34,4 +32,6 @@ pub(crate) use sort::spatial_sort_likely_to_help;
 pub(crate) use stream::*;
 #[cfg(feature = "__private")]
 pub use stream::{IntEncoder, LogicalEncoder, PhysicalEncoder};
+#[cfg(any(test, feature = "__private"))]
+pub use tests::stage_tile;
 pub use writer::Encoder;

--- a/rust/mlt-core/src/encoder/mod.rs
+++ b/rust/mlt-core/src/encoder/mod.rs
@@ -24,6 +24,8 @@ pub use model::{ColumnKind, ExplicitEncoder, StagedLayer, StrEncoding, StreamCtx
 pub use model::{EncodedUnknown, EncoderConfig};
 #[cfg(all(test, not(feature = "__private")))]
 pub(crate) use model::{ExplicitEncoder, StagedLayer, StrEncoding};
+#[cfg(any(test, feature = "__private"))]
+pub use optimizer::analyze_layer;
 pub(crate) use property::*;
 #[cfg(feature = "__private")]
 pub use property::{StagedProperty, StagedSharedDict};

--- a/rust/mlt-core/src/encoder/optimizer.rs
+++ b/rust/mlt-core/src/encoder/optimizer.rs
@@ -1,11 +1,11 @@
 use crate::decoder::TileLayer;
 use crate::encoder::model::StagedLayer;
+use crate::encoder::property::apply_string_groups;
 use crate::encoder::property::encode::write_properties;
-use crate::encoder::property::{StringStatsBuilder, apply_string_groups};
 use crate::encoder::{
     Encoder, EncoderConfig, SortStrategy, StringGroup, spatial_sort_likely_to_help,
 };
-use crate::{MltResult, PropValue};
+use crate::{MltError, MltResult, PropValue};
 
 impl StagedLayer {
     /// Encode and serialize the layer directly into `enc`, without creating any
@@ -69,29 +69,29 @@ impl TileLayer {
             sort_by.push(SortStrategy::Id);
         }
 
-        let analysis = self.analyze(cfg.allow_shared_dict);
+        let stats = self.analyze(cfg.allow_shared_dict)?;
 
         let (last, init) = sort_by.split_last().expect("at least one strategy");
         if init.is_empty() {
-            StagedLayer::from_tile(self, *last, &analysis, cfg.tessellate)
+            StagedLayer::from_tile(self, *last, &stats, cfg.tessellate)
                 .encode_into(Encoder::new(cfg))?
         } else {
             let mut enc: Encoder = {
                 let first = init[0];
-                StagedLayer::from_tile(self.clone(), first, &analysis, cfg.tessellate)
+                StagedLayer::from_tile(self.clone(), first, &stats, cfg.tessellate)
                     .encode_into(Encoder::new(cfg))?
             };
             let mut best = enc.preserve_results();
             // Clone for all-but-last strategies
             for &sort in &init[1..] {
-                let layer = StagedLayer::from_tile(self.clone(), sort, &analysis, cfg.tessellate);
+                let layer = StagedLayer::from_tile(self.clone(), sort, &stats, cfg.tessellate);
                 enc = layer.encode_into(enc)?;
                 if enc.total_len() < best.total_len() {
                     best = enc.preserve_results();
                 }
             }
             // Last strategy: consume self, no clone
-            let layer = StagedLayer::from_tile(self, *last, &analysis, cfg.tessellate);
+            let layer = StagedLayer::from_tile(self, *last, &stats, cfg.tessellate);
             enc = layer.encode_into(enc)?;
             if enc.total_len() < best.total_len() {
                 best = enc.preserve_results();
@@ -154,12 +154,9 @@ pub enum PropertyTypedStats {
         min: u64,
         max: u64,
     },
-    Float,
+    F32,
+    F64,
     String {
-        total_bytes: usize,
-        max_bytes: usize,
-        exact_hashes: Vec<u64>,
-        trigram_hashes: Vec<u64>,
         shared_dict: SharedDictRole,
     },
 }
@@ -168,7 +165,7 @@ impl PropertyTypedStats {
     #[must_use]
     pub fn values_fit_u32(&self) -> bool {
         match self {
-            Self::None | Self::Bool | Self::Float | Self::String { .. } => false,
+            Self::None | Self::Bool | Self::F32 | Self::F64 | Self::String { .. } => false,
             Self::Signed { min, max } => *min >= 0 && u32::try_from(*max).is_ok(),
             Self::Unsigned { max, .. } => u32::try_from(*max).is_ok(),
         }
@@ -189,26 +186,28 @@ impl PropertyTypedStats {
         }
     }
 
-    pub(crate) fn push(&mut self, prop: &PropValue) {
+    pub(crate) fn push(&mut self, prop: &PropValue) -> MltResult<()> {
         match prop {
-            PropValue::Bool(Some(_)) => self.merge_bool(),
-            PropValue::I8(Some(v)) => self.merge_signed(i64::from(*v)),
-            PropValue::U8(Some(v)) => self.merge_unsigned(u64::from(*v)),
-            PropValue::I32(Some(v)) => self.merge_signed(i64::from(*v)),
-            PropValue::U32(Some(v)) => self.merge_unsigned(u64::from(*v)),
-            PropValue::I64(Some(v)) => self.merge_signed(*v),
-            PropValue::U64(Some(v)) => self.merge_unsigned(*v),
-            PropValue::F32(Some(_)) | PropValue::F64(Some(_)) => self.merge_float(),
-            PropValue::Str(Some(s)) => self.merge_string(s.len()),
+            PropValue::Bool(Some(_)) => self.merge_bool()?,
+            PropValue::I8(Some(v)) => self.merge_signed(i64::from(*v))?,
+            PropValue::U8(Some(v)) => self.merge_unsigned(u64::from(*v))?,
+            PropValue::I32(Some(v)) => self.merge_signed(i64::from(*v))?,
+            PropValue::U32(Some(v)) => self.merge_unsigned(u64::from(*v))?,
+            PropValue::I64(Some(v)) => self.merge_signed(*v)?,
+            PropValue::U64(Some(v)) => self.merge_unsigned(*v)?,
+            PropValue::F32(Some(_)) => self.merge_same_kind(Self::F32)?,
+            PropValue::F64(Some(_)) => self.merge_same_kind(Self::F64)?,
+            PropValue::Str(Some(_)) => self.merge_string()?,
             _ => {}
         }
+        Ok(())
     }
 
-    fn merge_bool(&mut self) {
-        self.merge_same_kind(Self::Bool);
+    fn merge_bool(&mut self) -> MltResult<()> {
+        self.merge_same_kind(Self::Bool)
     }
 
-    fn merge_signed(&mut self, value: i64) {
+    fn merge_signed(&mut self, value: i64) -> MltResult<()> {
         match self {
             Self::None => {
                 *self = Self::Signed {
@@ -220,11 +219,12 @@ impl PropertyTypedStats {
                 *min = (*min).min(value);
                 *max = (*max).max(value);
             }
-            _ => panic!("mixed property types are not allowed"),
+            _ => return Err(MltError::MixedPropertyTypes),
         }
+        Ok(())
     }
 
-    fn merge_unsigned(&mut self, value: u64) {
+    fn merge_unsigned(&mut self, value: u64) -> MltResult<()> {
         match self {
             Self::None => {
                 *self = Self::Unsigned {
@@ -236,67 +236,53 @@ impl PropertyTypedStats {
                 *min = (*min).min(value);
                 *max = (*max).max(value);
             }
-            _ => panic!("mixed property types are not allowed"),
+            _ => return Err(MltError::MixedPropertyTypes),
         }
+        Ok(())
     }
 
-    fn merge_float(&mut self) {
-        self.merge_same_kind(Self::Float);
-    }
-
-    fn merge_string(&mut self, len: usize) {
+    fn merge_string(&mut self) -> MltResult<()> {
         match self {
             Self::None => {
                 *self = Self::String {
-                    total_bytes: len,
-                    max_bytes: len,
-                    exact_hashes: Vec::new(),
-                    trigram_hashes: Vec::new(),
                     shared_dict: SharedDictRole::None,
                 };
             }
-            Self::String {
-                total_bytes,
-                max_bytes,
-                exact_hashes: _,
-                trigram_hashes: _,
-                shared_dict: _,
-            } => {
-                *total_bytes += len;
-                *max_bytes = (*max_bytes).max(len);
-            }
-            _ => panic!("mixed property types are not allowed"),
+            Self::String { .. } => {}
+            _ => return Err(MltError::MixedPropertyTypes),
         }
+        Ok(())
     }
 
-    fn merge_same_kind(&mut self, kind: Self) {
+    fn merge_same_kind(&mut self, kind: Self) -> MltResult<()> {
         match self {
             Self::None => *self = kind,
             Self::Bool if matches!(kind, Self::Bool) => {}
-            Self::Float if matches!(kind, Self::Float) => {}
-            _ => panic!("mixed property types are not allowed"),
+            Self::F32 if matches!(kind, Self::F32) => {}
+            Self::F64 if matches!(kind, Self::F64) => {}
+            _ => return Err(MltError::MixedPropertyTypes),
         }
+        Ok(())
     }
 }
 
 impl TileLayer {
     /// Analyze a [`TileLayer`] and return reusable ID/property facts for the optimizer.
-    #[must_use]
     #[hotpath::measure]
-    pub(crate) fn analyze(&self, allow_shared_dict: bool) -> LayerStats {
+    pub(crate) fn analyze(&self, allow_shared_dict: bool) -> MltResult<LayerStats> {
         let id = self.analyze_ids();
-        let mut properties = self.profile_properties(allow_shared_dict);
+        let mut properties = self.profile_properties()?;
         let string_groups = if allow_shared_dict {
-            apply_string_groups(&self.property_names, &mut properties)
+            self.apply_string_groups(&mut properties)
         } else {
             Vec::new()
         };
 
-        LayerStats {
+        Ok(LayerStats {
             id,
             properties,
             string_groups,
-        }
+        })
     }
 
     fn analyze_ids(&self) -> Option<PropertyStats> {
@@ -324,24 +310,19 @@ impl TileLayer {
         })
     }
 
-    fn profile_properties(&self, allow_shared_dict: bool) -> Vec<PropertyStats> {
-        let string_stats = allow_shared_dict.then(StringStatsBuilder::new);
+    fn profile_properties(&self) -> MltResult<Vec<PropertyStats>> {
         self.property_names
             .iter()
             .enumerate()
-            .map(|(col_idx, _name)| {
+            .map(|(col_idx, _name)| -> MltResult<PropertyStats> {
                 let mut present = 0usize;
                 let mut stats = PropertyTypedStats::default();
-                let mut string_values = Vec::new();
                 for feature in &self.features {
                     let prop = feature.properties.get(col_idx);
                     if prop_is_present(prop) {
                         present += 1;
                         let prop = prop.expect("present property exists");
-                        stats.push(prop);
-                        if let (Some(_), PropValue::Str(Some(s))) = (&string_stats, prop) {
-                            string_values.push(s.as_str());
-                        }
+                        stats.push(prop)?;
                     }
                 }
 
@@ -353,22 +334,7 @@ impl TileLayer {
                     Presence::Mixed
                 };
 
-                if let (Some(string_stats), false) =
-                    (string_stats.as_ref(), string_values.is_empty())
-                {
-                    let (exact, trigram) = string_stats.hashes(&string_values);
-                    if let PropertyTypedStats::String {
-                        exact_hashes,
-                        trigram_hashes,
-                        ..
-                    } = &mut stats
-                    {
-                        *exact_hashes = exact;
-                        *trigram_hashes = trigram;
-                    }
-                }
-
-                PropertyStats { presence, stats }
+                Ok(PropertyStats { presence, stats })
             })
             .collect()
     }

--- a/rust/mlt-core/src/encoder/optimizer.rs
+++ b/rust/mlt-core/src/encoder/optimizer.rs
@@ -69,7 +69,7 @@ impl TileLayer {
             sort_by.push(SortStrategy::Id);
         }
 
-        let analysis = analyze_layer(&self, cfg.allow_shared_dict);
+        let analysis = self.analyze(cfg.allow_shared_dict);
 
         let (last, init) = sort_by.split_last().expect("at least one strategy");
         if init.is_empty() {
@@ -279,96 +279,99 @@ impl PropertyTypedStats {
     }
 }
 
-/// Analyze a [`TileLayer`] and return reusable ID/property facts for the optimizer.
-#[must_use]
-#[hotpath::measure]
-pub fn analyze_layer(source: &TileLayer, allow_shared_dict: bool) -> LayerStats {
-    let id = analyze_ids(source);
-    let mut properties = profile_properties(source, allow_shared_dict);
-    let string_groups = if allow_shared_dict {
-        apply_string_groups(&source.property_names, &mut properties)
-    } else {
-        Vec::new()
-    };
+impl TileLayer {
+    /// Analyze a [`TileLayer`] and return reusable ID/property facts for the optimizer.
+    #[must_use]
+    #[hotpath::measure]
+    pub(crate) fn analyze(&self, allow_shared_dict: bool) -> LayerStats {
+        let id = self.analyze_ids();
+        let mut properties = self.profile_properties(allow_shared_dict);
+        let string_groups = if allow_shared_dict {
+            apply_string_groups(&self.property_names, &mut properties)
+        } else {
+            Vec::new()
+        };
 
-    LayerStats {
-        id,
-        properties,
-        string_groups,
-    }
-}
-
-fn analyze_ids(source: &TileLayer) -> Option<PropertyStats> {
-    let mut present = 0usize;
-    let mut min = u64::MAX;
-    let mut max = 0u64;
-    for feature in &source.features {
-        if let Some(id) = feature.id {
-            present += 1;
-            min = min.min(id);
-            max = max.max(id);
+        LayerStats {
+            id,
+            properties,
+            string_groups,
         }
     }
-    if present == 0 {
-        return None;
-    }
-    let presence = if present == source.features.len() {
-        Presence::AllPresent
-    } else {
-        Presence::Mixed
-    };
-    Some(PropertyStats {
-        presence,
-        stats: PropertyTypedStats::Unsigned { min, max },
-    })
-}
 
-fn profile_properties(source: &TileLayer, allow_shared_dict: bool) -> Vec<PropertyStats> {
-    let string_stats = allow_shared_dict.then(StringStatsBuilder::new);
-    source
-        .property_names
-        .iter()
-        .enumerate()
-        .map(|(col_idx, _name)| {
-            let mut present = 0usize;
-            let mut stats = PropertyTypedStats::default();
-            let mut string_values = Vec::new();
-            for feature in &source.features {
-                let prop = feature.properties.get(col_idx);
-                if prop_is_present(prop) {
-                    present += 1;
-                    let prop = prop.expect("present property exists");
-                    stats.push(prop);
-                    if let (Some(_), PropValue::Str(Some(s))) = (&string_stats, prop) {
-                        string_values.push(s.as_str());
+    fn analyze_ids(&self) -> Option<PropertyStats> {
+        let mut present = 0usize;
+        let mut min = u64::MAX;
+        let mut max = 0u64;
+        for feature in &self.features {
+            if let Some(id) = feature.id {
+                present += 1;
+                min = min.min(id);
+                max = max.max(id);
+            }
+        }
+        if present == 0 {
+            return None;
+        }
+        let presence = if present == self.features.len() {
+            Presence::AllPresent
+        } else {
+            Presence::Mixed
+        };
+        Some(PropertyStats {
+            presence,
+            stats: PropertyTypedStats::Unsigned { min, max },
+        })
+    }
+
+    fn profile_properties(&self, allow_shared_dict: bool) -> Vec<PropertyStats> {
+        let string_stats = allow_shared_dict.then(StringStatsBuilder::new);
+        self.property_names
+            .iter()
+            .enumerate()
+            .map(|(col_idx, _name)| {
+                let mut present = 0usize;
+                let mut stats = PropertyTypedStats::default();
+                let mut string_values = Vec::new();
+                for feature in &self.features {
+                    let prop = feature.properties.get(col_idx);
+                    if prop_is_present(prop) {
+                        present += 1;
+                        let prop = prop.expect("present property exists");
+                        stats.push(prop);
+                        if let (Some(_), PropValue::Str(Some(s))) = (&string_stats, prop) {
+                            string_values.push(s.as_str());
+                        }
                     }
                 }
-            }
 
-            let presence = if present == 0 {
-                Presence::AllNull
-            } else if present == source.features.len() {
-                Presence::AllPresent
-            } else {
-                Presence::Mixed
-            };
+                let presence = if present == 0 {
+                    Presence::AllNull
+                } else if present == self.features.len() {
+                    Presence::AllPresent
+                } else {
+                    Presence::Mixed
+                };
 
-            if let (Some(string_stats), false) = (string_stats.as_ref(), string_values.is_empty()) {
-                let (exact, trigram) = string_stats.hashes(&string_values);
-                if let PropertyTypedStats::String {
-                    exact_hashes,
-                    trigram_hashes,
-                    ..
-                } = &mut stats
+                if let (Some(string_stats), false) =
+                    (string_stats.as_ref(), string_values.is_empty())
                 {
-                    *exact_hashes = exact;
-                    *trigram_hashes = trigram;
+                    let (exact, trigram) = string_stats.hashes(&string_values);
+                    if let PropertyTypedStats::String {
+                        exact_hashes,
+                        trigram_hashes,
+                        ..
+                    } = &mut stats
+                    {
+                        *exact_hashes = exact;
+                        *trigram_hashes = trigram;
+                    }
                 }
-            }
 
-            PropertyStats { presence, stats }
-        })
-        .collect()
+                PropertyStats { presence, stats }
+            })
+            .collect()
+    }
 }
 
 fn prop_is_present(prop: Option<&PropValue>) -> bool {

--- a/rust/mlt-core/src/encoder/optimizer.rs
+++ b/rust/mlt-core/src/encoder/optimizer.rs
@@ -1,4 +1,4 @@
-use crate::decoder::TileLayer;
+use crate::decoder::{PropKind, TileLayer};
 use crate::encoder::model::StagedLayer;
 use crate::encoder::property::encode::write_properties;
 use crate::encoder::{Encoder, EncoderConfig, SortStrategy, spatial_sort_likely_to_help};
@@ -182,28 +182,54 @@ impl PropertyTypedStats {
         }
     }
 
-    pub(crate) fn push(&mut self, prop: &PropValue) -> MltResult<()> {
+    pub(crate) fn push(
+        &mut self,
+        prop: &PropValue,
+        column_index: usize,
+        property_name: &str,
+    ) -> MltResult<()> {
         match prop {
-            PropValue::Bool(Some(_)) => self.merge_bool()?,
-            PropValue::I8(Some(v)) => self.merge_signed(i64::from(*v))?,
-            PropValue::U8(Some(v)) => self.merge_unsigned(u64::from(*v))?,
-            PropValue::I32(Some(v)) => self.merge_signed(i64::from(*v))?,
-            PropValue::U32(Some(v)) => self.merge_unsigned(u64::from(*v))?,
-            PropValue::I64(Some(v)) => self.merge_signed(*v)?,
-            PropValue::U64(Some(v)) => self.merge_unsigned(*v)?,
-            PropValue::F32(Some(_)) => self.merge_same_kind(Self::F32)?,
-            PropValue::F64(Some(_)) => self.merge_same_kind(Self::F64)?,
-            PropValue::Str(Some(_)) => self.merge_string()?,
+            PropValue::Bool(Some(_)) => self.merge_bool(column_index, property_name)?,
+            PropValue::I8(Some(v)) => {
+                self.merge_signed(i64::from(*v), column_index, property_name)?;
+            }
+            PropValue::U8(Some(v)) => {
+                self.merge_unsigned(u64::from(*v), column_index, property_name)?;
+            }
+            PropValue::I32(Some(v)) => {
+                self.merge_signed(i64::from(*v), column_index, property_name)?;
+            }
+            PropValue::U32(Some(v)) => {
+                self.merge_unsigned(u64::from(*v), column_index, property_name)?;
+            }
+            PropValue::I64(Some(v)) => self.merge_signed(*v, column_index, property_name)?,
+            PropValue::U64(Some(v)) => self.merge_unsigned(*v, column_index, property_name)?,
+            PropValue::F32(Some(_)) => {
+                self.merge_same_kind(Self::F32, column_index, property_name)?;
+            }
+            PropValue::F64(Some(_)) => {
+                self.merge_same_kind(Self::F64, column_index, property_name)?;
+            }
+            PropValue::Str(Some(_)) => self.merge_string(column_index, property_name)?,
             _ => {}
         }
         Ok(())
     }
 
-    fn merge_bool(&mut self) -> MltResult<()> {
-        self.merge_same_kind(Self::Bool)
+    fn mixed_property_types(column_index: usize, property_name: &str) -> MltError {
+        MltError::MixedPropertyTypes(column_index, property_name.to_owned())
     }
 
-    fn merge_signed(&mut self, value: i64) -> MltResult<()> {
+    fn merge_bool(&mut self, column_index: usize, property_name: &str) -> MltResult<()> {
+        self.merge_same_kind(Self::Bool, column_index, property_name)
+    }
+
+    fn merge_signed(
+        &mut self,
+        value: i64,
+        column_index: usize,
+        property_name: &str,
+    ) -> MltResult<()> {
         match self {
             Self::None => {
                 *self = Self::Signed {
@@ -215,12 +241,17 @@ impl PropertyTypedStats {
                 *min = (*min).min(value);
                 *max = (*max).max(value);
             }
-            _ => return Err(MltError::MixedPropertyTypes),
+            _ => return Err(Self::mixed_property_types(column_index, property_name)),
         }
         Ok(())
     }
 
-    fn merge_unsigned(&mut self, value: u64) -> MltResult<()> {
+    fn merge_unsigned(
+        &mut self,
+        value: u64,
+        column_index: usize,
+        property_name: &str,
+    ) -> MltResult<()> {
         match self {
             Self::None => {
                 *self = Self::Unsigned {
@@ -232,12 +263,12 @@ impl PropertyTypedStats {
                 *min = (*min).min(value);
                 *max = (*max).max(value);
             }
-            _ => return Err(MltError::MixedPropertyTypes),
+            _ => return Err(Self::mixed_property_types(column_index, property_name)),
         }
         Ok(())
     }
 
-    fn merge_string(&mut self) -> MltResult<()> {
+    fn merge_string(&mut self, column_index: usize, property_name: &str) -> MltResult<()> {
         match self {
             Self::None => {
                 *self = Self::String {
@@ -245,18 +276,23 @@ impl PropertyTypedStats {
                 };
             }
             Self::String { .. } => {}
-            _ => return Err(MltError::MixedPropertyTypes),
+            _ => return Err(Self::mixed_property_types(column_index, property_name)),
         }
         Ok(())
     }
 
-    fn merge_same_kind(&mut self, kind: Self) -> MltResult<()> {
+    fn merge_same_kind(
+        &mut self,
+        kind: Self,
+        column_index: usize,
+        property_name: &str,
+    ) -> MltResult<()> {
         match self {
             Self::None => *self = kind,
             Self::Bool if matches!(kind, Self::Bool) => {}
             Self::F32 if matches!(kind, Self::F32) => {}
             Self::F64 if matches!(kind, Self::F64) => {}
-            _ => return Err(MltError::MixedPropertyTypes),
+            _ => return Err(Self::mixed_property_types(column_index, property_name)),
         }
         Ok(())
     }
@@ -304,15 +340,26 @@ impl TileLayer {
         self.property_names
             .iter()
             .enumerate()
-            .map(|(col_idx, _name)| -> MltResult<PropertyStats> {
+            .map(|(col_idx, name)| -> MltResult<PropertyStats> {
                 let mut present = 0usize;
+                let mut kind = None;
                 let mut stats = PropertyTypedStats::default();
                 for feature in &self.features {
                     let prop = feature.properties.get(col_idx);
+                    if let Some(prop) = prop {
+                        let prop_kind = PropKind::from(prop);
+                        if let Some(kind) = kind {
+                            if kind != prop_kind {
+                                return Err(MltError::MixedPropertyTypes(col_idx, name.clone()));
+                            }
+                        } else {
+                            kind = Some(prop_kind);
+                        }
+                    }
                     if prop_is_present(prop) {
                         present += 1;
                         let prop = prop.expect("present property exists");
-                        stats.push(prop)?;
+                        stats.push(prop, col_idx, name)?;
                     }
                 }
 

--- a/rust/mlt-core/src/encoder/optimizer.rs
+++ b/rust/mlt-core/src/encoder/optimizer.rs
@@ -1,9 +1,7 @@
 use crate::decoder::TileLayer;
 use crate::encoder::model::StagedLayer;
 use crate::encoder::property::encode::write_properties;
-use crate::encoder::property::{
-    StringStatsBuilder, apply_string_groups, string_stats_without_hashes,
-};
+use crate::encoder::property::{StringStatsBuilder, apply_string_groups};
 use crate::encoder::{
     Encoder, EncoderConfig, SortStrategy, StringGroup, spatial_sort_likely_to_help,
 };
@@ -287,7 +285,11 @@ impl PropertyTypedStats {
 pub fn analyze_layer(source: &TileLayer, allow_shared_dict: bool) -> LayerStats {
     let id = analyze_ids(source);
     let mut properties = profile_properties(source, allow_shared_dict);
-    let string_groups = apply_string_groups(&source.property_names, &mut properties);
+    let string_groups = if allow_shared_dict {
+        apply_string_groups(&source.property_names, &mut properties)
+    } else {
+        Vec::new()
+    };
 
     LayerStats {
         id,
@@ -335,9 +337,10 @@ fn profile_properties(source: &TileLayer, allow_shared_dict: bool) -> Vec<Proper
                 let prop = feature.properties.get(col_idx);
                 if prop_is_present(prop) {
                     present += 1;
-                    match prop.expect("present property exists") {
-                        PropValue::Str(Some(s)) => string_values.push(s.as_str()),
-                        prop => stats.push(prop),
+                    let prop = prop.expect("present property exists");
+                    stats.push(prop);
+                    if let (Some(_), PropValue::Str(Some(s))) = (&string_stats, prop) {
+                        string_values.push(s.as_str());
                     }
                 }
             }
@@ -350,15 +353,17 @@ fn profile_properties(source: &TileLayer, allow_shared_dict: bool) -> Vec<Proper
                 Presence::Mixed
             };
 
-            if !string_values.is_empty() {
-                assert!(
-                    matches!(stats, PropertyTypedStats::None),
-                    "mixed property types are not allowed"
-                );
-                stats = string_stats.as_ref().map_or_else(
-                    || string_stats_without_hashes(&string_values),
-                    |string_stats| string_stats.stats(&string_values),
-                );
+            if let (Some(string_stats), false) = (string_stats.as_ref(), string_values.is_empty()) {
+                let (exact, trigram) = string_stats.hashes(&string_values);
+                if let PropertyTypedStats::String {
+                    exact_hashes,
+                    trigram_hashes,
+                    ..
+                } = &mut stats
+                {
+                    *exact_hashes = exact;
+                    *trigram_hashes = trigram;
+                }
             }
 
             PropertyStats { presence, stats }

--- a/rust/mlt-core/src/encoder/optimizer.rs
+++ b/rust/mlt-core/src/encoder/optimizer.rs
@@ -1,10 +1,13 @@
-use crate::MltResult;
 use crate::decoder::TileLayer;
 use crate::encoder::model::StagedLayer;
 use crate::encoder::property::encode::write_properties;
-use crate::encoder::{
-    Encoder, EncoderConfig, SortStrategy, group_string_properties, spatial_sort_likely_to_help,
+use crate::encoder::property::{
+    StringStatsBuilder, apply_string_groups, string_stats_without_hashes,
 };
+use crate::encoder::{
+    Encoder, EncoderConfig, SortStrategy, StringGroup, spatial_sort_likely_to_help,
+};
+use crate::{MltResult, PropValue};
 
 impl StagedLayer {
     /// Encode and serialize the layer directly into `enc`, without creating any
@@ -68,33 +71,29 @@ impl TileLayer {
             sort_by.push(SortStrategy::Id);
         }
 
-        let groups = if cfg.allow_shared_dict {
-            group_string_properties(&self)
-        } else {
-            Vec::new()
-        };
+        let analysis = analyze_layer(&self, cfg.allow_shared_dict);
 
         let (last, init) = sort_by.split_last().expect("at least one strategy");
         if init.is_empty() {
-            StagedLayer::from_tile(self, *last, &groups, cfg.tessellate)
+            StagedLayer::from_tile(self, *last, &analysis, cfg.tessellate)
                 .encode_into(Encoder::new(cfg))?
         } else {
             let mut enc: Encoder = {
                 let first = init[0];
-                StagedLayer::from_tile(self.clone(), first, &groups, cfg.tessellate)
+                StagedLayer::from_tile(self.clone(), first, &analysis, cfg.tessellate)
                     .encode_into(Encoder::new(cfg))?
             };
             let mut best = enc.preserve_results();
             // Clone for all-but-last strategies
             for &sort in &init[1..] {
-                let layer = StagedLayer::from_tile(self.clone(), sort, &groups, cfg.tessellate);
+                let layer = StagedLayer::from_tile(self.clone(), sort, &analysis, cfg.tessellate);
                 enc = layer.encode_into(enc)?;
                 if enc.total_len() < best.total_len() {
                     best = enc.preserve_results();
                 }
             }
             // Last strategy: consume self, no clone
-            let layer = StagedLayer::from_tile(self, *last, &groups, cfg.tessellate);
+            let layer = StagedLayer::from_tile(self, *last, &analysis, cfg.tessellate);
             enc = layer.encode_into(enc)?;
             if enc.total_len() < best.total_len() {
                 best = enc.preserve_results();
@@ -103,4 +102,284 @@ impl TileLayer {
         }
         .into_layer_bytes()
     }
+}
+
+/// Row-order-independent presence classification for IDs and properties.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Presence {
+    /// No feature has a value for this logical column.
+    AllNull,
+    /// Every feature has a value for this logical column.
+    AllPresent,
+    /// Some, but not all, features have a value for this logical column.
+    Mixed,
+}
+
+/// How a property participates in a shared dictionary group.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SharedDictRole {
+    /// The property is encoded as a standalone column.
+    None,
+    /// The property is the first column in this group and emits the shared dictionary.
+    Owner(usize),
+    /// The property is emitted by the group's owner column.
+    Member(usize),
+}
+
+/// Row-order-independent facts for a single property column.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PropertyStats {
+    pub presence: Presence,
+    pub stats: PropertyTypedStats,
+}
+
+/// Row-order-independent layer facts computed once before sort trials.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LayerStats {
+    pub id: Option<PropertyStats>,
+    pub properties: Vec<PropertyStats>,
+    pub string_groups: Vec<StringGroup>,
+}
+
+/// Row-order-independent value statistics for a property column.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum PropertyTypedStats {
+    /// No present values.
+    #[default]
+    None,
+    Bool,
+    Signed {
+        min: i64,
+        max: i64,
+    },
+    Unsigned {
+        min: u64,
+        max: u64,
+    },
+    Float,
+    String {
+        total_bytes: usize,
+        max_bytes: usize,
+        exact_hashes: Vec<u64>,
+        trigram_hashes: Vec<u64>,
+        shared_dict: SharedDictRole,
+    },
+}
+
+impl PropertyTypedStats {
+    #[must_use]
+    pub fn values_fit_u32(&self) -> bool {
+        match self {
+            Self::None | Self::Bool | Self::Float | Self::String { .. } => false,
+            Self::Signed { min, max } => *min >= 0 && u32::try_from(*max).is_ok(),
+            Self::Unsigned { max, .. } => u32::try_from(*max).is_ok(),
+        }
+    }
+
+    #[must_use]
+    pub fn shared_dict(&self) -> SharedDictRole {
+        match self {
+            Self::String { shared_dict, .. } => *shared_dict,
+            _ => SharedDictRole::None,
+        }
+    }
+
+    pub(crate) fn set_shared_dict(&mut self, role: SharedDictRole) {
+        match self {
+            Self::String { shared_dict, .. } => *shared_dict = role,
+            _ => debug_assert_eq!(role, SharedDictRole::None),
+        }
+    }
+
+    pub(crate) fn push(&mut self, prop: &PropValue) {
+        match prop {
+            PropValue::Bool(Some(_)) => self.merge_bool(),
+            PropValue::I8(Some(v)) => self.merge_signed(i64::from(*v)),
+            PropValue::U8(Some(v)) => self.merge_unsigned(u64::from(*v)),
+            PropValue::I32(Some(v)) => self.merge_signed(i64::from(*v)),
+            PropValue::U32(Some(v)) => self.merge_unsigned(u64::from(*v)),
+            PropValue::I64(Some(v)) => self.merge_signed(*v),
+            PropValue::U64(Some(v)) => self.merge_unsigned(*v),
+            PropValue::F32(Some(_)) | PropValue::F64(Some(_)) => self.merge_float(),
+            PropValue::Str(Some(s)) => self.merge_string(s.len()),
+            _ => {}
+        }
+    }
+
+    fn merge_bool(&mut self) {
+        self.merge_same_kind(Self::Bool);
+    }
+
+    fn merge_signed(&mut self, value: i64) {
+        match self {
+            Self::None => {
+                *self = Self::Signed {
+                    min: value,
+                    max: value,
+                };
+            }
+            Self::Signed { min, max } => {
+                *min = (*min).min(value);
+                *max = (*max).max(value);
+            }
+            _ => panic!("mixed property types are not allowed"),
+        }
+    }
+
+    fn merge_unsigned(&mut self, value: u64) {
+        match self {
+            Self::None => {
+                *self = Self::Unsigned {
+                    min: value,
+                    max: value,
+                };
+            }
+            Self::Unsigned { min, max } => {
+                *min = (*min).min(value);
+                *max = (*max).max(value);
+            }
+            _ => panic!("mixed property types are not allowed"),
+        }
+    }
+
+    fn merge_float(&mut self) {
+        self.merge_same_kind(Self::Float);
+    }
+
+    fn merge_string(&mut self, len: usize) {
+        match self {
+            Self::None => {
+                *self = Self::String {
+                    total_bytes: len,
+                    max_bytes: len,
+                    exact_hashes: Vec::new(),
+                    trigram_hashes: Vec::new(),
+                    shared_dict: SharedDictRole::None,
+                };
+            }
+            Self::String {
+                total_bytes,
+                max_bytes,
+                exact_hashes: _,
+                trigram_hashes: _,
+                shared_dict: _,
+            } => {
+                *total_bytes += len;
+                *max_bytes = (*max_bytes).max(len);
+            }
+            _ => panic!("mixed property types are not allowed"),
+        }
+    }
+
+    fn merge_same_kind(&mut self, kind: Self) {
+        match self {
+            Self::None => *self = kind,
+            Self::Bool if matches!(kind, Self::Bool) => {}
+            Self::Float if matches!(kind, Self::Float) => {}
+            _ => panic!("mixed property types are not allowed"),
+        }
+    }
+}
+
+/// Analyze a [`TileLayer`] and return reusable ID/property facts for the optimizer.
+#[must_use]
+#[hotpath::measure]
+pub fn analyze_layer(source: &TileLayer, allow_shared_dict: bool) -> LayerStats {
+    let id = analyze_ids(source);
+    let mut properties = profile_properties(source, allow_shared_dict);
+    let string_groups = apply_string_groups(&source.property_names, &mut properties);
+
+    LayerStats {
+        id,
+        properties,
+        string_groups,
+    }
+}
+
+fn analyze_ids(source: &TileLayer) -> Option<PropertyStats> {
+    let mut present = 0usize;
+    let mut min = u64::MAX;
+    let mut max = 0u64;
+    for feature in &source.features {
+        if let Some(id) = feature.id {
+            present += 1;
+            min = min.min(id);
+            max = max.max(id);
+        }
+    }
+    if present == 0 {
+        return None;
+    }
+    let presence = if present == source.features.len() {
+        Presence::AllPresent
+    } else {
+        Presence::Mixed
+    };
+    Some(PropertyStats {
+        presence,
+        stats: PropertyTypedStats::Unsigned { min, max },
+    })
+}
+
+fn profile_properties(source: &TileLayer, allow_shared_dict: bool) -> Vec<PropertyStats> {
+    let string_stats = allow_shared_dict.then(StringStatsBuilder::new);
+    source
+        .property_names
+        .iter()
+        .enumerate()
+        .map(|(col_idx, _name)| {
+            let mut present = 0usize;
+            let mut stats = PropertyTypedStats::default();
+            let mut string_values = Vec::new();
+            for feature in &source.features {
+                let prop = feature.properties.get(col_idx);
+                if prop_is_present(prop) {
+                    present += 1;
+                    match prop.expect("present property exists") {
+                        PropValue::Str(Some(s)) => string_values.push(s.as_str()),
+                        prop => stats.push(prop),
+                    }
+                }
+            }
+
+            let presence = if present == 0 {
+                Presence::AllNull
+            } else if present == source.features.len() {
+                Presence::AllPresent
+            } else {
+                Presence::Mixed
+            };
+
+            if !string_values.is_empty() {
+                assert!(
+                    matches!(stats, PropertyTypedStats::None),
+                    "mixed property types are not allowed"
+                );
+                stats = string_stats.as_ref().map_or_else(
+                    || string_stats_without_hashes(&string_values),
+                    |string_stats| string_stats.stats(&string_values),
+                );
+            }
+
+            PropertyStats { presence, stats }
+        })
+        .collect()
+}
+
+fn prop_is_present(prop: Option<&PropValue>) -> bool {
+    matches!(
+        prop,
+        Some(
+            PropValue::Bool(Some(_))
+                | PropValue::I8(Some(_))
+                | PropValue::U8(Some(_))
+                | PropValue::I32(Some(_))
+                | PropValue::U32(Some(_))
+                | PropValue::I64(Some(_))
+                | PropValue::U64(Some(_))
+                | PropValue::F32(Some(_))
+                | PropValue::F64(Some(_))
+                | PropValue::Str(Some(_)),
+        )
+    )
 }

--- a/rust/mlt-core/src/encoder/optimizer.rs
+++ b/rust/mlt-core/src/encoder/optimizer.rs
@@ -269,7 +269,7 @@ impl TileLayer {
         let id = self.analyze_ids();
         let mut properties = self.profile_properties()?;
         if allow_shared_dict {
-            self.apply_string_groups(&mut properties);
+            self.group_string_properties(&mut properties);
         }
 
         Ok(LayerStats { id, properties })

--- a/rust/mlt-core/src/encoder/optimizer.rs
+++ b/rust/mlt-core/src/encoder/optimizer.rs
@@ -216,10 +216,6 @@ impl PropertyTypedStats {
         Ok(())
     }
 
-    fn mixed_property_types(column_index: usize, property_name: &str) -> MltError {
-        MltError::MixedPropertyTypes(column_index, property_name.to_owned())
-    }
-
     fn merge_bool(&mut self, column_index: usize, property_name: &str) -> MltResult<()> {
         self.merge_same_kind(Self::Bool, column_index, property_name)
     }
@@ -241,7 +237,7 @@ impl PropertyTypedStats {
                 *min = (*min).min(value);
                 *max = (*max).max(value);
             }
-            _ => return Err(Self::mixed_property_types(column_index, property_name)),
+            _ => return mixed_prop_err(column_index, property_name),
         }
         Ok(())
     }
@@ -263,7 +259,7 @@ impl PropertyTypedStats {
                 *min = (*min).min(value);
                 *max = (*max).max(value);
             }
-            _ => return Err(Self::mixed_property_types(column_index, property_name)),
+            _ => return mixed_prop_err(column_index, property_name),
         }
         Ok(())
     }
@@ -276,7 +272,7 @@ impl PropertyTypedStats {
                 };
             }
             Self::String { .. } => {}
-            _ => return Err(Self::mixed_property_types(column_index, property_name)),
+            _ => return mixed_prop_err(column_index, property_name),
         }
         Ok(())
     }
@@ -292,7 +288,7 @@ impl PropertyTypedStats {
             Self::Bool if matches!(kind, Self::Bool) => {}
             Self::F32 if matches!(kind, Self::F32) => {}
             Self::F64 if matches!(kind, Self::F64) => {}
-            _ => return Err(Self::mixed_property_types(column_index, property_name)),
+            _ => return mixed_prop_err(column_index, property_name),
         }
         Ok(())
     }
@@ -346,14 +342,13 @@ impl TileLayer {
                 let mut stats = PropertyTypedStats::default();
                 for feature in &self.features {
                     let prop = feature.properties.get(col_idx);
-                    if let Some(prop) = prop {
-                        let prop_kind = PropKind::from(prop);
-                        if let Some(kind) = kind {
-                            if kind != prop_kind {
-                                return Err(MltError::MixedPropertyTypes(col_idx, name.clone()));
+                    if let Some(prop_kind) = prop.map(PropKind::from) {
+                        match kind {
+                            Some(kind) if kind != prop_kind => {
+                                return mixed_prop_err(col_idx, name.as_str());
                             }
-                        } else {
-                            kind = Some(prop_kind);
+                            None => kind = Some(prop_kind),
+                            _ => {}
                         }
                     }
                     if prop_is_present(prop) {
@@ -393,4 +388,12 @@ fn prop_is_present(prop: Option<&PropValue>) -> bool {
                 | PropValue::Str(Some(_)),
         )
     )
+}
+
+#[inline]
+fn mixed_prop_err<T>(column_index: usize, property_name: &str) -> MltResult<T> {
+    Err(MltError::MixedPropertyTypes(
+        column_index,
+        property_name.to_owned(),
+    ))
 }

--- a/rust/mlt-core/src/encoder/optimizer.rs
+++ b/rust/mlt-core/src/encoder/optimizer.rs
@@ -1,10 +1,7 @@
 use crate::decoder::TileLayer;
 use crate::encoder::model::StagedLayer;
-use crate::encoder::property::apply_string_groups;
 use crate::encoder::property::encode::write_properties;
-use crate::encoder::{
-    Encoder, EncoderConfig, SortStrategy, StringGroup, spatial_sort_likely_to_help,
-};
+use crate::encoder::{Encoder, EncoderConfig, SortStrategy, spatial_sort_likely_to_help};
 use crate::{MltError, MltResult, PropValue};
 
 impl StagedLayer {
@@ -114,13 +111,13 @@ pub enum Presence {
 }
 
 /// How a property participates in a shared dictionary group.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SharedDictRole {
     /// The property is encoded as a standalone column.
     None,
-    /// The property is the first column in this group and emits the shared dictionary.
-    Owner(usize),
-    /// The property is emitted by the group's owner column.
+    /// The property is the first column in this group and emits the shared dictionary with this prefix.
+    Owner(String),
+    /// The property is emitted by the group owner at this property index.
     Member(usize),
 }
 
@@ -136,7 +133,6 @@ pub struct PropertyStats {
 pub struct LayerStats {
     pub id: Option<PropertyStats>,
     pub properties: Vec<PropertyStats>,
-    pub string_groups: Vec<StringGroup>,
 }
 
 /// Row-order-independent value statistics for a property column.
@@ -174,7 +170,7 @@ impl PropertyTypedStats {
     #[must_use]
     pub fn shared_dict(&self) -> SharedDictRole {
         match self {
-            Self::String { shared_dict, .. } => *shared_dict,
+            Self::String { shared_dict, .. } => shared_dict.clone(),
             _ => SharedDictRole::None,
         }
     }
@@ -272,17 +268,11 @@ impl TileLayer {
     pub(crate) fn analyze(&self, allow_shared_dict: bool) -> MltResult<LayerStats> {
         let id = self.analyze_ids();
         let mut properties = self.profile_properties()?;
-        let string_groups = if allow_shared_dict {
-            self.apply_string_groups(&mut properties)
-        } else {
-            Vec::new()
-        };
+        if allow_shared_dict {
+            self.apply_string_groups(&mut properties);
+        }
 
-        Ok(LayerStats {
-            id,
-            properties,
-            string_groups,
-        })
+        Ok(LayerStats { id, properties })
     }
 
     fn analyze_ids(&self) -> Option<PropertyStats> {

--- a/rust/mlt-core/src/encoder/property/mod.rs
+++ b/rust/mlt-core/src/encoder/property/mod.rs
@@ -13,6 +13,4 @@ pub use model::{
     StagedStrings,
 };
 pub use shared_dict::StringGroup;
-pub(crate) use shared_dict::{
-    StringStatsBuilder, apply_string_groups, string_stats_without_hashes,
-};
+pub(crate) use shared_dict::{StringStatsBuilder, apply_string_groups};

--- a/rust/mlt-core/src/encoder/property/mod.rs
+++ b/rust/mlt-core/src/encoder/property/mod.rs
@@ -12,5 +12,3 @@ pub use model::{
     StagedOptScalar, StagedProperty, StagedScalar, StagedSharedDict, StagedSharedDictItem,
     StagedStrings,
 };
-pub use shared_dict::StringGroup;
-pub(crate) use shared_dict::apply_string_groups;

--- a/rust/mlt-core/src/encoder/property/mod.rs
+++ b/rust/mlt-core/src/encoder/property/mod.rs
@@ -12,4 +12,7 @@ pub use model::{
     StagedOptScalar, StagedProperty, StagedScalar, StagedSharedDict, StagedSharedDictItem,
     StagedStrings,
 };
-pub use shared_dict::{StringGroup, group_string_properties};
+pub use shared_dict::StringGroup;
+pub(crate) use shared_dict::{
+    StringStatsBuilder, apply_string_groups, string_stats_without_hashes,
+};

--- a/rust/mlt-core/src/encoder/property/mod.rs
+++ b/rust/mlt-core/src/encoder/property/mod.rs
@@ -13,4 +13,4 @@ pub use model::{
     StagedStrings,
 };
 pub use shared_dict::StringGroup;
-pub(crate) use shared_dict::{StringStatsBuilder, apply_string_groups};
+pub(crate) use shared_dict::apply_string_groups;

--- a/rust/mlt-core/src/encoder/property/shared_dict.rs
+++ b/rust/mlt-core/src/encoder/property/shared_dict.rs
@@ -27,13 +27,6 @@ const MINHASH_PERMUTATIONS: usize = 128;
 /// grouped into a single shared dictionary.
 const MINHASH_SIMILARITY_THRESHOLD: f64 = 0.075;
 
-/// A group of string columns to be merged into a single [`crate::encoder::StagedProperty::SharedDict`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct StringGroup {
-    pub prefix: String,
-    pub columns: Vec<(String, usize)>,
-}
-
 struct StringProfile<'a> {
     col_idx: usize,
     name: &'a str,
@@ -44,31 +37,27 @@ struct StringProfile<'a> {
 }
 
 impl TileLayer {
-    pub(crate) fn apply_string_groups(&self, properties: &mut [PropertyStats]) -> Vec<StringGroup> {
-        let string_groups = group_string_properties(self);
-        for (group_idx, group) in string_groups.iter().enumerate() {
-            let Some(owner_col) = group.columns.first().map(|(_, col_idx)| *col_idx) else {
-                continue;
-            };
-            for &(_, col_idx) in &group.columns {
+    pub(crate) fn apply_string_groups(&self, properties: &mut [PropertyStats]) {
+        for (prefix, owner_col, member_cols) in group_string_properties(self) {
+            debug_assert_ne!(properties[owner_col].presence, Presence::AllNull);
+            properties[owner_col]
+                .stats
+                .set_shared_dict(SharedDictRole::Owner(prefix));
+            for col_idx in member_cols {
                 debug_assert_ne!(properties[col_idx].presence, Presence::AllNull);
-                let role = if col_idx == owner_col {
-                    SharedDictRole::Owner(group_idx)
-                } else {
-                    SharedDictRole::Member(group_idx)
-                };
-                properties[col_idx].stats.set_shared_dict(role);
+                properties[col_idx]
+                    .stats
+                    .set_shared_dict(SharedDictRole::Member(owner_col));
             }
         }
-        string_groups
     }
 }
 
-/// Analyze a [`TileLayer`] and return one [`StringGroup`] per cluster of similar
+/// Analyze a [`TileLayer`] and return one `(prefix, owner, members)` entry per cluster of similar
 /// string columns.
 #[must_use]
 #[hotpath::measure]
-pub fn group_string_properties(source: &TileLayer) -> Vec<StringGroup> {
+fn group_string_properties(source: &TileLayer) -> Vec<(String, usize, Vec<usize>)> {
     let exact_mh = MinHash::with_hashers(
         MINHASH_PERMUTATIONS,
         [
@@ -125,16 +114,11 @@ pub fn group_string_properties(source: &TileLayer) -> Vec<StringGroup> {
 
     cluster_by_similarity(profiles)
         .into_iter()
-        .map(|group| {
+        .filter_map(|group| {
             let prefix = common_prefix_name(&group);
-            let columns = group
-                .into_iter()
-                .map(|p| {
-                    let suffix = p.name.strip_prefix(&prefix).unwrap_or(p.name).to_owned();
-                    (suffix, p.col_idx)
-                })
-                .collect();
-            StringGroup { prefix, columns }
+            let mut columns = group.into_iter().map(|p| p.col_idx);
+            let owner_col = columns.next()?;
+            Some((prefix, owner_col, columns.collect()))
         })
         .collect()
 }

--- a/rust/mlt-core/src/encoder/property/shared_dict.rs
+++ b/rust/mlt-core/src/encoder/property/shared_dict.rs
@@ -243,56 +243,40 @@ impl StagedSharedDict {
         T: AsRef<str>,
     {
         let prefix = prefix.into();
-        // Collect all columns so we can make two passes (dedup then assign ranges).
-        let columns: Vec<(String, Vec<Option<T>>, Presence)> = columns
-            .into_iter()
-            .map(|(s, i, p)| (s.into(), i.into_iter().collect(), p))
-            .collect();
-
-        // First pass: build deduplicated corpus in insertion order.
-        let mut dict_index = HashMap::<String, u32>::new();
-        let mut dict_ranges = Vec::<(u32, u32)>::new();
+        let mut dict_index = HashMap::<String, (u32, u32)>::new();
         let mut data = String::new();
 
-        for (_, values, _) in &columns {
-            for value in values.iter().filter_map(Option::as_ref) {
-                let s = value.as_ref();
-                if !dict_index.contains_key(s) {
-                    let idx = u32::try_from(dict_ranges.len()).or_overflow()?;
-                    let offset = u32::try_from(data.len()).or_overflow()?;
-                    let end = offset
-                        .checked_add(u32::try_from(s.len()).or_overflow()?)
-                        .or_overflow()?;
-                    dict_index.insert(s.to_owned(), idx);
-                    dict_ranges.push((offset, end));
-                    data.push_str(s);
-                }
-            }
-        }
-
-        // Second pass: emit per-feature ranges for each column.
         let items = columns
             .into_iter()
             .map(
                 |(suffix, values, presence)| -> MltResult<StagedSharedDictItem> {
-                    let mut ranges = Vec::with_capacity(values.len());
+                    let values = values.into_iter();
+                    let (lower, upper) = values.size_hint();
+                    let mut ranges = Vec::with_capacity(upper.unwrap_or(lower));
                     for opt_val in values {
                         match opt_val {
                             Some(value) => {
-                                let idx = *dict_index
-                                    .get(value.as_ref())
-                                    .expect("StagedSharedDict::new: value must be present");
-                                let (start, end) = dict_ranges[idx as usize];
+                                let s = value.as_ref();
+                                let (start, end) = if let Some(&span) = dict_index.get(s) {
+                                    span
+                                } else {
+                                    let start = u32::try_from(data.len()).or_overflow()?;
+                                    let end = start
+                                        .checked_add(u32::try_from(s.len()).or_overflow()?)
+                                        .or_overflow()?;
+                                    data.push_str(s);
+                                    dict_index.insert(s.to_owned(), (start, end));
+                                    (start, end)
+                                };
                                 ranges.push(encode_shared_dict_range(start, end)?);
                             }
                             None => ranges.push(DictRange::NULL),
                         }
                     }
-                    let has_presence = presence != Presence::AllPresent;
                     Ok(StagedSharedDictItem {
-                        suffix,
+                        suffix: suffix.into(),
                         ranges,
-                        has_presence,
+                        has_presence: presence != Presence::AllPresent,
                     })
                 },
             )

--- a/rust/mlt-core/src/encoder/property/shared_dict.rs
+++ b/rust/mlt-core/src/encoder/property/shared_dict.rs
@@ -11,8 +11,8 @@ use union_find::{QuickUnionUf, UnionBySize, UnionFind as _};
 use crate::MltError::DictIndexOutOfBounds;
 use crate::codecs::fsst::compress_fsst_with;
 use crate::decoder::strings::{decode_shared_dict_range, encode_shared_dict_range};
-use crate::decoder::{PropValue, TileLayer};
 use crate::encoder::model::{StrEncoding, StreamCtx};
+use crate::encoder::optimizer::{Presence, PropertyStats, PropertyTypedStats, SharedDictRole};
 use crate::encoder::property::strings::{fsst_try_train, write_fsst_data, write_raw_str_data};
 use crate::encoder::{Encoder, StagedSharedDict, StagedSharedDictItem, write_u32_stream};
 use crate::errors::AsMltError as _;
@@ -27,76 +27,123 @@ const MINHASH_PERMUTATIONS: usize = 128;
 const MINHASH_SIMILARITY_THRESHOLD: f64 = 0.075;
 
 /// A group of string columns to be merged into a single [`crate::encoder::StagedProperty::SharedDict`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StringGroup {
     pub prefix: String,
     pub columns: Vec<(String, usize)>,
+}
+
+type ExactStringMinHash<'a> = MinHash<std::iter::Copied<std::slice::Iter<'a, &'a str>>, &'a str>;
+type TrigramMinHash = MinHash<std::vec::IntoIter<[u8; 3]>, [u8; 3]>;
+
+pub(crate) struct StringStatsBuilder<'a> {
+    exact_mh: ExactStringMinHash<'a>,
+    trigram_mh: TrigramMinHash,
+}
+
+impl<'a> StringStatsBuilder<'a> {
+    pub(crate) fn new() -> Self {
+        Self {
+            exact_mh: MinHash::with_hashers(
+                MINHASH_PERMUTATIONS,
+                [
+                    SipHasherBuilder::from_seed(0, 0),
+                    SipHasherBuilder::from_seed(1, 1),
+                ],
+            ),
+            trigram_mh: MinHash::with_hashers(
+                MINHASH_PERMUTATIONS,
+                [
+                    SipHasherBuilder::from_seed(0, 0),
+                    SipHasherBuilder::from_seed(1, 1),
+                ],
+            ),
+        }
+    }
+
+    pub(crate) fn stats(&self, values: &[&'a str]) -> PropertyTypedStats {
+        let exact_hashes = self.exact_mh.get_min_hashes(values.iter().copied());
+        let trigrams: Vec<[u8; 3]> = values
+            .iter()
+            .flat_map(|s| s.as_bytes().windows(3).map(|w| [w[0], w[1], w[2]]))
+            .collect();
+        let trigram_hashes = if trigrams.is_empty() {
+            Vec::new()
+        } else {
+            self.trigram_mh.get_min_hashes(trigrams.into_iter())
+        };
+        string_stats(values, exact_hashes, trigram_hashes)
+    }
+}
+
+pub(crate) fn string_stats_without_hashes(values: &[&str]) -> PropertyTypedStats {
+    string_stats(values, Vec::new(), Vec::new())
+}
+
+fn string_stats(
+    values: &[&str],
+    exact_hashes: Vec<u64>,
+    trigram_hashes: Vec<u64>,
+) -> PropertyTypedStats {
+    PropertyTypedStats::String {
+        total_bytes: values.iter().map(|s| s.len()).sum(),
+        max_bytes: values.iter().map(|s| s.len()).max().unwrap_or(0),
+        exact_hashes,
+        trigram_hashes,
+        shared_dict: SharedDictRole::None,
+    }
 }
 
 struct StringProfile<'a> {
     col_idx: usize,
     name: &'a str,
     /// `MinHash` over exact string values.
-    exact_hashes: Vec<u64>,
+    exact_hashes: &'a [u64],
     /// `MinHash` over byte trigrams (empty when all strings are shorter than 3 bytes).
-    trigram_hashes: Vec<u64>,
+    trigram_hashes: &'a [u64],
 }
 
-/// Analyze a [`TileLayer`] and return one [`StringGroup`] per cluster of similar
-/// string columns.
-#[must_use]
-#[hotpath::measure]
-pub fn group_string_properties(source: &TileLayer) -> Vec<StringGroup> {
-    let exact_mh = MinHash::with_hashers(
-        MINHASH_PERMUTATIONS,
-        [
-            SipHasherBuilder::from_seed(0, 0),
-            SipHasherBuilder::from_seed(1, 1),
-        ],
-    );
-    let trigram_mh = MinHash::with_hashers(
-        MINHASH_PERMUTATIONS,
-        [
-            SipHasherBuilder::from_seed(0, 0),
-            SipHasherBuilder::from_seed(1, 1),
-        ],
-    );
-
-    let profiles: Vec<StringProfile<'_>> = source
-        .property_names
+pub(crate) fn apply_string_groups(
+    property_names: &[String],
+    properties: &mut [PropertyStats],
+) -> Vec<StringGroup> {
+    let string_profiles = properties
         .iter()
         .enumerate()
-        .filter_map(|(col_idx, name)| {
-            let vals: Vec<&str> = source
-                .features
-                .iter()
-                .filter_map(|f| match f.properties.get(col_idx) {
-                    Some(PropValue::Str(Some(s))) => Some(s.as_str()),
-                    _ => None,
-                })
-                .collect();
-            if vals.is_empty() {
-                return None;
-            }
-            let exact_hashes = exact_mh.get_min_hashes(vals.iter().copied());
-            let trigrams: Vec<[u8; 3]> = vals
-                .iter()
-                .flat_map(|s| s.as_bytes().windows(3).map(|w| [w[0], w[1], w[2]]))
-                .collect();
-            let trigram_hashes = if trigrams.is_empty() {
-                Vec::new()
-            } else {
-                trigram_mh.get_min_hashes(trigrams.into_iter())
-            };
-            Some(StringProfile {
-                col_idx,
-                name,
+        .filter_map(|(col_idx, prop)| match &prop.stats {
+            PropertyTypedStats::String {
                 exact_hashes,
                 trigram_hashes,
-            })
+                ..
+            } if !exact_hashes.is_empty() => Some(StringProfile {
+                col_idx,
+                name: &property_names[col_idx],
+                exact_hashes,
+                trigram_hashes,
+            }),
+            _ => None,
         })
         .collect();
 
+    let string_groups = string_groups_from_profiles(string_profiles);
+    for (group_idx, group) in string_groups.iter().enumerate() {
+        let Some(owner_col) = group.columns.first().map(|(_, col_idx)| *col_idx) else {
+            continue;
+        };
+        for &(_, col_idx) in &group.columns {
+            debug_assert_ne!(properties[col_idx].presence, Presence::AllNull);
+            let role = if col_idx == owner_col {
+                SharedDictRole::Owner(group_idx)
+            } else {
+                SharedDictRole::Member(group_idx)
+            };
+            properties[col_idx].stats.set_shared_dict(role);
+        }
+    }
+    string_groups
+}
+
+fn string_groups_from_profiles(profiles: Vec<StringProfile<'_>>) -> Vec<StringGroup> {
     if profiles.is_empty() {
         return Vec::new();
     }
@@ -133,8 +180,8 @@ fn cluster_by_similarity(profiles: Vec<StringProfile<'_>>) -> Vec<Vec<StringProf
 
     for i in 0..n {
         for j in (i + 1)..n {
-            let exact = minhash_similarity(&profiles[i].exact_hashes, &profiles[j].exact_hashes);
-            let tri = minhash_similarity(&profiles[i].trigram_hashes, &profiles[j].trigram_hashes);
+            let exact = minhash_similarity(profiles[i].exact_hashes, profiles[j].exact_hashes);
+            let tri = minhash_similarity(profiles[i].trigram_hashes, profiles[j].trigram_hashes);
             if f64::max(exact, tri) > MINHASH_SIMILARITY_THRESHOLD {
                 uf.union(i, j);
             }
@@ -247,11 +294,46 @@ impl StagedSharedDict {
         I: IntoIterator<Item = Option<T>>,
         T: AsRef<str>,
     {
+        Self::new_inner(
+            prefix,
+            columns
+                .into_iter()
+                .map(|(suffix, values)| (suffix, values, None)),
+        )
+    }
+
+    /// Build a shared-dictionary column with precomputed child presence facts.
+    pub(crate) fn new_with_presence<S, I, T>(
+        prefix: impl Into<String>,
+        columns: impl IntoIterator<Item = (S, I, Presence)>,
+    ) -> MltResult<Self>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = Option<T>>,
+        T: AsRef<str>,
+    {
+        Self::new_inner(
+            prefix,
+            columns
+                .into_iter()
+                .map(|(suffix, values, presence)| (suffix, values, Some(presence))),
+        )
+    }
+
+    fn new_inner<S, I, T>(
+        prefix: impl Into<String>,
+        columns: impl IntoIterator<Item = (S, I, Option<Presence>)>,
+    ) -> MltResult<Self>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = Option<T>>,
+        T: AsRef<str>,
+    {
         let prefix = prefix.into();
         // Collect all columns so we can make two passes (dedup then assign ranges).
-        let columns: Vec<(String, Vec<Option<T>>)> = columns
+        let columns: Vec<(String, Vec<Option<T>>, Option<Presence>)> = columns
             .into_iter()
-            .map(|(s, i)| (s.into(), i.into_iter().collect()))
+            .map(|(s, i, p)| (s.into(), i.into_iter().collect(), p))
             .collect();
 
         // First pass: build deduplicated corpus in insertion order.
@@ -259,7 +341,7 @@ impl StagedSharedDict {
         let mut dict_ranges = Vec::<(u32, u32)>::new();
         let mut data = String::new();
 
-        for (_, values) in &columns {
+        for (_, values, _) in &columns {
             for value in values.iter().filter_map(Option::as_ref) {
                 let s = value.as_ref();
                 if !dict_index.contains_key(s) {
@@ -278,29 +360,32 @@ impl StagedSharedDict {
         // Second pass: emit per-feature ranges for each column.
         let items = columns
             .into_iter()
-            .map(|(suffix, values)| -> MltResult<StagedSharedDictItem> {
-                let mut ranges = Vec::with_capacity(values.len());
-                let mut present_items = 0;
-                for opt_val in values {
-                    match opt_val {
-                        Some(value) => {
-                            let idx = *dict_index
-                                .get(value.as_ref())
-                                .expect("StagedSharedDict::new: value must be present");
-                            let (start, end) = dict_ranges[idx as usize];
-                            ranges.push(encode_shared_dict_range(start, end)?);
-                            present_items += 1;
+            .map(
+                |(suffix, values, presence)| -> MltResult<StagedSharedDictItem> {
+                    let mut ranges = Vec::with_capacity(values.len());
+                    for opt_val in values {
+                        match opt_val {
+                            Some(value) => {
+                                let idx = *dict_index
+                                    .get(value.as_ref())
+                                    .expect("StagedSharedDict::new: value must be present");
+                                let (start, end) = dict_ranges[idx as usize];
+                                ranges.push(encode_shared_dict_range(start, end)?);
+                            }
+                            None => ranges.push(DictRange::NULL),
                         }
-                        None => ranges.push(DictRange::NULL),
                     }
-                }
-                let has_presence = present_items < ranges.len();
-                Ok(StagedSharedDictItem {
-                    suffix,
-                    ranges,
-                    has_presence,
-                })
-            })
+                    let has_presence = presence.map_or_else(
+                        || ranges.contains(&DictRange::NULL),
+                        |presence| matches!(presence, Presence::Mixed | Presence::AllNull),
+                    );
+                    Ok(StagedSharedDictItem {
+                        suffix,
+                        ranges,
+                        has_presence,
+                    })
+                },
+            )
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self {

--- a/rust/mlt-core/src/encoder/property/shared_dict.rs
+++ b/rust/mlt-core/src/encoder/property/shared_dict.rs
@@ -61,7 +61,7 @@ impl<'a> StringStatsBuilder<'a> {
         }
     }
 
-    pub(crate) fn stats(&self, values: &[&'a str]) -> PropertyTypedStats {
+    pub(crate) fn hashes(&self, values: &[&'a str]) -> (Vec<u64>, Vec<u64>) {
         let exact_hashes = self.exact_mh.get_min_hashes(values.iter().copied());
         let trigrams: Vec<[u8; 3]> = values
             .iter()
@@ -72,25 +72,7 @@ impl<'a> StringStatsBuilder<'a> {
         } else {
             self.trigram_mh.get_min_hashes(trigrams.into_iter())
         };
-        string_stats(values, exact_hashes, trigram_hashes)
-    }
-}
-
-pub(crate) fn string_stats_without_hashes(values: &[&str]) -> PropertyTypedStats {
-    string_stats(values, Vec::new(), Vec::new())
-}
-
-fn string_stats(
-    values: &[&str],
-    exact_hashes: Vec<u64>,
-    trigram_hashes: Vec<u64>,
-) -> PropertyTypedStats {
-    PropertyTypedStats::String {
-        total_bytes: values.iter().map(|s| s.len()).sum(),
-        max_bytes: values.iter().map(|s| s.len()).max().unwrap_or(0),
-        exact_hashes,
-        trigram_hashes,
-        shared_dict: SharedDictRole::None,
+        (exact_hashes, trigram_hashes)
     }
 }
 
@@ -138,6 +120,17 @@ pub(crate) fn apply_string_groups(
                 SharedDictRole::Member(group_idx)
             };
             properties[col_idx].stats.set_shared_dict(role);
+        }
+    }
+    for prop in properties {
+        if let PropertyTypedStats::String {
+            exact_hashes,
+            trigram_hashes,
+            ..
+        } = &mut prop.stats
+        {
+            *exact_hashes = Vec::new();
+            *trigram_hashes = Vec::new();
         }
     }
     string_groups

--- a/rust/mlt-core/src/encoder/property/shared_dict.rs
+++ b/rust/mlt-core/src/encoder/property/shared_dict.rs
@@ -11,8 +11,9 @@ use union_find::{QuickUnionUf, UnionBySize, UnionFind as _};
 use crate::MltError::DictIndexOutOfBounds;
 use crate::codecs::fsst::compress_fsst_with;
 use crate::decoder::strings::{decode_shared_dict_range, encode_shared_dict_range};
+use crate::decoder::{PropValue, TileLayer};
 use crate::encoder::model::{StrEncoding, StreamCtx};
-use crate::encoder::optimizer::{Presence, PropertyStats, PropertyTypedStats, SharedDictRole};
+use crate::encoder::optimizer::{Presence, PropertyStats, SharedDictRole};
 use crate::encoder::property::strings::{fsst_try_train, write_fsst_data, write_raw_str_data};
 use crate::encoder::{Encoder, StagedSharedDict, StagedSharedDictItem, write_u32_stream};
 use crate::errors::AsMltError as _;
@@ -33,110 +34,91 @@ pub struct StringGroup {
     pub columns: Vec<(String, usize)>,
 }
 
-type ExactStringMinHash<'a> = MinHash<std::iter::Copied<std::slice::Iter<'a, &'a str>>, &'a str>;
-type TrigramMinHash = MinHash<std::vec::IntoIter<[u8; 3]>, [u8; 3]>;
-
-pub(crate) struct StringStatsBuilder<'a> {
-    exact_mh: ExactStringMinHash<'a>,
-    trigram_mh: TrigramMinHash,
-}
-
-impl<'a> StringStatsBuilder<'a> {
-    pub(crate) fn new() -> Self {
-        Self {
-            exact_mh: MinHash::with_hashers(
-                MINHASH_PERMUTATIONS,
-                [
-                    SipHasherBuilder::from_seed(0, 0),
-                    SipHasherBuilder::from_seed(1, 1),
-                ],
-            ),
-            trigram_mh: MinHash::with_hashers(
-                MINHASH_PERMUTATIONS,
-                [
-                    SipHasherBuilder::from_seed(0, 0),
-                    SipHasherBuilder::from_seed(1, 1),
-                ],
-            ),
-        }
-    }
-
-    pub(crate) fn hashes(&self, values: &[&'a str]) -> (Vec<u64>, Vec<u64>) {
-        let exact_hashes = self.exact_mh.get_min_hashes(values.iter().copied());
-        let trigrams: Vec<[u8; 3]> = values
-            .iter()
-            .flat_map(|s| s.as_bytes().windows(3).map(|w| [w[0], w[1], w[2]]))
-            .collect();
-        let trigram_hashes = if trigrams.is_empty() {
-            Vec::new()
-        } else {
-            self.trigram_mh.get_min_hashes(trigrams.into_iter())
-        };
-        (exact_hashes, trigram_hashes)
-    }
-}
-
 struct StringProfile<'a> {
     col_idx: usize,
     name: &'a str,
     /// `MinHash` over exact string values.
-    exact_hashes: &'a [u64],
+    exact_hashes: Vec<u64>,
     /// `MinHash` over byte trigrams (empty when all strings are shorter than 3 bytes).
-    trigram_hashes: &'a [u64],
+    trigram_hashes: Vec<u64>,
 }
 
-pub(crate) fn apply_string_groups(
-    property_names: &[String],
-    properties: &mut [PropertyStats],
-) -> Vec<StringGroup> {
-    let string_profiles = properties
+impl TileLayer {
+    pub(crate) fn apply_string_groups(&self, properties: &mut [PropertyStats]) -> Vec<StringGroup> {
+        let string_groups = group_string_properties(self);
+        for (group_idx, group) in string_groups.iter().enumerate() {
+            let Some(owner_col) = group.columns.first().map(|(_, col_idx)| *col_idx) else {
+                continue;
+            };
+            for &(_, col_idx) in &group.columns {
+                debug_assert_ne!(properties[col_idx].presence, Presence::AllNull);
+                let role = if col_idx == owner_col {
+                    SharedDictRole::Owner(group_idx)
+                } else {
+                    SharedDictRole::Member(group_idx)
+                };
+                properties[col_idx].stats.set_shared_dict(role);
+            }
+        }
+        string_groups
+    }
+}
+
+/// Analyze a [`TileLayer`] and return one [`StringGroup`] per cluster of similar
+/// string columns.
+#[must_use]
+#[hotpath::measure]
+pub fn group_string_properties(source: &TileLayer) -> Vec<StringGroup> {
+    let exact_mh = MinHash::with_hashers(
+        MINHASH_PERMUTATIONS,
+        [
+            SipHasherBuilder::from_seed(0, 0),
+            SipHasherBuilder::from_seed(1, 1),
+        ],
+    );
+    let trigram_mh = MinHash::with_hashers(
+        MINHASH_PERMUTATIONS,
+        [
+            SipHasherBuilder::from_seed(0, 0),
+            SipHasherBuilder::from_seed(1, 1),
+        ],
+    );
+
+    let profiles: Vec<StringProfile<'_>> = source
+        .property_names
         .iter()
         .enumerate()
-        .filter_map(|(col_idx, prop)| match &prop.stats {
-            PropertyTypedStats::String {
-                exact_hashes,
-                trigram_hashes,
-                ..
-            } if !exact_hashes.is_empty() => Some(StringProfile {
+        .filter_map(|(col_idx, name)| {
+            let vals: Vec<&str> = source
+                .features
+                .iter()
+                .filter_map(|f| match f.properties.get(col_idx) {
+                    Some(PropValue::Str(Some(s))) => Some(s.as_str()),
+                    _ => None,
+                })
+                .collect();
+            if vals.is_empty() {
+                return None;
+            }
+            let exact_hashes = exact_mh.get_min_hashes(vals.iter().copied());
+            let trigrams: Vec<[u8; 3]> = vals
+                .iter()
+                .flat_map(|s| s.as_bytes().windows(3).map(|w| [w[0], w[1], w[2]]))
+                .collect();
+            let trigram_hashes = if trigrams.is_empty() {
+                Vec::new()
+            } else {
+                trigram_mh.get_min_hashes(trigrams.into_iter())
+            };
+            Some(StringProfile {
                 col_idx,
-                name: &property_names[col_idx],
+                name,
                 exact_hashes,
                 trigram_hashes,
-            }),
-            _ => None,
+            })
         })
         .collect();
 
-    let string_groups = string_groups_from_profiles(string_profiles);
-    for (group_idx, group) in string_groups.iter().enumerate() {
-        let Some(owner_col) = group.columns.first().map(|(_, col_idx)| *col_idx) else {
-            continue;
-        };
-        for &(_, col_idx) in &group.columns {
-            debug_assert_ne!(properties[col_idx].presence, Presence::AllNull);
-            let role = if col_idx == owner_col {
-                SharedDictRole::Owner(group_idx)
-            } else {
-                SharedDictRole::Member(group_idx)
-            };
-            properties[col_idx].stats.set_shared_dict(role);
-        }
-    }
-    for prop in properties {
-        if let PropertyTypedStats::String {
-            exact_hashes,
-            trigram_hashes,
-            ..
-        } = &mut prop.stats
-        {
-            *exact_hashes = Vec::new();
-            *trigram_hashes = Vec::new();
-        }
-    }
-    string_groups
-}
-
-fn string_groups_from_profiles(profiles: Vec<StringProfile<'_>>) -> Vec<StringGroup> {
     if profiles.is_empty() {
         return Vec::new();
     }
@@ -173,8 +155,8 @@ fn cluster_by_similarity(profiles: Vec<StringProfile<'_>>) -> Vec<Vec<StringProf
 
     for i in 0..n {
         for j in (i + 1)..n {
-            let exact = minhash_similarity(profiles[i].exact_hashes, profiles[j].exact_hashes);
-            let tri = minhash_similarity(profiles[i].trigram_hashes, profiles[j].trigram_hashes);
+            let exact = minhash_similarity(&profiles[i].exact_hashes, &profiles[j].exact_hashes);
+            let tri = minhash_similarity(&profiles[i].trigram_hashes, &profiles[j].trigram_hashes);
             if f64::max(exact, tri) > MINHASH_SIMILARITY_THRESHOLD {
                 uf.union(i, j);
             }
@@ -287,46 +269,11 @@ impl StagedSharedDict {
         I: IntoIterator<Item = Option<T>>,
         T: AsRef<str>,
     {
-        Self::new_inner(
-            prefix,
-            columns
-                .into_iter()
-                .map(|(suffix, values)| (suffix, values, None)),
-        )
-    }
-
-    /// Build a shared-dictionary column with precomputed child presence facts.
-    pub(crate) fn new_with_presence<S, I, T>(
-        prefix: impl Into<String>,
-        columns: impl IntoIterator<Item = (S, I, Presence)>,
-    ) -> MltResult<Self>
-    where
-        S: Into<String>,
-        I: IntoIterator<Item = Option<T>>,
-        T: AsRef<str>,
-    {
-        Self::new_inner(
-            prefix,
-            columns
-                .into_iter()
-                .map(|(suffix, values, presence)| (suffix, values, Some(presence))),
-        )
-    }
-
-    fn new_inner<S, I, T>(
-        prefix: impl Into<String>,
-        columns: impl IntoIterator<Item = (S, I, Option<Presence>)>,
-    ) -> MltResult<Self>
-    where
-        S: Into<String>,
-        I: IntoIterator<Item = Option<T>>,
-        T: AsRef<str>,
-    {
         let prefix = prefix.into();
         // Collect all columns so we can make two passes (dedup then assign ranges).
-        let columns: Vec<(String, Vec<Option<T>>, Option<Presence>)> = columns
+        let columns: Vec<(String, Vec<Option<T>>)> = columns
             .into_iter()
-            .map(|(s, i, p)| (s.into(), i.into_iter().collect(), p))
+            .map(|(s, i)| (s.into(), i.into_iter().collect()))
             .collect();
 
         // First pass: build deduplicated corpus in insertion order.
@@ -334,7 +281,7 @@ impl StagedSharedDict {
         let mut dict_ranges = Vec::<(u32, u32)>::new();
         let mut data = String::new();
 
-        for (_, values, _) in &columns {
+        for (_, values) in &columns {
             for value in values.iter().filter_map(Option::as_ref) {
                 let s = value.as_ref();
                 if !dict_index.contains_key(s) {
@@ -353,32 +300,29 @@ impl StagedSharedDict {
         // Second pass: emit per-feature ranges for each column.
         let items = columns
             .into_iter()
-            .map(
-                |(suffix, values, presence)| -> MltResult<StagedSharedDictItem> {
-                    let mut ranges = Vec::with_capacity(values.len());
-                    for opt_val in values {
-                        match opt_val {
-                            Some(value) => {
-                                let idx = *dict_index
-                                    .get(value.as_ref())
-                                    .expect("StagedSharedDict::new: value must be present");
-                                let (start, end) = dict_ranges[idx as usize];
-                                ranges.push(encode_shared_dict_range(start, end)?);
-                            }
-                            None => ranges.push(DictRange::NULL),
+            .map(|(suffix, values)| -> MltResult<StagedSharedDictItem> {
+                let mut ranges = Vec::with_capacity(values.len());
+                let mut present_items = 0;
+                for opt_val in values {
+                    match opt_val {
+                        Some(value) => {
+                            let idx = *dict_index
+                                .get(value.as_ref())
+                                .expect("StagedSharedDict::new: value must be present");
+                            let (start, end) = dict_ranges[idx as usize];
+                            ranges.push(encode_shared_dict_range(start, end)?);
+                            present_items += 1;
                         }
+                        None => ranges.push(DictRange::NULL),
                     }
-                    let has_presence = presence.map_or_else(
-                        || ranges.contains(&DictRange::NULL),
-                        |presence| matches!(presence, Presence::Mixed | Presence::AllNull),
-                    );
-                    Ok(StagedSharedDictItem {
-                        suffix,
-                        ranges,
-                        has_presence,
-                    })
-                },
-            )
+                }
+                let has_presence = present_items < ranges.len();
+                Ok(StagedSharedDictItem {
+                    suffix,
+                    ranges,
+                    has_presence,
+                })
+            })
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self {
@@ -386,6 +330,27 @@ impl StagedSharedDict {
             data,
             items,
         })
+    }
+
+    /// Build a shared-dictionary column with precomputed child presence facts.
+    pub(crate) fn new_with_presence<S, I, T>(
+        prefix: impl Into<String>,
+        columns: impl IntoIterator<Item = (S, I, Presence)>,
+    ) -> MltResult<Self>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = Option<T>>,
+        T: AsRef<str>,
+    {
+        let (columns, presences): (Vec<_>, Vec<_>) = columns
+            .into_iter()
+            .map(|(suffix, values, presence)| ((suffix, values), presence))
+            .unzip();
+        let mut shared_dict = Self::new(prefix, columns)?;
+        for (item, presence) in shared_dict.items.iter_mut().zip(presences) {
+            item.has_presence = presence != Presence::AllPresent;
+        }
+        Ok(shared_dict)
     }
 }
 

--- a/rust/mlt-core/src/encoder/property/shared_dict.rs
+++ b/rust/mlt-core/src/encoder/property/shared_dict.rs
@@ -229,13 +229,13 @@ impl StagedSharedDictItem {
 impl StagedSharedDict {
     /// Build a shared-dictionary column directly from raw per-column string data.
     ///
-    /// Each column is a `(suffix, values)` pair where `values` is an iterator of
-    /// optional strings (one per feature).  All unique non-null strings across every
+    /// Each column is a `(suffix, values, presence)` tuple where `values` is an iterator
+    /// of optional strings (one per feature).  All unique non-null strings across every
     /// column are deduplicated into a shared byte corpus; per-feature byte-range offsets
     /// into that corpus are recorded in each shared-dictionary item.
     pub fn new<S, I, T>(
         prefix: impl Into<String>,
-        columns: impl IntoIterator<Item = (S, I)>,
+        columns: impl IntoIterator<Item = (S, I, Presence)>,
     ) -> MltResult<Self>
     where
         S: Into<String>,
@@ -244,9 +244,9 @@ impl StagedSharedDict {
     {
         let prefix = prefix.into();
         // Collect all columns so we can make two passes (dedup then assign ranges).
-        let columns: Vec<(String, Vec<Option<T>>)> = columns
+        let columns: Vec<(String, Vec<Option<T>>, Presence)> = columns
             .into_iter()
-            .map(|(s, i)| (s.into(), i.into_iter().collect()))
+            .map(|(s, i, p)| (s.into(), i.into_iter().collect(), p))
             .collect();
 
         // First pass: build deduplicated corpus in insertion order.
@@ -254,7 +254,7 @@ impl StagedSharedDict {
         let mut dict_ranges = Vec::<(u32, u32)>::new();
         let mut data = String::new();
 
-        for (_, values) in &columns {
+        for (_, values, _) in &columns {
             for value in values.iter().filter_map(Option::as_ref) {
                 let s = value.as_ref();
                 if !dict_index.contains_key(s) {
@@ -273,29 +273,29 @@ impl StagedSharedDict {
         // Second pass: emit per-feature ranges for each column.
         let items = columns
             .into_iter()
-            .map(|(suffix, values)| -> MltResult<StagedSharedDictItem> {
-                let mut ranges = Vec::with_capacity(values.len());
-                let mut present_items = 0;
-                for opt_val in values {
-                    match opt_val {
-                        Some(value) => {
-                            let idx = *dict_index
-                                .get(value.as_ref())
-                                .expect("StagedSharedDict::new: value must be present");
-                            let (start, end) = dict_ranges[idx as usize];
-                            ranges.push(encode_shared_dict_range(start, end)?);
-                            present_items += 1;
+            .map(
+                |(suffix, values, presence)| -> MltResult<StagedSharedDictItem> {
+                    let mut ranges = Vec::with_capacity(values.len());
+                    for opt_val in values {
+                        match opt_val {
+                            Some(value) => {
+                                let idx = *dict_index
+                                    .get(value.as_ref())
+                                    .expect("StagedSharedDict::new: value must be present");
+                                let (start, end) = dict_ranges[idx as usize];
+                                ranges.push(encode_shared_dict_range(start, end)?);
+                            }
+                            None => ranges.push(DictRange::NULL),
                         }
-                        None => ranges.push(DictRange::NULL),
                     }
-                }
-                let has_presence = present_items < ranges.len();
-                Ok(StagedSharedDictItem {
-                    suffix,
-                    ranges,
-                    has_presence,
-                })
-            })
+                    let has_presence = presence != Presence::AllPresent;
+                    Ok(StagedSharedDictItem {
+                        suffix,
+                        ranges,
+                        has_presence,
+                    })
+                },
+            )
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self {
@@ -303,27 +303,6 @@ impl StagedSharedDict {
             data,
             items,
         })
-    }
-
-    /// Build a shared-dictionary column with precomputed child presence facts.
-    pub(crate) fn new_with_presence<S, I, T>(
-        prefix: impl Into<String>,
-        columns: impl IntoIterator<Item = (S, I, Presence)>,
-    ) -> MltResult<Self>
-    where
-        S: Into<String>,
-        I: IntoIterator<Item = Option<T>>,
-        T: AsRef<str>,
-    {
-        let (columns, presences): (Vec<_>, Vec<_>) = columns
-            .into_iter()
-            .map(|(suffix, values, presence)| ((suffix, values), presence))
-            .unzip();
-        let mut shared_dict = Self::new(prefix, columns)?;
-        for (item, presence) in shared_dict.items.iter_mut().zip(presences) {
-            item.has_presence = presence != Presence::AllPresent;
-        }
-        Ok(shared_dict)
     }
 }
 

--- a/rust/mlt-core/src/encoder/property/shared_dict.rs
+++ b/rust/mlt-core/src/encoder/property/shared_dict.rs
@@ -37,90 +37,76 @@ struct StringProfile<'a> {
 }
 
 impl TileLayer {
-    pub(crate) fn apply_string_groups(&self, properties: &mut [PropertyStats]) {
-        for (prefix, owner_col, member_cols) in group_string_properties(self) {
-            debug_assert_ne!(properties[owner_col].presence, Presence::AllNull);
+    /// Compute which string columns can be merged into a shared dict.
+    #[hotpath::measure]
+    pub(crate) fn group_string_properties(&self, properties: &mut [PropertyStats]) {
+        let exact_mh = MinHash::with_hashers(
+            MINHASH_PERMUTATIONS,
+            [
+                SipHasherBuilder::from_seed(0, 0),
+                SipHasherBuilder::from_seed(1, 1),
+            ],
+        );
+        let trigram_mh = MinHash::with_hashers(
+            MINHASH_PERMUTATIONS,
+            [
+                SipHasherBuilder::from_seed(0, 0),
+                SipHasherBuilder::from_seed(1, 1),
+            ],
+        );
+
+        let profiles: Vec<StringProfile<'_>> = self
+            .property_names
+            .iter()
+            .enumerate()
+            .filter_map(|(col_idx, name)| {
+                let vals: Vec<&str> = self
+                    .features
+                    .iter()
+                    .filter_map(|f| match f.properties.get(col_idx) {
+                        Some(PropValue::Str(Some(s))) => Some(s.as_str()),
+                        _ => None,
+                    })
+                    .collect();
+                if vals.is_empty() {
+                    return None;
+                }
+                let exact_hashes = exact_mh.get_min_hashes(vals.iter().copied());
+                let trigrams: Vec<[u8; 3]> = vals
+                    .iter()
+                    .flat_map(|s| s.as_bytes().windows(3).map(|w| [w[0], w[1], w[2]]))
+                    .collect();
+                let trigram_hashes = if trigrams.is_empty() {
+                    Vec::new()
+                } else {
+                    trigram_mh.get_min_hashes(trigrams.into_iter())
+                };
+                Some(StringProfile {
+                    col_idx,
+                    name,
+                    exact_hashes,
+                    trigram_hashes,
+                })
+            })
+            .collect();
+
+        for group in cluster_by_similarity(profiles) {
+            debug_assert!(
+                group
+                    .iter()
+                    .all(|p| properties[p.col_idx].presence != Presence::AllNull)
+            );
+            let owner_col = group[0].col_idx;
             properties[owner_col]
                 .stats
-                .set_shared_dict(SharedDictRole::Owner(prefix));
-            for col_idx in member_cols {
-                debug_assert_ne!(properties[col_idx].presence, Presence::AllNull);
-                properties[col_idx]
+                .set_shared_dict(SharedDictRole::Owner(common_prefix_name(&group)));
+            for profile in group.iter().skip(1) {
+                properties[profile.col_idx]
                     .stats
                     .set_shared_dict(SharedDictRole::Member(owner_col));
             }
         }
     }
-}
-
-/// Analyze a [`TileLayer`] and return one `(prefix, owner, members)` entry per cluster of similar
-/// string columns.
-#[must_use]
-#[hotpath::measure]
-fn group_string_properties(source: &TileLayer) -> Vec<(String, usize, Vec<usize>)> {
-    let exact_mh = MinHash::with_hashers(
-        MINHASH_PERMUTATIONS,
-        [
-            SipHasherBuilder::from_seed(0, 0),
-            SipHasherBuilder::from_seed(1, 1),
-        ],
-    );
-    let trigram_mh = MinHash::with_hashers(
-        MINHASH_PERMUTATIONS,
-        [
-            SipHasherBuilder::from_seed(0, 0),
-            SipHasherBuilder::from_seed(1, 1),
-        ],
-    );
-
-    let profiles: Vec<StringProfile<'_>> = source
-        .property_names
-        .iter()
-        .enumerate()
-        .filter_map(|(col_idx, name)| {
-            let vals: Vec<&str> = source
-                .features
-                .iter()
-                .filter_map(|f| match f.properties.get(col_idx) {
-                    Some(PropValue::Str(Some(s))) => Some(s.as_str()),
-                    _ => None,
-                })
-                .collect();
-            if vals.is_empty() {
-                return None;
-            }
-            let exact_hashes = exact_mh.get_min_hashes(vals.iter().copied());
-            let trigrams: Vec<[u8; 3]> = vals
-                .iter()
-                .flat_map(|s| s.as_bytes().windows(3).map(|w| [w[0], w[1], w[2]]))
-                .collect();
-            let trigram_hashes = if trigrams.is_empty() {
-                Vec::new()
-            } else {
-                trigram_mh.get_min_hashes(trigrams.into_iter())
-            };
-            Some(StringProfile {
-                col_idx,
-                name,
-                exact_hashes,
-                trigram_hashes,
-            })
-        })
-        .collect();
-
-    if profiles.is_empty() {
-        return Vec::new();
-    }
-
-    cluster_by_similarity(profiles)
-        .into_iter()
-        .filter_map(|group| {
-            let prefix = common_prefix_name(&group);
-            let mut columns = group.into_iter().map(|p| p.col_idx);
-            let owner_col = columns.next()?;
-            Some((prefix, owner_col, columns.collect()))
-        })
-        .collect()
 }
 
 /// Estimate Jaccard similarity from two `MinHash` signature vectors.
@@ -134,6 +120,9 @@ fn minhash_similarity(a: &[u64], b: &[u64]) -> f64 {
 }
 
 fn cluster_by_similarity(profiles: Vec<StringProfile<'_>>) -> Vec<Vec<StringProfile<'_>>> {
+    if profiles.is_empty() {
+        return Vec::new();
+    }
     let n = profiles.len();
     let mut uf = QuickUnionUf::<UnionBySize>::new(n);
 

--- a/rust/mlt-core/src/encoder/property/tests.rs
+++ b/rust/mlt-core/src/encoder/property/tests.rs
@@ -858,7 +858,20 @@ fn analyze_layer_rejects_mixed_property_types() {
 
     assert!(matches!(
         tile.analyze(false),
-        Err(MltError::MixedPropertyTypes)
+        Err(MltError::MixedPropertyTypes(0, property_name)) if property_name == "mixed"
+    ));
+}
+
+#[test]
+fn analyze_layer_rejects_typed_null_mixed_with_other_type() {
+    let tile = tile_from_cols(&[(
+        "mixed",
+        vec![PropValue::U32(None), PropValue::Str(Some("x".into()))],
+    )]);
+
+    assert!(matches!(
+        tile.analyze(false),
+        Err(MltError::MixedPropertyTypes(0, property_name)) if property_name == "mixed"
     ));
 }
 

--- a/rust/mlt-core/src/encoder/property/tests.rs
+++ b/rust/mlt-core/src/encoder/property/tests.rs
@@ -10,7 +10,7 @@ use crate::encoder::{
     StagedSharedDict, stage_tile,
 };
 use crate::test_helpers::{dec, parser};
-use crate::{DictRange, GeometryValues, Layer, PropValue, TileFeature, TileLayer};
+use crate::{DictRange, GeometryValues, Layer, MltError, PropValue, TileFeature, TileLayer};
 // proptest_derive::Arbitrary is only derived for these types inside the crate
 // under #[cfg(test)], so we write the strategies by hand here.
 
@@ -690,28 +690,28 @@ fn str_vals(values: &[&str]) -> Vec<PropValue> {
 #[test]
 fn staging_uses_id_presence_analysis() {
     let all_present = tile_from_ids(&[Some(1), Some(2), Some(3)]);
-    let analysis = all_present.analyze(false);
+    let analysis = all_present.analyze(false).unwrap();
     let id = analysis.id.as_ref().expect("ID analysis");
     assert!(id.stats.values_fit_u32());
     let staged = StagedLayer::from_tile(all_present, Unsorted, &analysis, false);
     assert!(matches!(staged.id, StagedId::U32(_)));
 
     let mixed = tile_from_ids(&[Some(1), None, Some(3)]);
-    let analysis = mixed.analyze(false);
+    let analysis = mixed.analyze(false).unwrap();
     let id = analysis.id.as_ref().expect("ID analysis");
     assert!(id.stats.values_fit_u32());
     let staged = StagedLayer::from_tile(mixed, Unsorted, &analysis, false);
     assert!(matches!(staged.id, StagedId::OptU32(_)));
 
     let large = tile_from_ids(&[Some(u64::from(u32::MAX) + 1), None, Some(3)]);
-    let analysis = large.analyze(false);
+    let analysis = large.analyze(false).unwrap();
     let id = analysis.id.as_ref().expect("ID analysis");
     assert!(!id.stats.values_fit_u32());
     let staged = StagedLayer::from_tile(large, Unsorted, &analysis, false);
     assert!(matches!(staged.id, StagedId::OptU64(_)));
 
     let all_null = tile_from_ids(&[None, None, None]);
-    let analysis = all_null.analyze(false);
+    let analysis = all_null.analyze(false).unwrap();
     assert_eq!(analysis.id, None);
     let staged = StagedLayer::from_tile(all_null, Unsorted, &analysis, false);
     assert!(matches!(staged.id, StagedId::None));
@@ -748,7 +748,7 @@ fn analyze_layer_classifies_id_and_property_presence() {
         ],
     );
 
-    let analysis = tile.analyze(true);
+    let analysis = tile.analyze(true).unwrap();
 
     let id = analysis.id.as_ref().expect("ID analysis");
     assert_eq!(id.presence, Presence::Mixed);
@@ -794,7 +794,7 @@ fn analyze_layer_tracks_typed_property_stats() {
         ),
     ]);
 
-    let analysis = tile.analyze(false);
+    let analysis = tile.analyze(false).unwrap();
 
     assert_eq!(
         analysis.properties[0].stats,
@@ -820,13 +820,22 @@ fn analyze_layer_tracks_typed_property_stats() {
     assert_eq!(
         analysis.properties[3].stats,
         PropertyTypedStats::String {
-            total_bytes: 5,
-            max_bytes: 4,
-            exact_hashes: Vec::new(),
-            trigram_hashes: Vec::new(),
             shared_dict: SharedDictRole::None
         }
     );
+}
+
+#[test]
+fn analyze_layer_rejects_mixed_property_types() {
+    let tile = tile_from_cols(&[(
+        "mixed",
+        vec![PropValue::F32(Some(1.0)), PropValue::F64(Some(2.0))],
+    )]);
+
+    assert!(matches!(
+        tile.analyze(false),
+        Err(MltError::MixedPropertyTypes)
+    ));
 }
 
 #[test]
@@ -869,7 +878,7 @@ fn analyze_layer_records_shared_dict_roles_by_property_index() {
     let vocab = &["Alice", "Bob", "Carol", "Dave"];
     let tile = tile_from_cols(&[("name:en", str_vals(vocab)), ("name:de", str_vals(vocab))]);
 
-    let analysis = tile.analyze(true);
+    let analysis = tile.analyze(true).unwrap();
 
     assert_eq!(analysis.string_groups.len(), 1);
     assert_eq!(

--- a/rust/mlt-core/src/encoder/property/tests.rs
+++ b/rust/mlt-core/src/encoder/property/tests.rs
@@ -81,7 +81,19 @@ fn opt_strs(vals: &[Option<&str>]) -> Vec<Option<String>> {
     vals.iter().map(|v| v.map(ToString::to_string)).collect()
 }
 
+fn presence<T>(values: &[Option<T>]) -> Presence {
+    if values.iter().all(Option::is_some) {
+        Presence::AllPresent
+    } else {
+        Presence::Mixed
+    }
+}
+
 fn shared_dict_prop(name: &str, children: Vec<(String, Vec<Option<String>>)>) -> StagedProperty {
+    let children = children.into_iter().map(|(suffix, values)| {
+        let presence = presence(&values);
+        (suffix, values, presence)
+    });
     StagedProperty::SharedDict(StagedSharedDict::new(name, children).expect("build shared dict"))
 }
 
@@ -441,8 +453,16 @@ fn struct_shared_dict_inline_ranges_track_nulls_and_empty_strings() {
     let dict = StagedSharedDict::new(
         "name",
         vec![
-            col(":de", opt_strs(&[Some(""), None, Some("Berlin")])),
-            col(":en", opt_strs(&[Some(""), Some("Berlin"), Some("")])),
+            (
+                ":de",
+                opt_strs(&[Some(""), None, Some("Berlin")]),
+                Presence::Mixed,
+            ),
+            (
+                ":en",
+                opt_strs(&[Some(""), Some("Berlin"), Some("")]),
+                Presence::AllPresent,
+            ),
         ],
     )
     .unwrap();
@@ -607,8 +627,12 @@ proptest! {
         input in arb_shared_dict_children(),
     ) {
         let (n, children) = input;
+        let staged_children = children.iter().map(|(suffix, values)| {
+            let presence = presence(values);
+            (suffix.clone(), values.clone(), presence)
+        });
         let staged = StagedProperty::SharedDict(
-            StagedSharedDict::new(&struct_name, children.clone()).expect("build shared dict"),
+            StagedSharedDict::new(&struct_name, staged_children).expect("build shared dict"),
         );
         let tile = encode_and_tile(vec![staged]);
 

--- a/rust/mlt-core/src/encoder/property/tests.rs
+++ b/rust/mlt-core/src/encoder/property/tests.rs
@@ -1,5 +1,6 @@
 use geo_types::Point;
 use proptest::prelude::*;
+use rstest::rstest;
 
 use crate::encoder::SortStrategy::Unsorted;
 use crate::encoder::model::{ExplicitEncoder, StagedLayer, StrEncoding};
@@ -849,30 +850,82 @@ fn analyze_layer_tracks_typed_property_stats() {
     );
 }
 
-#[test]
-fn analyze_layer_rejects_mixed_property_types() {
-    let tile = tile_from_cols(&[(
-        "mixed",
-        vec![PropValue::F32(Some(1.0)), PropValue::F64(Some(2.0))],
-    )]);
-
+#[rstest]
+#[case(vec![PropValue::I8(Some(1)), PropValue::I32(Some(2))])]
+#[case(vec![PropValue::I8(Some(1)), PropValue::I64(Some(2))])]
+#[case(vec![PropValue::I32(Some(1)), PropValue::I64(Some(2))])]
+#[case(vec![PropValue::U8(Some(1)), PropValue::U32(Some(2))])]
+#[case(vec![PropValue::U8(Some(1)), PropValue::U64(Some(2))])]
+#[case(vec![PropValue::U32(Some(1)), PropValue::U64(Some(2))])]
+#[case(vec![PropValue::I8(None), PropValue::I32(Some(2))])]
+#[case(vec![PropValue::I8(Some(1)), PropValue::I64(None)])]
+#[case(vec![PropValue::I32(None), PropValue::I64(Some(2))])]
+#[case(vec![PropValue::U8(None), PropValue::U32(Some(2))])]
+#[case(vec![PropValue::U8(Some(1)), PropValue::U64(None)])]
+#[case(vec![PropValue::U32(None), PropValue::U64(Some(2))])]
+#[case(vec![PropValue::F32(Some(1.0)), PropValue::F64(Some(2.0))])]
+#[case(vec![PropValue::F32(None), PropValue::F64(Some(2.0))])]
+#[case(vec![PropValue::F32(Some(1.0)), PropValue::F64(None)])]
+#[case(vec![PropValue::U32(None), PropValue::Str(Some("x".into()))])]
+fn analyze_layer_rejects_property_type_coercions(#[case] values: Vec<PropValue>) {
+    let tile = tile_from_cols(&[("mixed", values)]);
     assert!(matches!(
         tile.analyze(false),
         Err(MltError::MixedPropertyTypes(0, property_name)) if property_name == "mixed"
     ));
 }
 
-#[test]
-fn analyze_layer_rejects_typed_null_mixed_with_other_type() {
-    let tile = tile_from_cols(&[(
-        "mixed",
-        vec![PropValue::U32(None), PropValue::Str(Some("x".into()))],
-    )]);
-
-    assert!(matches!(
-        tile.analyze(false),
-        Err(MltError::MixedPropertyTypes(0, property_name)) if property_name == "mixed"
-    ));
+#[rstest]
+#[case(
+    vec![PropValue::Bool(None), PropValue::Bool(Some(true))],
+    PropertyTypedStats::Bool
+)]
+#[case(
+    vec![PropValue::I8(None), PropValue::I8(Some(-1))],
+    PropertyTypedStats::Signed { min: -1, max: -1 }
+)]
+#[case(
+    vec![PropValue::U8(None), PropValue::U8(Some(1))],
+    PropertyTypedStats::Unsigned { min: 1, max: 1 }
+)]
+#[case(
+    vec![PropValue::I32(None), PropValue::I32(Some(-2))],
+    PropertyTypedStats::Signed { min: -2, max: -2 }
+)]
+#[case(
+    vec![PropValue::U32(None), PropValue::U32(Some(2))],
+    PropertyTypedStats::Unsigned { min: 2, max: 2 }
+)]
+#[case(
+    vec![PropValue::I64(None), PropValue::I64(Some(-3))],
+    PropertyTypedStats::Signed { min: -3, max: -3 }
+)]
+#[case(
+    vec![PropValue::U64(None), PropValue::U64(Some(3))],
+    PropertyTypedStats::Unsigned { min: 3, max: 3 }
+)]
+#[case(
+    vec![PropValue::F32(None), PropValue::F32(Some(1.0))],
+    PropertyTypedStats::F32
+)]
+#[case(
+    vec![PropValue::F64(None), PropValue::F64(Some(1.0))],
+    PropertyTypedStats::F64
+)]
+#[case(
+    vec![PropValue::Str(None), PropValue::Str(Some("x".into()))],
+    PropertyTypedStats::String {
+        shared_dict: SharedDictRole::None,
+    }
+)]
+fn analyze_layer_accepts_typed_nulls_matching_column_type(
+    #[case] values: Vec<PropValue>,
+    #[case] expected_stats: PropertyTypedStats,
+) {
+    let tile = tile_from_cols(&[("typed_null", values)]);
+    let analysis = tile.analyze(false).unwrap();
+    assert_eq!(analysis.properties[0].presence, Presence::Mixed);
+    assert_eq!(analysis.properties[0].stats, expected_stats);
 }
 
 #[test]

--- a/rust/mlt-core/src/encoder/property/tests.rs
+++ b/rust/mlt-core/src/encoder/property/tests.rs
@@ -2,10 +2,11 @@ use geo_types::Point;
 use proptest::prelude::*;
 
 use crate::encoder::model::{ExplicitEncoder, StagedLayer, StrEncoding};
+use crate::encoder::optimizer::{Presence, PropertyTypedStats, SharedDictRole};
 use crate::encoder::property::encode::write_properties;
 use crate::encoder::{
     Encoder, EncoderConfig, IntEncoder, LogicalEncoder, PhysicalEncoder, SortStrategy, StagedId,
-    StagedProperty, StagedSharedDict, group_string_properties,
+    StagedProperty, StagedSharedDict, analyze_layer,
 };
 use crate::test_helpers::{dec, parser};
 use crate::{DictRange, GeometryValues, Layer, PropValue, TileFeature, TileLayer};
@@ -652,6 +653,31 @@ fn tile_from_cols(cols: &[(&str, Vec<PropValue>)]) -> TileLayer {
     }
 }
 
+fn tile_from_cols_with_ids(ids: &[Option<u64>], cols: &[(&str, Vec<PropValue>)]) -> TileLayer {
+    let mut tile = tile_from_cols(cols);
+    for (feature, id) in tile.features.iter_mut().zip(ids.iter().copied()) {
+        feature.id = id;
+    }
+    tile
+}
+
+fn tile_from_ids(ids: &[Option<u64>]) -> TileLayer {
+    let geom = geo_types::Geometry::<i32>::Point(Point::new(0, 0));
+    TileLayer {
+        name: "test".to_string(),
+        extent: 4096,
+        property_names: vec![],
+        features: ids
+            .iter()
+            .map(|&id| TileFeature {
+                id,
+                geometry: geom.clone(),
+                properties: vec![],
+            })
+            .collect(),
+    }
+}
+
 /// Convert a `&[&str]` slice into a column of `PropValue::Str` values.
 fn str_vals(values: &[&str]) -> Vec<PropValue> {
     values
@@ -662,8 +688,204 @@ fn str_vals(values: &[&str]) -> Vec<PropValue> {
 
 /// Stage a [`TileLayer`] with `MinHash` grouping and return its properties.
 fn stage_props(tile: TileLayer) -> Vec<StagedProperty> {
-    let groups = group_string_properties(&tile);
-    StagedLayer::from_tile(tile, SortStrategy::Unsorted, &groups, false).properties
+    let analysis = analyze_layer(&tile, true);
+    StagedLayer::from_tile(tile, SortStrategy::Unsorted, &analysis, false).properties
+}
+
+#[test]
+fn staging_uses_id_presence_analysis() {
+    let all_present = tile_from_ids(&[Some(1), Some(2), Some(3)]);
+    let analysis = analyze_layer(&all_present, false);
+    let id = analysis.id.as_ref().expect("ID analysis");
+    assert!(id.stats.values_fit_u32());
+    let staged = StagedLayer::from_tile(all_present, SortStrategy::Unsorted, &analysis, false);
+    assert!(matches!(staged.id, StagedId::U32(_)));
+
+    let mixed = tile_from_ids(&[Some(1), None, Some(3)]);
+    let analysis = analyze_layer(&mixed, false);
+    let id = analysis.id.as_ref().expect("ID analysis");
+    assert!(id.stats.values_fit_u32());
+    let staged = StagedLayer::from_tile(mixed, SortStrategy::Unsorted, &analysis, false);
+    assert!(matches!(staged.id, StagedId::OptU32(_)));
+
+    let large = tile_from_ids(&[Some(u64::from(u32::MAX) + 1), None, Some(3)]);
+    let analysis = analyze_layer(&large, false);
+    let id = analysis.id.as_ref().expect("ID analysis");
+    assert!(!id.stats.values_fit_u32());
+    let staged = StagedLayer::from_tile(large, SortStrategy::Unsorted, &analysis, false);
+    assert!(matches!(staged.id, StagedId::OptU64(_)));
+
+    let all_null = tile_from_ids(&[None, None, None]);
+    let analysis = analyze_layer(&all_null, false);
+    assert_eq!(analysis.id, None);
+    let staged = StagedLayer::from_tile(all_null, SortStrategy::Unsorted, &analysis, false);
+    assert!(matches!(staged.id, StagedId::None));
+}
+
+#[test]
+fn analyze_layer_classifies_id_and_property_presence() {
+    let tile = tile_from_cols_with_ids(
+        &[Some(1), None, Some(3)],
+        &[
+            (
+                "all_present",
+                [1u32, 2, 3]
+                    .iter()
+                    .map(|&v| PropValue::U32(Some(v)))
+                    .collect(),
+            ),
+            (
+                "mixed",
+                vec![
+                    PropValue::Bool(Some(true)),
+                    PropValue::Bool(None),
+                    PropValue::Bool(Some(false)),
+                ],
+            ),
+            (
+                "all_null",
+                vec![
+                    PropValue::Str(None),
+                    PropValue::Str(None),
+                    PropValue::Str(None),
+                ],
+            ),
+        ],
+    );
+
+    let analysis = analyze_layer(&tile, true);
+
+    let id = analysis.id.as_ref().expect("ID analysis");
+    assert_eq!(id.presence, Presence::Mixed);
+    assert_eq!(id.stats, PropertyTypedStats::Unsigned { min: 1, max: 3 });
+    assert_eq!(analysis.properties[0].presence, Presence::AllPresent);
+    assert_eq!(
+        analysis.properties[0].stats,
+        PropertyTypedStats::Unsigned { min: 1, max: 3 }
+    );
+    assert_eq!(analysis.properties[1].presence, Presence::Mixed);
+    assert_eq!(analysis.properties[1].stats, PropertyTypedStats::Bool);
+    assert_eq!(analysis.properties[2].presence, Presence::AllNull);
+    assert_eq!(analysis.properties[2].stats, PropertyTypedStats::None);
+}
+
+#[test]
+fn analyze_layer_tracks_typed_property_stats() {
+    let tile = tile_from_cols(&[
+        (
+            "small_u64",
+            vec![
+                PropValue::U64(Some(0)),
+                PropValue::U64(Some(u64::from(u32::MAX))),
+            ],
+        ),
+        (
+            "large_u64",
+            vec![
+                PropValue::U64(Some(0)),
+                PropValue::U64(Some(u64::from(u32::MAX) + 1)),
+            ],
+        ),
+        (
+            "negative_i64",
+            vec![PropValue::I64(Some(-1)), PropValue::I64(Some(2))],
+        ),
+        (
+            "names",
+            vec![
+                PropValue::Str(Some("a".to_string())),
+                PropValue::Str(Some("abcd".to_string())),
+            ],
+        ),
+    ]);
+
+    let analysis = analyze_layer(&tile, false);
+
+    assert_eq!(
+        analysis.properties[0].stats,
+        PropertyTypedStats::Unsigned {
+            min: 0,
+            max: u64::from(u32::MAX)
+        }
+    );
+    assert!(analysis.properties[0].stats.values_fit_u32());
+    assert_eq!(
+        analysis.properties[1].stats,
+        PropertyTypedStats::Unsigned {
+            min: 0,
+            max: u64::from(u32::MAX) + 1
+        }
+    );
+    assert!(!analysis.properties[1].stats.values_fit_u32());
+    assert_eq!(
+        analysis.properties[2].stats,
+        PropertyTypedStats::Signed { min: -1, max: 2 }
+    );
+    assert!(!analysis.properties[2].stats.values_fit_u32());
+    assert_eq!(
+        analysis.properties[3].stats,
+        PropertyTypedStats::String {
+            total_bytes: 5,
+            max_bytes: 4,
+            exact_hashes: Vec::new(),
+            trigram_hashes: Vec::new(),
+            shared_dict: SharedDictRole::None
+        }
+    );
+}
+
+#[test]
+fn staging_uses_presence_analysis_for_scalar_variants_and_skips_all_null() {
+    let tile = tile_from_cols(&[
+        (
+            "all_present",
+            [1u32, 2, 3]
+                .iter()
+                .map(|&v| PropValue::U32(Some(v)))
+                .collect(),
+        ),
+        (
+            "mixed",
+            vec![
+                PropValue::Bool(Some(true)),
+                PropValue::Bool(None),
+                PropValue::Bool(Some(false)),
+            ],
+        ),
+        (
+            "all_null",
+            vec![
+                PropValue::Str(None),
+                PropValue::Str(None),
+                PropValue::Str(None),
+            ],
+        ),
+    ]);
+    let analysis = analyze_layer(&tile, false);
+
+    let staged = StagedLayer::from_tile(tile, SortStrategy::Unsorted, &analysis, false);
+
+    assert_eq!(staged.properties.len(), 2);
+    assert!(matches!(staged.properties[0], StagedProperty::U32(_)));
+    assert!(matches!(staged.properties[1], StagedProperty::OptBool(_)));
+}
+
+#[test]
+fn analyze_layer_records_shared_dict_roles_by_property_index() {
+    let vocab = &["Alice", "Bob", "Carol", "Dave"];
+    let tile = tile_from_cols(&[("name:en", str_vals(vocab)), ("name:de", str_vals(vocab))]);
+
+    let analysis = analyze_layer(&tile, true);
+
+    assert_eq!(analysis.string_groups.len(), 1);
+    assert_eq!(
+        analysis.properties[0].stats.shared_dict(),
+        SharedDictRole::Owner(0)
+    );
+    assert_eq!(
+        analysis.properties[1].stats.shared_dict(),
+        SharedDictRole::Member(0)
+    );
 }
 
 #[test]

--- a/rust/mlt-core/src/encoder/property/tests.rs
+++ b/rust/mlt-core/src/encoder/property/tests.rs
@@ -880,11 +880,10 @@ fn analyze_layer_records_shared_dict_roles_by_property_index() {
 
     let analysis = tile.analyze(true).unwrap();
 
-    assert_eq!(analysis.string_groups.len(), 1);
-    assert_eq!(
-        analysis.properties[0].stats.shared_dict(),
-        SharedDictRole::Owner(0)
-    );
+    let SharedDictRole::Owner(prefix) = analysis.properties[0].stats.shared_dict() else {
+        panic!("first string column should own the shared dictionary");
+    };
+    assert_eq!(prefix, "name:");
     assert_eq!(
         analysis.properties[1].stats.shared_dict(),
         SharedDictRole::Member(0)

--- a/rust/mlt-core/src/encoder/property/tests.rs
+++ b/rust/mlt-core/src/encoder/property/tests.rs
@@ -1,12 +1,13 @@
 use geo_types::Point;
 use proptest::prelude::*;
 
+use crate::encoder::SortStrategy::Unsorted;
 use crate::encoder::model::{ExplicitEncoder, StagedLayer, StrEncoding};
 use crate::encoder::optimizer::{Presence, PropertyTypedStats, SharedDictRole};
 use crate::encoder::property::encode::write_properties;
 use crate::encoder::{
-    Encoder, EncoderConfig, IntEncoder, LogicalEncoder, PhysicalEncoder, SortStrategy, StagedId,
-    StagedProperty, StagedSharedDict, analyze_layer,
+    Encoder, EncoderConfig, IntEncoder, LogicalEncoder, PhysicalEncoder, StagedId, StagedProperty,
+    StagedSharedDict, stage_tile,
 };
 use crate::test_helpers::{dec, parser};
 use crate::{DictRange, GeometryValues, Layer, PropValue, TileFeature, TileLayer};
@@ -686,39 +687,33 @@ fn str_vals(values: &[&str]) -> Vec<PropValue> {
         .collect()
 }
 
-/// Stage a [`TileLayer`] with `MinHash` grouping and return its properties.
-fn stage_props(tile: TileLayer) -> Vec<StagedProperty> {
-    let analysis = analyze_layer(&tile, true);
-    StagedLayer::from_tile(tile, SortStrategy::Unsorted, &analysis, false).properties
-}
-
 #[test]
 fn staging_uses_id_presence_analysis() {
     let all_present = tile_from_ids(&[Some(1), Some(2), Some(3)]);
-    let analysis = analyze_layer(&all_present, false);
+    let analysis = all_present.analyze(false);
     let id = analysis.id.as_ref().expect("ID analysis");
     assert!(id.stats.values_fit_u32());
-    let staged = StagedLayer::from_tile(all_present, SortStrategy::Unsorted, &analysis, false);
+    let staged = StagedLayer::from_tile(all_present, Unsorted, &analysis, false);
     assert!(matches!(staged.id, StagedId::U32(_)));
 
     let mixed = tile_from_ids(&[Some(1), None, Some(3)]);
-    let analysis = analyze_layer(&mixed, false);
+    let analysis = mixed.analyze(false);
     let id = analysis.id.as_ref().expect("ID analysis");
     assert!(id.stats.values_fit_u32());
-    let staged = StagedLayer::from_tile(mixed, SortStrategy::Unsorted, &analysis, false);
+    let staged = StagedLayer::from_tile(mixed, Unsorted, &analysis, false);
     assert!(matches!(staged.id, StagedId::OptU32(_)));
 
     let large = tile_from_ids(&[Some(u64::from(u32::MAX) + 1), None, Some(3)]);
-    let analysis = analyze_layer(&large, false);
+    let analysis = large.analyze(false);
     let id = analysis.id.as_ref().expect("ID analysis");
     assert!(!id.stats.values_fit_u32());
-    let staged = StagedLayer::from_tile(large, SortStrategy::Unsorted, &analysis, false);
+    let staged = StagedLayer::from_tile(large, Unsorted, &analysis, false);
     assert!(matches!(staged.id, StagedId::OptU64(_)));
 
     let all_null = tile_from_ids(&[None, None, None]);
-    let analysis = analyze_layer(&all_null, false);
+    let analysis = all_null.analyze(false);
     assert_eq!(analysis.id, None);
-    let staged = StagedLayer::from_tile(all_null, SortStrategy::Unsorted, &analysis, false);
+    let staged = StagedLayer::from_tile(all_null, Unsorted, &analysis, false);
     assert!(matches!(staged.id, StagedId::None));
 }
 
@@ -753,7 +748,7 @@ fn analyze_layer_classifies_id_and_property_presence() {
         ],
     );
 
-    let analysis = analyze_layer(&tile, true);
+    let analysis = tile.analyze(true);
 
     let id = analysis.id.as_ref().expect("ID analysis");
     assert_eq!(id.presence, Presence::Mixed);
@@ -799,7 +794,7 @@ fn analyze_layer_tracks_typed_property_stats() {
         ),
     ]);
 
-    let analysis = analyze_layer(&tile, false);
+    let analysis = tile.analyze(false);
 
     assert_eq!(
         analysis.properties[0].stats,
@@ -861,9 +856,8 @@ fn staging_uses_presence_analysis_for_scalar_variants_and_skips_all_null() {
             ],
         ),
     ]);
-    let analysis = analyze_layer(&tile, false);
 
-    let staged = StagedLayer::from_tile(tile, SortStrategy::Unsorted, &analysis, false);
+    let staged = stage_tile(tile, Unsorted, false, false);
 
     assert_eq!(staged.properties.len(), 2);
     assert!(matches!(staged.properties[0], StagedProperty::U32(_)));
@@ -875,7 +869,7 @@ fn analyze_layer_records_shared_dict_roles_by_property_index() {
     let vocab = &["Alice", "Bob", "Carol", "Dave"];
     let tile = tile_from_cols(&[("name:en", str_vals(vocab)), ("name:de", str_vals(vocab))]);
 
-    let analysis = analyze_layer(&tile, true);
+    let analysis = tile.analyze(true);
 
     assert_eq!(analysis.string_groups.len(), 1);
     assert_eq!(
@@ -927,7 +921,11 @@ fn similar_strings_grouped_into_shared_dict() {
     let vocab = &["Alice", "Bob", "Carol", "Dave"];
     let tile = tile_from_cols(&[("name:en", str_vals(vocab)), ("name:de", str_vals(vocab))]);
     let mut enc = Encoder::default();
-    write_properties(&stage_props(tile), &mut enc).unwrap();
+    write_properties(
+        &stage_tile(tile, Unsorted, true, false).properties,
+        &mut enc,
+    )
+    .unwrap();
 
     assert_eq!(
         enc.layer_column_count, 1,
@@ -944,7 +942,11 @@ fn multiple_similar_string_columns_grouped() {
         ("addr:zipcode", str_vals(vocab)),
     ]);
     let mut enc = Encoder::default();
-    write_properties(&stage_props(tile), &mut enc).unwrap();
+    write_properties(
+        &stage_tile(tile, Unsorted, true, false).properties,
+        &mut enc,
+    )
+    .unwrap();
 
     assert_eq!(
         enc.layer_column_count, 1,
@@ -982,7 +984,11 @@ fn mixed_scalars_and_grouped_strings() {
         ),
     ]);
     let mut enc = Encoder::default();
-    write_properties(&stage_props(tile), &mut enc).unwrap();
+    write_properties(
+        &stage_tile(tile, Unsorted, true, false).properties,
+        &mut enc,
+    )
+    .unwrap();
     assert_eq!(enc.layer_column_count, 3, "two scalar + one merged dict");
 }
 

--- a/rust/mlt-core/src/encoder/sort.rs
+++ b/rust/mlt-core/src/encoder/sort.rs
@@ -141,9 +141,7 @@ mod tests {
     use geo_types::{Coord, Geometry as GeoGeom, Geometry, LineString, Point, Polygon};
 
     use crate::decoder::{GeometryType, GeometryValues, RawGeometry, TileFeature, TileLayer};
-    use crate::encoder::{
-        Encoder, ExplicitEncoder, IntEncoder, SortStrategy, StagedLayer, analyze_layer,
-    };
+    use crate::encoder::{Encoder, ExplicitEncoder, IntEncoder, SortStrategy, stage_tile};
     use crate::test_helpers::{assert_empty, dec, into_layer01, parser};
     use crate::{Layer, LazyParsed};
 
@@ -380,8 +378,7 @@ mod tests {
     fn sort_encode_decode(tile: TileLayer, sort: SortStrategy) -> TileLayer {
         let enc_cfg = Encoder::default().cfg;
         let enc = Encoder::with_explicit(enc_cfg, ExplicitEncoder::for_id(IntEncoder::varint()));
-        let analysis = analyze_layer(&tile, false);
-        let enc = StagedLayer::from_tile(tile, sort, &analysis, enc_cfg.tessellate)
+        let enc = stage_tile(tile, sort, false, enc_cfg.tessellate)
             .encode_into(enc)
             .expect("encode failed");
 

--- a/rust/mlt-core/src/encoder/sort.rs
+++ b/rust/mlt-core/src/encoder/sort.rs
@@ -141,7 +141,9 @@ mod tests {
     use geo_types::{Coord, Geometry as GeoGeom, Geometry, LineString, Point, Polygon};
 
     use crate::decoder::{GeometryType, GeometryValues, RawGeometry, TileFeature, TileLayer};
-    use crate::encoder::{Encoder, ExplicitEncoder, IntEncoder, SortStrategy, StagedLayer};
+    use crate::encoder::{
+        Encoder, ExplicitEncoder, IntEncoder, SortStrategy, StagedLayer, analyze_layer,
+    };
     use crate::test_helpers::{assert_empty, dec, into_layer01, parser};
     use crate::{Layer, LazyParsed};
 
@@ -378,7 +380,8 @@ mod tests {
     fn sort_encode_decode(tile: TileLayer, sort: SortStrategy) -> TileLayer {
         let enc_cfg = Encoder::default().cfg;
         let enc = Encoder::with_explicit(enc_cfg, ExplicitEncoder::for_id(IntEncoder::varint()));
-        let enc = StagedLayer::from_tile(tile, sort, &[], enc_cfg.tessellate)
+        let analysis = analyze_layer(&tile, false);
+        let enc = StagedLayer::from_tile(tile, sort, &analysis, enc_cfg.tessellate)
             .encode_into(enc)
             .expect("encode failed");
 

--- a/rust/mlt-core/src/encoder/tests.rs
+++ b/rust/mlt-core/src/encoder/tests.rs
@@ -49,6 +49,6 @@ pub fn stage_tile(
     allow_shared_dict: bool,
     tessellate: bool,
 ) -> StagedLayer {
-    let analysis = tile.analyze(allow_shared_dict);
+    let analysis = tile.analyze(allow_shared_dict).expect("analyze tile");
     StagedLayer::from_tile(tile, sort, &analysis, tessellate)
 }

--- a/rust/mlt-core/src/encoder/tests.rs
+++ b/rust/mlt-core/src/encoder/tests.rs
@@ -1,5 +1,6 @@
+use crate::TileLayer;
 use crate::encoder::model::ColumnKind;
-use crate::encoder::{ExplicitEncoder, IntEncoder, VertexBufferType};
+use crate::encoder::{ExplicitEncoder, IntEncoder, SortStrategy, StagedLayer, VertexBufferType};
 
 impl ExplicitEncoder {
     /// Use `enc` for all integer streams, plain string encoding, and `Vec2` vertex layout.
@@ -39,4 +40,15 @@ impl ExplicitEncoder {
             ..Self::all(IntEncoder::varint())
         }
     }
+}
+
+#[must_use]
+pub fn stage_tile(
+    tile: TileLayer,
+    sort: SortStrategy,
+    allow_shared_dict: bool,
+    tessellate: bool,
+) -> StagedLayer {
+    let analysis = tile.analyze(allow_shared_dict);
+    StagedLayer::from_tile(tile, sort, &analysis, tessellate)
 }

--- a/rust/mlt-core/src/encoder/tile.rs
+++ b/rust/mlt-core/src/encoder/tile.rs
@@ -7,23 +7,16 @@
 //! and free from any encoded/decoded duality.
 //!
 //! Conversion from [`TileLayer`] to [`StagedLayer`] is done via
-//! [`StagedLayer::from_tile`] (pre-computed `StringGroup` pairings produced by
-//! `group_string_properties`) or the blanket [`From`] impl (no grouping).
-
-use std::collections::HashMap;
+//! [`StagedLayer::from_tile`] with pre-computed layer statistics.
 
 use crate::decoder::{GeometryValues, PropValue, TileFeature, TileLayer};
 use crate::encoder::model::StagedLayer;
+use crate::encoder::optimizer::{LayerStats, Presence, SharedDictRole};
 use crate::encoder::{SortStrategy, StagedId, StagedProperty, StagedSharedDict, StringGroup};
 
 impl StagedLayer {
-    /// Construct a [`StagedLayer`] from a row-oriented [`TileLayer`], applying
-    /// pre-computed `StringGroup` pairings to merge similar string columns into
-    /// shared dictionaries.
-    ///
-    /// `groups` should be the output of `group_string_properties` called on the
-    /// same [`TileLayer`] source.  Because unique-value membership is
-    /// row-order-independent, the same groups can be reused across sort trials.
+    /// Construct a [`StagedLayer`] from a row-oriented [`TileLayer`] using
+    /// pre-computed layer statistics.
     ///
     /// When `tessellate` is `true`, polygon and multi-polygon geometries have
     /// their triangulation stored alongside the geometry.
@@ -32,7 +25,7 @@ impl StagedLayer {
     pub fn from_tile(
         mut source: TileLayer,
         sort: SortStrategy,
-        groups: &[StringGroup],
+        stats: &LayerStats,
         tessellate: bool,
     ) -> Self {
         assert!(!source.features.is_empty(), "empty tile");
@@ -46,23 +39,37 @@ impl StagedLayer {
             geometry.push_geom(&f.geometry);
         }
 
-        let id = StagedId::from_optional(source.features.iter().map(|f| f.id).collect());
-
-        let col_to_group: HashMap<_, _> = groups
-            .iter()
-            .flat_map(|g| g.columns.iter().map(move |(_, i)| (*i, g)))
-            .collect();
-
-        // first col_idx of each group → the group (emit the SharedDict here)
-        let mut group_start: HashMap<_, _> = groups.iter().map(|g| (g.columns[0].1, g)).collect();
+        let id = StagedId::from_optional_with_presence(
+            source.features.iter().map(|f| f.id),
+            stats.id.as_ref(),
+        );
 
         let mut properties = Vec::with_capacity(source.property_names.len());
         for (col_idx, name) in source.property_names.into_iter().enumerate() {
-            if let Some(g) = group_start.remove(&col_idx) {
-                properties.push(build_shared_dict(g, &mut source.features));
-            } else if !col_to_group.contains_key(&col_idx) {
-                properties.push(build_scalar_column(name, col_idx, &mut source.features));
-            } // else this column is part of a group we already consumed
+            let prop_analysis = stats
+                .properties
+                .get(col_idx)
+                .expect("analysis matches source property columns");
+            match prop_analysis.stats.shared_dict() {
+                SharedDictRole::Owner(group_idx) => {
+                    properties.push(build_shared_dict(
+                        &stats.string_groups[group_idx],
+                        stats,
+                        &mut source.features,
+                    ));
+                }
+                SharedDictRole::Member(_) => {}
+                SharedDictRole::None => {
+                    if let Some(prop) = build_scalar_column(
+                        name,
+                        col_idx,
+                        prop_analysis.presence,
+                        &mut source.features,
+                    ) {
+                        properties.push(prop);
+                    }
+                }
+            }
         }
 
         Self {
@@ -75,15 +82,24 @@ impl StagedLayer {
     }
 }
 
-fn build_scalar_column(name: String, col: usize, features: &mut [TileFeature]) -> StagedProperty {
+fn build_scalar_column(
+    name: String,
+    col: usize,
+    presence: Presence,
+    features: &mut [TileFeature],
+) -> Option<StagedProperty> {
+    if presence == Presence::AllNull {
+        return None;
+    }
+
     // Determine the variant by peeking at the first feature value.
     // Typed nulls (e.g. `PropValue::Bool(None)`) already carry the column type,
     // so no filtering is needed; only a fully-absent column returns `None` here.
     // Fall back to `Str` if every feature has no value for this column.
     let first_val = features.iter().find_map(|f| f.properties.get(col));
 
-    // Collect optional values and check whether any are null. When no nulls
-    // exist, use the non-optional staged variant (no presence stream written).
+    // Presence is precomputed before sort trials; this pass only gathers values
+    // in the selected row order.
     macro_rules! scalar_col {
         ($opt_ctor:ident, $non_opt_ctor:ident, $ty:ty, $sv:ident) => {{
             let opt_values: Vec<Option<$ty>> = features
@@ -96,11 +112,13 @@ fn build_scalar_column(name: String, col: usize, features: &mut [TileFeature]) -
                     }
                 })
                 .collect();
-            if opt_values.iter().any(Option::is_none) {
-                StagedProperty::$opt_ctor(name, opt_values)
-            } else {
-                StagedProperty::$non_opt_ctor(name, opt_values.into_iter().flatten().collect())
-            }
+            Some(match presence {
+                Presence::AllNull => unreachable!("handled before variant dispatch"),
+                Presence::AllPresent => {
+                    StagedProperty::$non_opt_ctor(name, opt_values.into_iter().flatten().collect())
+                }
+                Presence::Mixed => StagedProperty::$opt_ctor(name, opt_values),
+            })
         }};
     }
 
@@ -122,16 +140,20 @@ fn build_scalar_column(name: String, col: usize, features: &mut [TileFeature]) -
                     _ => None,
                 })
                 .collect();
-            if opt_values.iter().any(Option::is_none) {
-                StagedProperty::opt_str(name, opt_values)
-            } else {
-                StagedProperty::str(name, opt_values.into_iter().flatten())
-            }
+            Some(match presence {
+                Presence::AllNull => unreachable!("handled before variant dispatch"),
+                Presence::AllPresent => StagedProperty::str(name, opt_values.into_iter().flatten()),
+                Presence::Mixed => StagedProperty::opt_str(name, opt_values),
+            })
         }
     }
 }
 
-fn build_shared_dict(group: &StringGroup, features: &mut [TileFeature]) -> StagedProperty {
+fn build_shared_dict(
+    group: &StringGroup,
+    analysis: &LayerStats,
+    features: &mut [TileFeature],
+) -> StagedProperty {
     let mut order: Vec<usize> = (0..group.columns.len()).collect();
     order.sort_by_key(|&i| group.columns[i].1);
 
@@ -144,11 +166,13 @@ fn build_shared_dict(group: &StringGroup, features: &mut [TileFeature]) -> Stage
                 _ => None,
             })
             .collect();
-        (suffix.clone(), values)
+        let presence = analysis.properties[*col_idx].presence;
+        (suffix.clone(), values, presence)
     });
 
     StagedProperty::SharedDict(
-        StagedSharedDict::new(group.prefix.clone(), columns).expect("StagedSharedDict succeed"),
+        StagedSharedDict::new_with_presence(group.prefix.clone(), columns)
+            .expect("StagedSharedDict succeed"),
     )
 }
 

--- a/rust/mlt-core/src/encoder/tile.rs
+++ b/rust/mlt-core/src/encoder/tile.rs
@@ -44,8 +44,13 @@ impl StagedLayer {
             stats.id.as_ref(),
         );
 
+        let shared_dict_columns = shared_dict_columns(stats);
         let mut properties = Vec::with_capacity(source.property_names.len());
-        for col_idx in 0..source.property_names.len() {
+        for (col_idx, shared_cols) in shared_dict_columns
+            .iter()
+            .enumerate()
+            .take(source.property_names.len())
+        {
             let prop_analysis = stats
                 .properties
                 .get(col_idx)
@@ -55,6 +60,7 @@ impl StagedLayer {
                     properties.push(build_shared_dict(
                         col_idx,
                         &prefix,
+                        shared_cols,
                         &source.property_names,
                         stats,
                         &mut source.features,
@@ -82,6 +88,18 @@ impl StagedLayer {
             properties,
         }
     }
+}
+
+fn shared_dict_columns(stats: &LayerStats) -> Vec<Vec<usize>> {
+    let mut columns = vec![Vec::new(); stats.properties.len()];
+    for (col_idx, prop) in stats.properties.iter().enumerate() {
+        match prop.stats.shared_dict() {
+            SharedDictRole::Owner(_) => columns[col_idx].push(col_idx),
+            SharedDictRole::Member(owner_col) => columns[owner_col].push(col_idx),
+            SharedDictRole::None => {}
+        }
+    }
+    columns
 }
 
 fn build_scalar_column(
@@ -164,32 +182,25 @@ fn build_scalar_column(
 fn build_shared_dict(
     owner_col: usize,
     prefix: &str,
+    shared_dict_columns: &[usize],
     property_names: &[String],
     analysis: &LayerStats,
     features: &mut [TileFeature],
 ) -> StagedProperty {
-    let columns = analysis
-        .properties
-        .iter()
-        .enumerate()
-        .filter_map(|(col_idx, prop)| match prop.stats.shared_dict() {
-            SharedDictRole::Owner(_) if col_idx == owner_col => Some(col_idx),
-            SharedDictRole::Member(owner) if owner == owner_col => Some(col_idx),
-            _ => None,
-        })
-        .map(|col_idx| {
-            let name = &property_names[col_idx];
-            let suffix = name.strip_prefix(prefix).unwrap_or(name).to_owned();
-            let values: Vec<Option<String>> = features
-                .iter_mut()
-                .map(|f| match f.properties.get_mut(col_idx) {
-                    Some(PropValue::Str(s)) => s.take(),
-                    _ => None,
-                })
-                .collect();
-            let presence = analysis.properties[col_idx].presence;
-            (suffix, values, presence)
-        });
+    debug_assert_eq!(shared_dict_columns.first(), Some(&owner_col));
+    let columns = shared_dict_columns.iter().copied().map(|col_idx| {
+        let name = &property_names[col_idx];
+        let suffix = name.strip_prefix(prefix).unwrap_or(name).to_owned();
+        let values: Vec<Option<String>> = features
+            .iter_mut()
+            .map(|f| match f.properties.get_mut(col_idx) {
+                Some(PropValue::Str(s)) => s.take(),
+                _ => None,
+            })
+            .collect();
+        let presence = analysis.properties[col_idx].presence;
+        (suffix, values, presence)
+    });
 
     StagedProperty::SharedDict(
         StagedSharedDict::new(prefix.to_owned(), columns).expect("StagedSharedDict succeed"),

--- a/rust/mlt-core/src/encoder/tile.rs
+++ b/rust/mlt-core/src/encoder/tile.rs
@@ -102,22 +102,25 @@ fn build_scalar_column(
     // in the selected row order.
     macro_rules! scalar_col {
         ($opt_ctor:ident, $non_opt_ctor:ident, $ty:ty, $sv:ident) => {{
-            let opt_values: Vec<Option<$ty>> = features
-                .iter()
-                .map(|f| {
-                    if let Some(PropValue::$sv(v)) = f.properties.get(col) {
-                        *v
-                    } else {
-                        None
-                    }
-                })
-                .collect();
             Some(match presence {
                 Presence::AllNull => unreachable!("handled before variant dispatch"),
-                Presence::AllPresent => {
-                    StagedProperty::$non_opt_ctor(name, opt_values.into_iter().flatten().collect())
-                }
-                Presence::Mixed => StagedProperty::$opt_ctor(name, opt_values),
+                Presence::AllPresent => StagedProperty::$non_opt_ctor(
+                    name,
+                    features
+                        .iter()
+                        .map(|f| match f.properties.get(col) {
+                            Some(PropValue::$sv(Some(v))) => *v,
+                            _ => unreachable!("analysis guarantees present typed values"),
+                        })
+                        .collect(),
+                ),
+                Presence::Mixed => StagedProperty::$opt_ctor(
+                    name,
+                    features.iter().map(|f| match f.properties.get(col) {
+                        Some(PropValue::$sv(v)) => *v,
+                        _ => None,
+                    }),
+                ),
             })
         }};
     }
@@ -132,20 +135,27 @@ fn build_scalar_column(
         Some(PropValue::U64(_)) => scalar_col!(opt_u64, u64, u64, U64),
         Some(PropValue::F32(_)) => scalar_col!(opt_f32, f32, f32, F32),
         Some(PropValue::F64(_)) => scalar_col!(opt_f64, f64, f64, F64),
-        Some(PropValue::Str(_)) | None => {
-            let opt_values: Vec<Option<String>> = features
-                .iter_mut()
-                .map(|f| match f.properties.get_mut(col) {
-                    Some(PropValue::Str(v)) => v.take(),
-                    _ => None,
-                })
-                .collect();
-            Some(match presence {
-                Presence::AllNull => unreachable!("handled before variant dispatch"),
-                Presence::AllPresent => StagedProperty::str(name, opt_values.into_iter().flatten()),
-                Presence::Mixed => StagedProperty::opt_str(name, opt_values),
-            })
-        }
+        Some(PropValue::Str(_)) | None => Some(match presence {
+            Presence::AllNull => unreachable!("handled before variant dispatch"),
+            Presence::AllPresent => StagedProperty::str(
+                name,
+                features
+                    .iter_mut()
+                    .map(|f| match f.properties.get_mut(col) {
+                        Some(PropValue::Str(Some(v))) => std::mem::take(v),
+                        _ => unreachable!("analysis guarantees present string values"),
+                    }),
+            ),
+            Presence::Mixed => StagedProperty::opt_str(
+                name,
+                features
+                    .iter_mut()
+                    .map(|f| match f.properties.get_mut(col) {
+                        Some(PropValue::Str(v)) => v.take(),
+                        _ => None,
+                    }),
+            ),
+        }),
     }
 }
 

--- a/rust/mlt-core/src/encoder/tile.rs
+++ b/rust/mlt-core/src/encoder/tile.rs
@@ -192,8 +192,7 @@ fn build_shared_dict(
         });
 
     StagedProperty::SharedDict(
-        StagedSharedDict::new_with_presence(prefix.to_owned(), columns)
-            .expect("StagedSharedDict succeed"),
+        StagedSharedDict::new(prefix.to_owned(), columns).expect("StagedSharedDict succeed"),
     )
 }
 

--- a/rust/mlt-core/src/encoder/tile.rs
+++ b/rust/mlt-core/src/encoder/tile.rs
@@ -12,7 +12,7 @@
 use crate::decoder::{GeometryValues, PropValue, TileFeature, TileLayer};
 use crate::encoder::model::StagedLayer;
 use crate::encoder::optimizer::{LayerStats, Presence, SharedDictRole};
-use crate::encoder::{SortStrategy, StagedId, StagedProperty, StagedSharedDict, StringGroup};
+use crate::encoder::{SortStrategy, StagedId, StagedProperty, StagedSharedDict};
 
 impl StagedLayer {
     /// Construct a [`StagedLayer`] from a row-oriented [`TileLayer`] using
@@ -45,15 +45,17 @@ impl StagedLayer {
         );
 
         let mut properties = Vec::with_capacity(source.property_names.len());
-        for (col_idx, name) in source.property_names.into_iter().enumerate() {
+        for col_idx in 0..source.property_names.len() {
             let prop_analysis = stats
                 .properties
                 .get(col_idx)
                 .expect("analysis matches source property columns");
             match prop_analysis.stats.shared_dict() {
-                SharedDictRole::Owner(group_idx) => {
+                SharedDictRole::Owner(prefix) => {
                     properties.push(build_shared_dict(
-                        &stats.string_groups[group_idx],
+                        col_idx,
+                        &prefix,
+                        &source.property_names,
                         stats,
                         &mut source.features,
                     ));
@@ -61,7 +63,7 @@ impl StagedLayer {
                 SharedDictRole::Member(_) => {}
                 SharedDictRole::None => {
                     if let Some(prop) = build_scalar_column(
-                        name,
+                        std::mem::take(&mut source.property_names[col_idx]),
                         col_idx,
                         prop_analysis.presence,
                         &mut source.features,
@@ -160,28 +162,37 @@ fn build_scalar_column(
 }
 
 fn build_shared_dict(
-    group: &StringGroup,
+    owner_col: usize,
+    prefix: &str,
+    property_names: &[String],
     analysis: &LayerStats,
     features: &mut [TileFeature],
 ) -> StagedProperty {
-    let mut order: Vec<usize> = (0..group.columns.len()).collect();
-    order.sort_by_key(|&i| group.columns[i].1);
-
-    let columns = order.into_iter().map(|i| {
-        let (suffix, col_idx) = &group.columns[i];
-        let values: Vec<Option<String>> = features
-            .iter_mut()
-            .map(|f| match f.properties.get_mut(*col_idx) {
-                Some(PropValue::Str(s)) => s.take(),
-                _ => None,
-            })
-            .collect();
-        let presence = analysis.properties[*col_idx].presence;
-        (suffix.clone(), values, presence)
-    });
+    let columns = analysis
+        .properties
+        .iter()
+        .enumerate()
+        .filter_map(|(col_idx, prop)| match prop.stats.shared_dict() {
+            SharedDictRole::Owner(_) if col_idx == owner_col => Some(col_idx),
+            SharedDictRole::Member(owner) if owner == owner_col => Some(col_idx),
+            _ => None,
+        })
+        .map(|col_idx| {
+            let name = &property_names[col_idx];
+            let suffix = name.strip_prefix(prefix).unwrap_or(name).to_owned();
+            let values: Vec<Option<String>> = features
+                .iter_mut()
+                .map(|f| match f.properties.get_mut(col_idx) {
+                    Some(PropValue::Str(s)) => s.take(),
+                    _ => None,
+                })
+                .collect();
+            let presence = analysis.properties[col_idx].presence;
+            (suffix, values, presence)
+        });
 
     StagedProperty::SharedDict(
-        StagedSharedDict::new_with_presence(group.prefix.clone(), columns)
+        StagedSharedDict::new_with_presence(prefix.to_owned(), columns)
             .expect("StagedSharedDict succeed"),
     )
 }

--- a/rust/mlt-core/src/errors.rs
+++ b/rust/mlt-core/src/errors.rs
@@ -102,6 +102,8 @@ pub enum MltError {
     NotImplemented(&'static str),
     #[error("unsupported property value and encoder combination: {0:?} + {1:?}")]
     UnsupportedPropertyEncoderCombination(&'static str, &'static str),
+    #[error("mixed property types are not allowed in one column")]
+    MixedPropertyTypes,
     #[error("shared dictionary requires at least 2 streams, got {0}")]
     SharedDictRequiresStreams(usize),
     #[error("unsupported string stream count (expected between 2 and 5): {0}")]

--- a/rust/mlt-core/src/errors.rs
+++ b/rust/mlt-core/src/errors.rs
@@ -102,8 +102,8 @@ pub enum MltError {
     NotImplemented(&'static str),
     #[error("unsupported property value and encoder combination: {0:?} + {1:?}")]
     UnsupportedPropertyEncoderCombination(&'static str, &'static str),
-    #[error("mixed property types are not allowed in one column")]
-    MixedPropertyTypes,
+    #[error("mixed property types are not allowed in column {0} ({1})")]
+    MixedPropertyTypes(usize, String),
     #[error("shared dictionary requires at least 2 streams, got {0}")]
     SharedDictRequiresStreams(usize),
     #[error("unsupported string stream count (expected between 2 and 5): {0}")]

--- a/rust/mlt-synthetics/src/layer.rs
+++ b/rust/mlt-synthetics/src/layer.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 
 use mlt_core::GeometryValues;
 use mlt_core::encoder::{
-    ColumnKind, Encoder, EncoderConfig, ExplicitEncoder, IntEncoder, StagedId, StagedLayer,
-    StagedProperty, StagedSharedDict, StrEncoding, StreamCtx, VertexBufferType,
+    ColumnKind, Encoder, EncoderConfig, ExplicitEncoder, IntEncoder, Presence, StagedId,
+    StagedLayer, StagedProperty, StagedSharedDict, StrEncoding, StreamCtx, VertexBufferType,
 };
 use mlt_core::geo_types::{Coord, Geometry};
 use mlt_core::wire::{LengthType, OffsetType, StreamType};
@@ -288,21 +288,21 @@ impl Layer {
             .iter()
             .map(|(suffix, enc, _, _)| (suffix.clone(), *enc))
             .collect();
-        let is_optional_flags: Vec<bool> =
-            shared_dict.items.iter().map(|(_, _, _, f)| *f).collect();
-        let mut dict = StagedSharedDict::new(
+        let dict = StagedSharedDict::new(
             shared_dict.name,
             shared_dict
                 .items
                 .into_iter()
-                .map(|(suffix, _, vals, _)| (suffix, vals)),
+                .map(|(suffix, _, vals, is_optional)| {
+                    let presence = if is_optional {
+                        Presence::Mixed
+                    } else {
+                        Presence::AllPresent
+                    };
+                    (suffix, vals, presence)
+                }),
         )
         .expect("shared dict builder should be valid");
-        for (item, is_optional) in dict.items.iter_mut().zip(is_optional_flags) {
-            if is_optional {
-                item.set_presence(true);
-            }
-        }
         self.props.push((
             StagedProperty::SharedDict(dict),
             PropConfig::SharedDict {


### PR DESCRIPTION
The goal is to compute these in addition to the existing string grouping stats:
* presence statistics
* min/max for integers
* in v2 - duplicate presence