### PR TITLE
chore(java): minor API improvements

### DIFF
--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/ColumnMapping.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/ColumnMapping.java
@@ -1,5 +1,6 @@
 package org.maplibre.mlt.converter;
 
+import jakarta.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -79,7 +80,7 @@ public class ColumnMapping {
   }
 
   /// Find a matching column mapping among a collection of mappings grouped by layer name patterns
-  public static ColumnMapping findMapping(
+  public static @Nullable ColumnMapping findMapping(
       ColumnMappingConfig patternMappings, String layerName, String propertyName) {
     return patternMappings.entrySet().stream()
         .filter(entry -> entry.getKey().matcher(layerName).matches())
@@ -90,7 +91,7 @@ public class ColumnMapping {
   }
 
   /// Find a matching column mapping among a collection of mappings
-  public static ColumnMapping findMapping(
+  public static @Nullable ColumnMapping findMapping(
       Collection<ColumnMapping> columnMappings, String propertyName) {
     return columnMappings.stream().filter(m -> m.isMatch(propertyName)).findFirst().orElse(null);
   }

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/MltConverter.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/MltConverter.java
@@ -14,6 +14,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.SequencedCollection;
 import java.util.TreeMap;
 import java.util.function.Function;
@@ -92,7 +93,7 @@ public class MltConverter {
   /// Create tileset metadata from source data
   /// See {@link #createTilesetMetadata(LayerSource, ColumnMappingConfig, boolean)}
   /// @param layerSource The input tile to create metadata from
-  /// @param config Optional configuration
+  /// @param typeMismatchPolicy Policy for handling type mismatches
   /// @param columnMappingConfig Optional column mapping configuration to be applied to all layers
   /// @param includeIdIfPresent Whether to include an ID column
   public static MltMetadata.TileSetMetadata createTilesetMetadata(
@@ -560,8 +561,8 @@ public class MltConverter {
         continue;
       }
 
-      final var featureTableOptimizations =
-          config.optimizations() == null ? null : config.optimizations().get(featureTableName);
+      final var optimizations = Optional.ofNullable(config.optimizations());
+      final var featureTableOptimizations = optimizations.map(opt -> opt.get(featureTableName));
 
       final var createPolygonOutline =
           config.outlineFeatureTableNames().contains(featureTableName)
@@ -634,17 +635,17 @@ public class MltConverter {
     return ByteArrayUtil.concat(targetStream, tileBuffers);
   }
 
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
   private static ArrayList<byte[]> encodePropertyColumns(
       ConversionConfig config,
       MltMetadata.FeatureTable featureTableMetadata,
       SequencedCollection<Feature> sortedFeatures,
-      FeatureTableOptimizations featureTableOptimizations)
+      @NotNull Optional<FeatureTableOptimizations> featureTableOptimizations)
       throws IOException {
     final var propertyColumns = filterPropertyColumns(featureTableMetadata);
-    final List<ColumnMapping> columnMappings =
-        (featureTableOptimizations != null)
-            ? featureTableOptimizations.columnMappings()
-            : List.of();
+    @NotNull
+    final var columnMappings =
+        featureTableOptimizations.map(FeatureTableOptimizations::columnMappings).orElse(List.of());
     return PropertyEncoder.encodePropertyColumns(
         propertyColumns,
         sortedFeatures,
@@ -655,10 +656,11 @@ public class MltConverter {
         config.integerEncodingOption());
   }
 
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
   private static Pair<SequencedCollection<Feature>, GeometryEncoder.EncodedGeometryColumn>
       sortFeaturesAndEncodeGeometryColumn(
           ConversionConfig config,
-          FeatureTableOptimizations featureTableOptimizations,
+          Optional<FeatureTableOptimizations> featureTableOptimizations,
           SequencedCollection<Feature> sortedFeatures,
           SequencedCollection<Feature> sourceFeatures,
           PhysicalLevelTechnique physicalLevelTechnique,
@@ -679,11 +681,12 @@ public class MltConverter {
       throw new IllegalArgumentException("No features to encode");
     }
 
-    var isColumnSortable =
+    final var isColumnSortable =
         config.includeIds()
-            && featureTableOptimizations != null
-            && featureTableOptimizations.allowSorting();
-    if (isColumnSortable && !featureTableOptimizations.allowIdRegeneration()) {
+            && featureTableOptimizations.map(FeatureTableOptimizations::allowSorting).orElse(false);
+    final var allowIdRegeneration =
+        featureTableOptimizations.map(FeatureTableOptimizations::allowIdRegeneration).orElse(false);
+    if (isColumnSortable && !allowIdRegeneration) {
       sortedFeatures = sortFeaturesById(sourceFeatures).toList();
     }
 
@@ -697,8 +700,7 @@ public class MltConverter {
     /* Only sort geometries if ids can be reassigned since sorting the id column turned out
      * to be more efficient in the tests */
     var sortSettings =
-        new GeometryEncoder.SortSettings(
-            isColumnSortable && featureTableOptimizations.allowIdRegeneration(), ids);
+        new GeometryEncoder.SortSettings(isColumnSortable && allowIdRegeneration, ids);
     /* Morton Vertex Dictionary encoding is currently not supported in pre-tessellation */
     var useMortonEncoding = false;
     var geometryEncodingOption = config.geometryEncodingOption();
@@ -731,9 +733,7 @@ public class MltConverter {
               .collect(Collectors.toList());
     }
 
-    if (config.includeIds()
-        && featureTableOptimizations != null
-        && featureTableOptimizations.allowIdRegeneration()) {
+    if (config.includeIds() && allowIdRegeneration) {
       sortedFeatures = generateSequenceIds(sortedFeatures).toList();
     }
 

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/MltTypeMap.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/MltTypeMap.java
@@ -104,20 +104,36 @@ public class MltTypeMap {
     }
 
     public static boolean isID(MltMetadata.Column column) {
-      return column.is(MltMetadata.LogicalScalarType.ID);
+      return isID(column.field().type());
+    }
+
+    public static boolean isID(MltMetadata.FieldType type) {
+      return type.is(MltMetadata.LogicalScalarType.ID);
     }
 
     public static boolean isGeometry(MltMetadata.Column column) {
-      return column.is(MltMetadata.ComplexType.GEOMETRY);
+      return isGeometry(column.field().type());
     }
 
-    static boolean isStruct(MltMetadata.Column column) {
-      return column.is(MltMetadata.ComplexType.STRUCT);
+    public static boolean isGeometry(MltMetadata.FieldType type) {
+      return type.is(MltMetadata.ComplexType.GEOMETRY);
+    }
+
+    public static boolean isStruct(MltMetadata.Column column) {
+      return isStruct(column.field().type());
+    }
+
+    public static boolean isStruct(MltMetadata.FieldType type) {
+      return type.is(MltMetadata.ComplexType.STRUCT);
     }
 
     public static boolean hasStreamCount(MltMetadata.Column column) {
-      if (column.isScalar()) {
-        final var scalar = column.field().type().scalarType();
+      return hasStreamCount(column.field().type());
+    }
+
+    public static boolean hasStreamCount(MltMetadata.FieldType type) {
+      if (type.scalarType() != null) {
+        final var scalar = type.scalarType();
         if (scalar.physicalType() != null) {
           switch (scalar.physicalType()) {
             case BOOLEAN:
@@ -139,8 +155,8 @@ public class MltTypeMap {
             return false;
           }
         }
-      } else if (column.isComplex()) {
-        final var complex = column.field().type().complexType();
+      } else if (type.complexType() != null) {
+        final var complex = type.complexType();
         if (complex.physicalType() != null) {
           switch (complex.physicalType()) {
             case GEOMETRY:

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/PropertyEncoder.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/PropertyEncoder.java
@@ -46,7 +46,7 @@ public class PropertyEncoder {
     final var estimatedBuffers = propertyColumns.size() * 5;
     final var featureScopedPropertyColumns = new ArrayList<byte[]>(estimatedBuffers);
 
-    final var columnMappingsIterator = (columnMappings != null) ? columnMappings.iterator() : null;
+    final var columnMappingsIterator = columnMappings.iterator();
     for (var columnMetadata : propertyColumns) {
       final ArrayList<byte[]> encodedColumn;
       if (columnMetadata.isScalar()) {
@@ -59,7 +59,7 @@ public class PropertyEncoder {
                 physicalLevelTechnique,
                 integerEncodingOption);
       } else if (MltTypeMap.Tag0x01.isStruct(columnMetadata)) {
-        if (columnMappingsIterator == null || !columnMappingsIterator.hasNext()) {
+        if (!columnMappingsIterator.hasNext()) {
           throw new IllegalArgumentException(
               "Missing column mapping for nested property column " + columnMetadata.getName());
         }

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/PropertyEncoder.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/PropertyEncoder.java
@@ -33,7 +33,7 @@ public class PropertyEncoder {
       boolean useFastPFOR,
       boolean useFSST,
       boolean coercePropertyValues,
-      SequencedCollection<ColumnMapping> columnMappings,
+      @Nullable SequencedCollection<ColumnMapping> columnMappings,
       @NotNull ConversionConfig.IntegerEncodingOption integerEncodingOption)
       throws IOException {
     /*
@@ -46,7 +46,7 @@ public class PropertyEncoder {
     final var estimatedBuffers = propertyColumns.size() * 5;
     final var featureScopedPropertyColumns = new ArrayList<byte[]>(estimatedBuffers);
 
-    final var columnMappingsIterator = columnMappings.iterator();
+    final var columnMappingsIterator = (columnMappings != null) ? columnMappings.iterator() : null;
     for (var columnMetadata : propertyColumns) {
       final ArrayList<byte[]> encodedColumn;
       if (columnMetadata.isScalar()) {
@@ -59,7 +59,7 @@ public class PropertyEncoder {
                 physicalLevelTechnique,
                 integerEncodingOption);
       } else if (MltTypeMap.Tag0x01.isStruct(columnMetadata)) {
-        if (!columnMappingsIterator.hasNext()) {
+        if (columnMappingsIterator == null || !columnMappingsIterator.hasNext()) {
           throw new IllegalArgumentException(
               "Missing column mapping for nested property column " + columnMetadata.getName());
         }


### PR DESCRIPTION
Adds some convenience overloads and allows for nulls instead of empty lists for column mappings on non-struct columns.  I noticed the need for these while integrating #1176 in Planetiler.
