### PR TITLE
chore(rust): simplify encoding

### DIFF
--- a/rust/mlt-core/src/codecs/fsst.rs
+++ b/rust/mlt-core/src/codecs/fsst.rs
@@ -140,9 +140,7 @@ mod tests {
     use super::*;
     use crate::decoder::{DictionaryType, LengthType, RawFsstData, RawStream, StreamType};
     use crate::encoder::model::StreamCtx;
-    use crate::encoder::{
-        Codecs, EncodedStream, Encoder, ExplicitEncoder, IntEncoder, write_int_stream,
-    };
+    use crate::encoder::{Codecs, EncodedStream, Encoder, ExplicitEncoder, IntEncoder};
     use crate::test_helpers::{assert_empty, dec, parser};
     use crate::utils::BinarySerializer as _;
 
@@ -156,9 +154,11 @@ mod tests {
                 Encoder::default().cfg,
                 ExplicitEncoder::all(IntEncoder::varint()),
             );
-            let codecs = &mut Codecs::default();
+            let mut codecs = Codecs::default();
             let ctx = StreamCtx::prop(StreamType::Length(LengthType::Symbol), "symbol");
-            write_int_stream::<[u32]>(&raw.symbol_lengths, &ctx, &mut enc, codecs).unwrap();
+            codecs
+                .write_int_stream(&raw.symbol_lengths, &ctx, &mut enc)
+                .unwrap();
             enc.data
         };
         let sym_table_stream = EncodedStream {
@@ -174,9 +174,11 @@ mod tests {
                 Encoder::default().cfg,
                 ExplicitEncoder::all(IntEncoder::varint()),
             );
-            let codecs = &mut Codecs::default();
+            let mut codecs = Codecs::default();
             let ctx = StreamCtx::prop(StreamType::Length(LengthType::Dictionary), "dictionary");
-            write_int_stream::<[u32]>(&raw.value_lengths, &ctx, &mut enc, codecs).unwrap();
+            codecs
+                .write_int_stream(&raw.value_lengths, &ctx, &mut enc)
+                .unwrap();
             enc.data
         };
         let corpus_stream = EncodedStream {

--- a/rust/mlt-core/src/encoder/analyze.rs
+++ b/rust/mlt-core/src/encoder/analyze.rs
@@ -1,7 +1,11 @@
-use crate::decoder::{ParsedScalar, ParsedSharedDict, ParsedStrings, StreamMeta};
+#[cfg(any(test, feature = "__private"))]
+use crate::decoder::StreamMeta;
+use crate::decoder::{ParsedScalar, ParsedSharedDict, ParsedStrings};
+#[cfg(any(test, feature = "__private"))]
 use crate::encoder::EncodedStream;
 use crate::{Analyze, StatType};
 
+#[cfg(any(test, feature = "__private"))]
 impl Analyze for EncodedStream {
     fn for_each_stream(&self, cb: &mut dyn FnMut(StreamMeta)) {
         cb(self.meta);

--- a/rust/mlt-core/src/encoder/geometry/encode.rs
+++ b/rust/mlt-core/src/encoder/geometry/encode.rs
@@ -15,10 +15,7 @@ use crate::decoder::{
     OffsetType, PhysicalEncoding, StreamMeta, StreamType,
 };
 use crate::encoder::model::{CurveParams, StreamCtx};
-use crate::encoder::{
-    Codecs, Encoder, PhysicalCodecs, PhysicalEncoder, PhysicalIntStreamKind, U32Physical,
-    write_int_stream, write_stream_payload,
-};
+use crate::encoder::{Codecs, Encoder, PhysicalCodecs, write_stream_payload};
 use crate::utils::AsUsize as _;
 
 /// Compute `ZOrderCurve` parameters from the vertex value range.
@@ -481,7 +478,7 @@ fn write_geo_u32_stream(
     Ok(if data.is_empty() && !enc.force_stream(&ctx) {
         0
     } else {
-        write_int_stream::<[u32]>(data, &ctx, enc, codecs)?;
+        codecs.write_int_stream(data, &ctx, enc)?;
         1
     })
 }
@@ -497,26 +494,28 @@ fn write_geo_precomputed_stream(
     enc: &mut Encoder,
     physical: &mut PhysicalCodecs,
 ) -> MltResult<u8> {
+    use PhysicalEncoding as PE;
+
     Ok(if data.is_empty() && !enc.force_stream(&ctx) {
         0
     } else {
         if let Some(int_enc) = enc.override_int_enc(&ctx) {
-            let stream_type = ctx.stream_type;
-            let (phys, vals) = U32Physical::encode_physical(physical, data, int_enc.physical)?;
-            let meta = StreamMeta::new2(stream_type, logical, phys, data.len())?;
-            write_stream_payload(&mut enc.data, meta, false, vals)?;
+            physical.write_encoded_as::<[u32]>(&ctx, enc, logical, data, int_enc.physical)?;
         } else if data.is_empty() {
-            let meta = StreamMeta::new2(ctx.stream_type, logical, PhysicalEncoding::None, 0)?;
+            let meta = StreamMeta::new2(ctx.stream_type, logical, PE::None, 0)?;
             write_stream_payload(&mut enc.data, meta, false, &[])?;
         } else {
             let mut alt = enc.try_alternatives();
-            for physical_enc in [PhysicalEncoder::FastPFOR, PhysicalEncoder::VarInt] {
-                alt.with(|enc| {
-                    let (phys, vals) = U32Physical::encode_physical(physical, data, physical_enc)?;
-                    let meta = StreamMeta::new2(ctx.stream_type, logical, phys, data.len())?;
-                    write_stream_payload(&mut enc.data, meta, false, vals)
-                })?;
-            }
+            alt.with(|enc| {
+                let vals = physical.fastpfor(data)?;
+                let meta = StreamMeta::new2(ctx.stream_type, logical, PE::FastPFor256, data.len())?;
+                write_stream_payload(&mut enc.data, meta, false, vals)
+            })?;
+            alt.with(|enc| {
+                let vals = physical.varint(data);
+                let meta = StreamMeta::new2(ctx.stream_type, logical, PE::VarInt, data.len())?;
+                write_stream_payload(&mut enc.data, meta, false, vals)
+            })?;
         }
         1
     })
@@ -580,7 +579,7 @@ impl GeometryValues {
 
         // Meta stream — always written, even for a zero-feature layer.
         let ctx = StreamCtx::geom(StreamType::Length(LengthType::VarBinary), "meta");
-        write_int_stream::<[u32]>(&meta, &ctx, enc, codecs)?;
+        codecs.write_int_stream(&meta, &ctx, enc)?;
         n += 1;
 
         // Topology: compute each length stream and write it immediately.

--- a/rust/mlt-core/src/encoder/geometry/geotype.rs
+++ b/rust/mlt-core/src/encoder/geometry/geotype.rs
@@ -288,9 +288,7 @@ mod tests {
         StreamMeta, StreamType,
     };
     use crate::encoder::model::StreamCtx;
-    use crate::encoder::{
-        Codecs, EncodedStream, Encoder, ExplicitEncoder, IntEncoder, write_int_stream,
-    };
+    use crate::encoder::{Codecs, EncodedStream, Encoder, ExplicitEncoder, IntEncoder};
     use crate::test_helpers::{assert_empty, dec, parser};
     use crate::utils::BinarySerializer as _;
 
@@ -595,27 +593,27 @@ mod tests {
             ExplicitEncoder::all(IntEncoder::varint()),
         );
         enc.write_varint(4u32).unwrap();
-        write_int_stream::<[u32]>(
-            &[GeometryType::LineString as u32],
-            &StreamCtx::geom(StreamType::Length(LengthType::VarBinary), "meta"),
-            &mut enc,
-            &mut codecs,
-        )
-        .unwrap();
-        write_int_stream::<[u32]>(
-            &[4u32],
-            &StreamCtx::geom(StreamType::Length(LengthType::Parts), "parts"),
-            &mut enc,
-            &mut codecs,
-        )
-        .unwrap();
-        write_int_stream::<[u32]>(
-            &[0u32, 1, 2, 1],
-            &StreamCtx::geom(StreamType::Offset(OffsetType::Vertex), "vertex"),
-            &mut enc,
-            &mut codecs,
-        )
-        .unwrap();
+        codecs
+            .write_int_stream(
+                &[GeometryType::LineString as u32],
+                &StreamCtx::geom(StreamType::Length(LengthType::VarBinary), "meta"),
+                &mut enc,
+            )
+            .unwrap();
+        codecs
+            .write_int_stream(
+                &[4u32],
+                &StreamCtx::geom(StreamType::Length(LengthType::Parts), "parts"),
+                &mut enc,
+            )
+            .unwrap();
+        codecs
+            .write_int_stream(
+                &[0u32, 1, 2, 1],
+                &StreamCtx::geom(StreamType::Offset(OffsetType::Vertex), "vertex"),
+                &mut enc,
+            )
+            .unwrap();
         enc.write_stream(&morton_dict).unwrap();
         let buffer = enc.data;
 

--- a/rust/mlt-core/src/encoder/model.rs
+++ b/rust/mlt-core/src/encoder/model.rs
@@ -1,6 +1,6 @@
 use derive_debug::Dbg;
 
-use crate::decoder::{GeometryValues, StreamType};
+use crate::decoder::{DictionaryType, GeometryValues, StreamType};
 use crate::encoder::geometry::VertexBufferType;
 use crate::encoder::{IntEncoder, StagedId, StagedProperty};
 
@@ -154,6 +154,13 @@ impl<'a> StreamCtx<'a> {
     #[inline]
     #[must_use]
     pub const fn prop(stream_type: StreamType, name: &'a str) -> Self {
+        Self::new(ColumnKind::Property, stream_type, name, "")
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn prop_data(name: &'a str) -> Self {
+        let stream_type = StreamType::Data(DictionaryType::None);
         Self::new(ColumnKind::Property, stream_type, name, "")
     }
 

--- a/rust/mlt-core/src/encoder/property/encode.rs
+++ b/rust/mlt-core/src/encoder/property/encode.rs
@@ -4,7 +4,6 @@ use crate::MltResult;
 use crate::decoder::{ColumnType, DictionaryType, StreamType};
 use crate::encoder::model::StreamCtx;
 use crate::encoder::property::shared_dict::write_shared_dict;
-use crate::encoder::stream::{write_bool_stream, write_int_stream};
 use crate::encoder::{Codecs, EncodedStream, Encoder, StagedScalar, StagedStrings};
 use crate::utils::BinarySerializer as _;
 
@@ -33,25 +32,19 @@ fn write_prop(prop: &StagedProperty, enc: &mut Encoder, codecs: &mut Codecs) -> 
         D::Bool(v) => {
             enc.write_column_header(CT::Bool, &v.name)?;
             let values = v.values.iter().copied();
-            write_bool_stream(values, StreamType::Data(DictionaryType::None), enc, codecs)?;
+            codecs.write_bool_stream(values, StreamType::Data(DictionaryType::None), enc)?;
         }
         D::OptBool(v) => {
-            begin_opt_col(
-                CT::OptBool,
-                &v.name,
-                v.presence.iter().copied(),
-                enc,
-                codecs,
-            )?;
+            begin_opt_col(CT::OptBool, &v.name, &v.presence, enc, codecs)?;
             let values = v.values.iter().copied();
-            write_bool_stream(values, StreamType::Data(DictionaryType::None), enc, codecs)?;
+            codecs.write_bool_stream(values, StreamType::Data(DictionaryType::None), enc)?;
         }
         D::F32(v) => {
             enc.write_column_header(CT::F32, &v.name)?;
             enc.write_stream(&EncodedStream::encode_f32(&v.values)?)?;
         }
         D::OptF32(v) => {
-            begin_opt_col(CT::OptF32, &v.name, v.presence.iter().copied(), enc, codecs)?;
+            begin_opt_col(CT::OptF32, &v.name, &v.presence, enc, codecs)?;
             enc.write_stream(&EncodedStream::encode_f32(&v.values)?)?;
         }
         D::F64(v) => {
@@ -59,54 +52,42 @@ fn write_prop(prop: &StagedProperty, enc: &mut Encoder, codecs: &mut Codecs) -> 
             enc.write_stream(&EncodedStream::encode_f64(&v.values)?)?;
         }
         D::OptF64(v) => {
-            begin_opt_col(CT::OptF64, &v.name, v.presence.iter().copied(), enc, codecs)?;
+            begin_opt_col(CT::OptF64, &v.name, &v.presence, enc, codecs)?;
             enc.write_stream(&EncodedStream::encode_f64(&v.values)?)?;
         }
         D::I8(v) => {
             enc.write_column_header(CT::I8, &v.name)?;
-            let widened: Vec<i32> = v.values.iter().map(|&x| i32::from(x)).collect();
-            let ctx = StreamCtx::prop(StreamType::Data(DictionaryType::None), &v.name);
-            write_int_stream::<[i32]>(&widened, &ctx, enc, codecs)?;
+            codecs.write_int_stream(&v.values, &StreamCtx::prop_data(&v.name), enc)?;
         }
         D::OptI8(v) => {
-            begin_opt_col(CT::OptI8, &v.name, v.presence.iter().copied(), enc, codecs)?;
-            let widened: Vec<i32> = v.values.iter().map(|&x| i32::from(x)).collect();
-            let ctx = StreamCtx::prop(StreamType::Data(DictionaryType::None), &v.name);
-            write_int_stream::<[i32]>(&widened, &ctx, enc, codecs)?;
+            begin_opt_col(CT::OptI8, &v.name, &v.presence, enc, codecs)?;
+            codecs.write_int_stream(&v.values, &StreamCtx::prop_data(&v.name), enc)?;
         }
         D::U8(v) => {
             enc.write_column_header(CT::U8, &v.name)?;
-            let widened: Vec<u32> = v.values.iter().map(|&x| u32::from(x)).collect();
-            let ctx = StreamCtx::prop(StreamType::Data(DictionaryType::None), &v.name);
-            write_int_stream::<[u32]>(&widened, &ctx, enc, codecs)?;
+            codecs.write_int_stream(&v.values, &StreamCtx::prop_data(&v.name), enc)?;
         }
         D::OptU8(v) => {
-            begin_opt_col(CT::OptU8, &v.name, v.presence.iter().copied(), enc, codecs)?;
-            let widened: Vec<u32> = v.values.iter().map(|&x| u32::from(x)).collect();
-            let ctx = StreamCtx::prop(StreamType::Data(DictionaryType::None), &v.name);
-            write_int_stream::<[u32]>(&widened, &ctx, enc, codecs)?;
+            begin_opt_col(CT::OptU8, &v.name, &v.presence, enc, codecs)?;
+            codecs.write_int_stream(&v.values, &StreamCtx::prop_data(&v.name), enc)?;
         }
         D::I32(v) => {
             enc.write_column_header(CT::I32, &v.name)?;
-            let ctx = StreamCtx::prop(StreamType::Data(DictionaryType::None), &v.name);
-            write_int_stream::<[i32]>(&v.values, &ctx, enc, codecs)?;
+            codecs.write_int_stream(&v.values, &StreamCtx::prop_data(&v.name), enc)?;
         }
         D::OptI32(v) => {
-            begin_opt_col(CT::OptI32, &v.name, v.presence.iter().copied(), enc, codecs)?;
-            let ctx = StreamCtx::prop(StreamType::Data(DictionaryType::None), &v.name);
-            write_int_stream::<[i32]>(&v.values, &ctx, enc, codecs)?;
+            begin_opt_col(CT::OptI32, &v.name, &v.presence, enc, codecs)?;
+            codecs.write_int_stream(&v.values, &StreamCtx::prop_data(&v.name), enc)?;
         }
         D::U32(v) => write_u32_scalar_col(CT::U32, Some(&v.name), v, enc, codecs)?,
         D::OptU32(v) => write_opt_u32_scalar_col(CT::OptU32, Some(&v.name), v, enc, codecs)?,
         D::I64(v) => {
             enc.write_column_header(CT::I64, &v.name)?;
-            let ctx = StreamCtx::prop(StreamType::Data(DictionaryType::None), &v.name);
-            write_int_stream::<[i64]>(&v.values, &ctx, enc, codecs)?;
+            codecs.write_int_stream(&v.values, &StreamCtx::prop_data(&v.name), enc)?;
         }
         D::OptI64(v) => {
-            begin_opt_col(CT::OptI64, &v.name, v.presence.iter().copied(), enc, codecs)?;
-            let ctx = StreamCtx::prop(StreamType::Data(DictionaryType::None), &v.name);
-            write_int_stream::<[i64]>(&v.values, &ctx, enc, codecs)?;
+            begin_opt_col(CT::OptI64, &v.name, &v.presence, enc, codecs)?;
+            codecs.write_int_stream(&v.values, &StreamCtx::prop_data(&v.name), enc)?;
         }
         D::U64(v) => write_u64_scalar_col(CT::U64, Some(&v.name), v, enc, codecs)?,
         D::OptU64(v) => write_opt_u64_scalar_col(CT::OptU64, Some(&v.name), v, enc, codecs)?,
@@ -132,12 +113,12 @@ fn write_prop(prop: &StagedProperty, enc: &mut Encoder, codecs: &mut Codecs) -> 
 fn begin_opt_col(
     ct: ColumnType,
     name: &str,
-    presence_bools: impl ExactSizeIterator<Item = bool>,
+    presence: &[bool],
     enc: &mut Encoder,
     codecs: &mut Codecs,
 ) -> MltResult<()> {
     enc.write_column_header(ct, name)?;
-    write_bool_stream(presence_bools, StreamType::Present, enc, codecs)
+    codecs.write_presence_stream(presence.iter().copied(), enc)
 }
 
 pub(crate) fn write_u32_scalar_col(
@@ -148,7 +129,7 @@ pub(crate) fn write_u32_scalar_col(
     codecs: &mut Codecs,
 ) -> MltResult<()> {
     begin_scalar_col(ct, name, enc)?;
-    write_int_stream::<[u32]>(&v.values, &scalar_ctx(name), enc, codecs)
+    codecs.write_int_stream(&v.values, &scalar_ctx(name), enc)
 }
 
 pub(crate) fn write_opt_u32_scalar_col(
@@ -159,8 +140,8 @@ pub(crate) fn write_opt_u32_scalar_col(
     codecs: &mut Codecs,
 ) -> MltResult<()> {
     begin_scalar_col(ct, name, enc)?;
-    write_bool_stream(v.presence.iter().copied(), StreamType::Present, enc, codecs)?;
-    write_int_stream::<[u32]>(&v.values, &scalar_ctx(name), enc, codecs)
+    codecs.write_presence_stream(v.presence.iter().copied(), enc)?;
+    codecs.write_int_stream(&v.values, &scalar_ctx(name), enc)
 }
 
 pub(crate) fn write_u64_scalar_col(
@@ -171,7 +152,7 @@ pub(crate) fn write_u64_scalar_col(
     codecs: &mut Codecs,
 ) -> MltResult<()> {
     begin_scalar_col(ct, name, enc)?;
-    write_int_stream::<[u64]>(&v.values, &scalar_ctx(name), enc, codecs)
+    codecs.write_int_stream(&v.values, &scalar_ctx(name), enc)
 }
 
 pub(crate) fn write_opt_u64_scalar_col(
@@ -183,8 +164,8 @@ pub(crate) fn write_opt_u64_scalar_col(
 ) -> MltResult<()> {
     let presence_bools = v.presence.iter().copied();
     begin_scalar_col(ct, name, enc)?;
-    write_bool_stream(presence_bools, StreamType::Present, enc, codecs)?;
-    write_int_stream::<[u64]>(&v.values, &scalar_ctx(name), enc, codecs)
+    codecs.write_presence_stream(presence_bools, enc)?;
+    codecs.write_int_stream(&v.values, &scalar_ctx(name), enc)
 }
 
 fn begin_scalar_col(ct: ColumnType, name: Option<&str>, enc: &mut Encoder) -> MltResult<()> {
@@ -197,7 +178,7 @@ fn begin_scalar_col(ct: ColumnType, name: Option<&str>, enc: &mut Encoder) -> Ml
 
 fn scalar_ctx(name: Option<&str>) -> StreamCtx<'_> {
     match name {
-        Some(name) => StreamCtx::prop(StreamType::Data(DictionaryType::None), name),
+        Some(name) => StreamCtx::prop_data(name),
         None => StreamCtx::id(StreamType::Data(DictionaryType::None)),
     }
 }

--- a/rust/mlt-core/src/encoder/property/encode.rs
+++ b/rust/mlt-core/src/encoder/property/encode.rs
@@ -4,8 +4,7 @@ use crate::MltResult;
 use crate::decoder::{ColumnType, DictionaryType, StreamType};
 use crate::encoder::model::StreamCtx;
 use crate::encoder::property::shared_dict::write_shared_dict;
-use crate::encoder::{Codecs, EncodedStream, Encoder, StagedScalar, StagedStrings};
-use crate::utils::BinarySerializer as _;
+use crate::encoder::{Codecs, Encoder, StagedScalar, StagedStrings};
 
 /// Encode all property columns and write them to `enc`.
 #[hotpath::measure]
@@ -41,19 +40,19 @@ fn write_prop(prop: &StagedProperty, enc: &mut Encoder, codecs: &mut Codecs) -> 
         }
         D::F32(v) => {
             enc.write_column_header(CT::F32, &v.name)?;
-            enc.write_stream(&EncodedStream::encode_f32(&v.values)?)?;
+            codecs.write_float_stream(&v.values, StreamType::Data(DictionaryType::None), enc)?;
         }
         D::OptF32(v) => {
             begin_opt_col(CT::OptF32, &v.name, &v.presence, enc, codecs)?;
-            enc.write_stream(&EncodedStream::encode_f32(&v.values)?)?;
+            codecs.write_float_stream(&v.values, StreamType::Data(DictionaryType::None), enc)?;
         }
         D::F64(v) => {
             enc.write_column_header(CT::F64, &v.name)?;
-            enc.write_stream(&EncodedStream::encode_f64(&v.values)?)?;
+            codecs.write_float_stream(&v.values, StreamType::Data(DictionaryType::None), enc)?;
         }
         D::OptF64(v) => {
             begin_opt_col(CT::OptF64, &v.name, &v.presence, enc, codecs)?;
-            enc.write_stream(&EncodedStream::encode_f64(&v.values)?)?;
+            codecs.write_float_stream(&v.values, StreamType::Data(DictionaryType::None), enc)?;
         }
         D::I8(v) => {
             enc.write_column_header(CT::I8, &v.name)?;

--- a/rust/mlt-core/src/encoder/property/shared_dict.rs
+++ b/rust/mlt-core/src/encoder/property/shared_dict.rs
@@ -15,9 +15,7 @@ use crate::decoder::{PropValue, TileLayer};
 use crate::encoder::model::{StrEncoding, StreamCtx};
 use crate::encoder::optimizer::{Presence, PropertyStats, SharedDictRole};
 use crate::encoder::property::strings::{fsst_try_train, write_fsst_data, write_raw_str_data};
-use crate::encoder::{
-    Codecs, Encoder, StagedSharedDict, StagedSharedDictItem, write_bool_stream, write_int_stream,
-};
+use crate::encoder::{Codecs, Encoder, StagedSharedDict, StagedSharedDictItem};
 use crate::errors::AsMltError as _;
 use crate::utils::{AsUsize as _, checked_sum3, strings_to_lengths};
 use crate::{ColumnType, DictRange, DictionaryType, LengthType, MltResult, OffsetType, StreamType};
@@ -369,7 +367,7 @@ pub(crate) fn write_shared_dict(
         let lengths = strings_to_lengths(&dict)?;
         let typ = StreamType::Length(LengthType::Dictionary);
         let ctx = StreamCtx::prop(typ, &shared_dict.prefix);
-        write_int_stream::<[u32]>(&lengths, &ctx, enc, codecs)?;
+        codecs.write_int_stream(&lengths, &ctx, enc)?;
         write_raw_str_data(&dict, DictionaryType::Shared, enc)?;
     }
 
@@ -380,7 +378,7 @@ pub(crate) fn write_shared_dict(
         if item.has_presence() {
             enc.write_varint(2u32)?;
             enc.write_column_type(ColumnType::OptStr)?;
-            write_bool_stream(item.presence_bools(), StreamType::Present, enc, codecs)?;
+            codecs.write_presence_stream(item.presence_bools(), enc)?;
         } else {
             enc.write_varint(1u32)?;
             enc.write_column_type(ColumnType::Str)?;
@@ -398,7 +396,7 @@ pub(crate) fn write_shared_dict(
             .collect::<Result<_, _>>()?;
         let typ = StreamType::Offset(OffsetType::String);
         let ctx = StreamCtx::prop2(typ, &shared_dict.prefix, &item.suffix);
-        write_int_stream::<[u32]>(&offsets, &ctx, enc, codecs)?;
+        codecs.write_int_stream(&offsets, &ctx, enc)?;
     }
 
     enc.increment_column_count();

--- a/rust/mlt-core/src/encoder/property/strings.rs
+++ b/rust/mlt-core/src/encoder/property/strings.rs
@@ -7,8 +7,8 @@ use crate::codecs::fsst::{FsstRawData, compress_fsst, compress_fsst_with};
 use crate::decoder::strings::{checked_string_end, encode_null_end};
 use crate::decoder::{DictionaryType, LengthType, OffsetType, StreamMeta, StreamType};
 use crate::encoder::model::{StrEncoding, StreamCtx};
-use crate::encoder::stream::{dedup_strings, write_bool_stream, write_stream_payload};
-use crate::encoder::{Codecs, Encoder, write_int_stream};
+use crate::encoder::stream::{dedup_strings, write_stream_payload};
+use crate::encoder::{Codecs, Encoder};
 use crate::utils::{AsUsize as _, strings_to_lengths};
 
 /// Minimum total raw byte size of a column before attempting FSST compression.
@@ -117,7 +117,7 @@ pub(crate) fn write_str_col(
 /// Encode with plain (`VarBinary` lengths) layout.
 ///
 /// Stream count varint is written first, then presence, then the lengths stream
-/// (via [`write_int_stream`] which handles the explicit/auto dispatch internally),
+/// (via [`Codecs::write_int_stream`] which handles the explicit/auto dispatch internally),
 /// then the raw string bytes as a plain unencoded data stream.
 #[hotpath::measure]
 fn write_str_plain(
@@ -131,7 +131,7 @@ fn write_str_plain(
     enc.write_varint(2u32 + u32::from(presence.is_some()))?;
     write_presence_stream(presence, enc, codecs)?;
     let ctx = StreamCtx::prop(StreamType::Length(LengthType::VarBinary), name);
-    write_int_stream::<[u32]>(&lengths, &ctx, enc, codecs)?;
+    codecs.write_int_stream(&lengths, &ctx, enc)?;
     write_raw_str_data(non_null, DictionaryType::None, enc)
 }
 
@@ -162,10 +162,10 @@ fn write_str_dict_raw(
     write_presence_stream(presence, enc, codecs)?;
 
     let ctx = StreamCtx::prop(StreamType::Length(LengthType::Dictionary), name);
-    write_int_stream::<[u32]>(&lengths, &ctx, enc, codecs)?;
+    codecs.write_int_stream(&lengths, &ctx, enc)?;
 
     let ctx = StreamCtx::prop(StreamType::Offset(OffsetType::String), name);
-    write_int_stream::<[u32]>(offset_indices, &ctx, enc, codecs)?;
+    codecs.write_int_stream(offset_indices, &ctx, enc)?;
     write_raw_str_data(unique, DictionaryType::Single, enc)
 }
 
@@ -198,7 +198,7 @@ fn write_str_fsst_raw(
     write_presence_stream(presence, enc, codecs)?;
     write_fsst_data(raw, DictionaryType::Single, name, enc, codecs)?;
     let ctx = StreamCtx::prop(StreamType::Offset(OffsetType::String), name);
-    write_int_stream::<[u32]>(&offsets, &ctx, enc, codecs)
+    codecs.write_int_stream(&offsets, &ctx, enc)
 }
 
 /// Encode with FSST + dictionary layout, training a fresh compressor.
@@ -230,7 +230,7 @@ fn write_str_fsst_dict_raw(
     write_presence_stream(presence, enc, codecs)?;
     write_fsst_data(raw, DictionaryType::Single, name, enc, codecs)?;
     let ctx = StreamCtx::prop(StreamType::Offset(OffsetType::String), name);
-    write_int_stream::<[u32]>(offset_indices, &ctx, enc, codecs)
+    codecs.write_int_stream(offset_indices, &ctx, enc)
 }
 
 fn write_presence_stream(
@@ -239,14 +239,14 @@ fn write_presence_stream(
     codecs: &mut Codecs,
 ) -> MltResult<()> {
     if let Some(strings) = presence {
-        write_bool_stream(strings.presence_bools(), StreamType::Present, enc, codecs)?;
+        codecs.write_presence_stream(strings.presence_bools(), enc)?;
     }
     Ok(())
 }
 
 /// Write 4 FSST sub-streams directly to `enc.data`.
 ///
-/// The two integer sub-streams (`symbol_lengths`, `value_lengths`) use [`write_int_stream`]
+/// The two integer sub-streams (`symbol_lengths`, `value_lengths`) use [`Codecs::write_int_stream`]
 /// so explicit encoder overrides are honored and all candidates are competed automatically.
 /// The two raw-byte sub-streams (`symbol_table`, `corpus`) are written without integer encoding.
 ///
@@ -260,12 +260,12 @@ pub fn write_fsst_data(
     codecs: &mut Codecs,
 ) -> MltResult<()> {
     let ctx = StreamCtx::prop(StreamType::Length(LengthType::Symbol), name);
-    write_int_stream::<[u32]>(&raw.symbol_lengths, &ctx, enc, codecs)?;
+    codecs.write_int_stream(&raw.symbol_lengths, &ctx, enc)?;
     let typ = StreamType::Data(DictionaryType::Fsst);
     let meta = StreamMeta::new_none(typ, raw.symbol_lengths.len())?;
     write_stream_payload(&mut enc.data, meta, false, &raw.symbol_bytes)?;
     let ctx = StreamCtx::prop(StreamType::Length(LengthType::Dictionary), name);
-    write_int_stream::<[u32]>(&raw.value_lengths, &ctx, enc, codecs)?;
+    codecs.write_int_stream(&raw.value_lengths, &ctx, enc)?;
     let meta = StreamMeta::new_none(StreamType::Data(dict_type), raw.value_lengths.len())?;
     write_stream_payload(&mut enc.data, meta, false, &raw.corpus)?;
     Ok(())

--- a/rust/mlt-core/src/encoder/stream/codecs.rs
+++ b/rust/mlt-core/src/encoder/stream/codecs.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use bytemuck::{NoUninit, cast_slice};
 use fastpfor::FastPFor256;
 use num_traits::WrappingSub;
 use zigzag::ZigZag;
@@ -83,6 +84,23 @@ impl Codecs {
         enc: &mut Encoder,
     ) -> MltResult<()> {
         self.write_bool_stream(values, StreamType::Present, enc)
+    }
+
+    #[expect(
+        clippy::unused_self,
+        reason = "kept as a Codecs method to match the other stream writers"
+    )]
+    pub(crate) fn write_float_stream<T: NoUninit>(
+        &mut self,
+        values: &[T],
+        stream_type: StreamType,
+        enc: &mut Encoder,
+    ) -> MltResult<()> {
+        #[cfg(not(target_endian = "little"))]
+        compile_error!("not implemented for non-little-endian targets");
+
+        let meta = StreamMeta::new_none(stream_type, values.len())?;
+        encoder::write_stream_payload(&mut enc.data, meta, false, cast_slice(values))
     }
 
     pub(crate) fn write_int_stream<T>(

--- a/rust/mlt-core/src/encoder/stream/codecs.rs
+++ b/rust/mlt-core/src/encoder/stream/codecs.rs
@@ -1,10 +1,18 @@
 use std::collections::HashMap;
 
 use fastpfor::FastPFor256;
+use num_traits::WrappingSub;
+use zigzag::ZigZag;
 
 use crate::codecs::bytes::encode_bools_to_bytes;
 use crate::codecs::rle::encode_byte_rle;
-use crate::decoder::{LogicalEncoding, RleMeta};
+use crate::decoder::{LogicalEncoding, PhysicalEncoding, RleMeta, StreamMeta, StreamType};
+use crate::encoder;
+use crate::encoder::Encoder;
+use crate::encoder::model::StreamCtx;
+use crate::encoder::stream::logical::LogicalEncoder;
+use crate::encoder::stream::optimizer::DataProfile;
+use crate::encoder::write::{LogicalIntCodec, LogicalIntStreamKind, PhysicalIntStreamKind};
 use crate::errors::MltResult;
 
 #[derive(Default)]
@@ -53,5 +61,103 @@ impl LogicalCodecs {
             num_rle_values: u32::try_from(encoded.len())?,
         });
         Ok((meta, encoded))
+    }
+}
+
+impl Codecs {
+    pub(crate) fn write_bool_stream(
+        &mut self,
+        values: impl ExactSizeIterator<Item = bool>,
+        stream_type: StreamType,
+        enc: &mut Encoder,
+    ) -> MltResult<()> {
+        let num_values = values.len();
+        let (logical, vals) = self.logical.encode_bools(values)?;
+        let meta = StreamMeta::new2(stream_type, logical, PhysicalEncoding::None, num_values)?;
+        encoder::write_stream_payload(&mut enc.data, meta, true, vals)
+    }
+
+    pub(crate) fn write_presence_stream(
+        &mut self,
+        values: impl ExactSizeIterator<Item = bool>,
+        enc: &mut Encoder,
+    ) -> MltResult<()> {
+        self.write_bool_stream(values, StreamType::Present, enc)
+    }
+
+    pub(crate) fn write_int_stream<T>(
+        &mut self,
+        values: &[T],
+        ctx: &StreamCtx<'_>,
+        enc: &mut Encoder,
+    ) -> MltResult<()>
+    where
+        [T]: LogicalIntStreamKind<Input = T>,
+        <<[T] as LogicalIntStreamKind>::Profile as ZigZag>::UInt: WrappingSub,
+        LogicalCodecs: LogicalIntCodec<[T]>,
+    {
+        type Output<T> = <[T] as LogicalIntStreamKind>::Output;
+
+        use LogicalEncoding as LE;
+        use PhysicalEncoding as PE;
+
+        // FIXME: does StreamMeta encode values.len() or vals1.len()?
+        if let Some(int_enc) = enc.override_int_enc(ctx) {
+            let (le, vals) = match int_enc.logical {
+                LogicalEncoder::None => (LE::None, self.logical.none(values)),
+                LogicalEncoder::Delta => (LE::Delta, self.logical.delta(values)),
+                LogicalEncoder::Rle => self.logical.rle(values)?,
+                LogicalEncoder::DeltaRle => self.logical.delta_rle(values)?,
+            };
+            let phys = int_enc.physical;
+            return self
+                .physical
+                .write_encoded_as::<Output<T>>(ctx, enc, le, vals, phys);
+        }
+
+        if values.is_empty() {
+            let vals1 = self.logical.none(values);
+            let vals2 = Output::<T>::none(&mut self.physical, vals1);
+            let meta = StreamMeta::new2(ctx.stream_type, LE::None, PE::None, vals1.len())?;
+            return encoder::write_stream_payload(&mut enc.data, meta, false, vals2);
+        }
+
+        let Self { logical, physical } = self;
+        let mut alt = enc.try_alternatives();
+
+        let sample = logical.none(DataProfile::take_sample(values));
+        let profile = DataProfile::profile::<<[T] as LogicalIntStreamKind>::Profile>(sample);
+
+        if profile.delta_is_beneficial()
+            && (profile.rle_is_viable() || profile.delta_rle_is_viable())
+        {
+            let (logical_enc, values) = logical.delta_rle(values)?;
+            physical.write_alternatives::<Output<T>>(
+                &mut alt,
+                values,
+                logical_enc,
+                ctx.stream_type,
+            )?;
+        }
+        if profile.delta_is_beneficial() {
+            let values = logical.delta(values);
+            physical.write_alternatives::<Output<T>>(
+                &mut alt,
+                values,
+                LE::Delta,
+                ctx.stream_type,
+            )?;
+        }
+        if profile.rle_is_viable() {
+            let (logical_enc, values) = logical.rle(values)?;
+            physical.write_alternatives::<Output<T>>(
+                &mut alt,
+                values,
+                logical_enc,
+                ctx.stream_type,
+            )?;
+        }
+        let values = logical.none(values);
+        physical.write_alternatives::<Output<T>>(&mut alt, values, LE::None, ctx.stream_type)
     }
 }

--- a/rust/mlt-core/src/encoder/stream/encode_stream.rs
+++ b/rust/mlt-core/src/encoder/stream/encode_stream.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 
 use crate::MltResult;
+#[cfg(any(test, feature = "__private"))]
 use crate::decoder::{DictionaryType, StreamMeta, StreamType};
+#[cfg(any(test, feature = "__private"))]
 use crate::encoder::EncodedStream;
 use crate::errors::AsMltError as _;
 
@@ -28,6 +30,7 @@ pub(crate) fn dedup_strings<S: AsRef<str>>(values: &[S]) -> MltResult<(Vec<&str>
     Ok((unique, indices))
 }
 
+#[cfg(any(test, feature = "__private"))]
 impl EncodedStream {
     /// Encodes `f32`s into a stream
     #[hotpath::measure]

--- a/rust/mlt-core/src/encoder/stream/logical.rs
+++ b/rust/mlt-core/src/encoder/stream/logical.rs
@@ -43,12 +43,10 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
-    use crate::decoder::{DictionaryType, RawStream, StreamType};
+    use crate::decoder::RawStream;
     use crate::encoder::model::StreamCtx;
-    use crate::encoder::{Codecs, Encoder, ExplicitEncoder, IntEncoder, write_int_stream};
+    use crate::encoder::{Codecs, Encoder, ExplicitEncoder, IntEncoder};
     use crate::test_helpers::{assert_empty, dec, parser};
-
-    const DATA_STREAM: StreamType = StreamType::Data(DictionaryType::None);
 
     proptest! {
         #[test]
@@ -61,8 +59,8 @@ mod tests {
                 ExplicitEncoder::all(IntEncoder::varint_with(logical)),
             );
             let mut codecs = Codecs::default();
-            let ctx = StreamCtx::prop(DATA_STREAM, "test");
-            write_int_stream::<[u32]>(&values, &ctx, &mut enc, &mut codecs).unwrap();
+            let ctx = StreamCtx::prop_data("test");
+            codecs.write_int_stream(&values, &ctx, &mut enc).unwrap();
             let parsed = assert_empty(RawStream::from_bytes(&enc.data, &mut parser()));
             let decoded = parsed.decode_u32s(&mut dec()).unwrap();
             prop_assert_eq!(decoded, values);
@@ -78,8 +76,8 @@ mod tests {
                 ExplicitEncoder::all(IntEncoder::varint_with(logical)),
             );
             let mut codecs = Codecs::default();
-            let ctx = StreamCtx::prop(DATA_STREAM, "test");
-            write_int_stream::<[i32]>(&values, &ctx, &mut enc, &mut codecs).unwrap();
+            let ctx = StreamCtx::prop_data("test");
+            codecs.write_int_stream(&values, &ctx, &mut enc).unwrap();
             let parsed = assert_empty(RawStream::from_bytes(&enc.data, &mut parser()));
             let decoded = parsed.decode_i32s(&mut dec()).unwrap();
             prop_assert_eq!(decoded, values);
@@ -95,8 +93,8 @@ mod tests {
                 ExplicitEncoder::all(IntEncoder::varint_with(logical)),
             );
             let mut codecs = Codecs::default();
-            let ctx = StreamCtx::prop(DATA_STREAM, "test");
-            write_int_stream::<[u64]>(&values, &ctx, &mut enc, &mut codecs).unwrap();
+            let ctx = StreamCtx::prop_data("test");
+            codecs.write_int_stream(&values, &ctx, &mut enc).unwrap();
             let parsed = assert_empty(RawStream::from_bytes(&enc.data, &mut parser()));
             let decoded = parsed.decode_u64s(&mut dec()).unwrap();
             prop_assert_eq!(decoded, values);
@@ -112,8 +110,8 @@ mod tests {
                 ExplicitEncoder::all(IntEncoder::varint_with(logical)),
             );
             let mut codecs = Codecs::default();
-            let ctx = StreamCtx::prop(DATA_STREAM, "test");
-            write_int_stream::<[i64]>(&values, &ctx, &mut enc, &mut codecs).unwrap();
+            let ctx = StreamCtx::prop_data("test");
+            codecs.write_int_stream(&values, &ctx, &mut enc).unwrap();
             let parsed = assert_empty(RawStream::from_bytes(&enc.data, &mut parser()));
             let decoded = parsed.decode_i64s(&mut dec()).unwrap();
             prop_assert_eq!(decoded, values);

--- a/rust/mlt-core/src/encoder/stream/mod.rs
+++ b/rust/mlt-core/src/encoder/stream/mod.rs
@@ -20,11 +20,8 @@ pub use logical::LogicalEncoder;
 #[cfg(all(test, not(feature = "__private")))]
 pub(crate) use logical::LogicalEncoder;
 pub use model::*;
-pub use optimizer::DataProfile;
 #[cfg(feature = "__private")]
 pub use physical::PhysicalEncoder;
-#[cfg(not(feature = "__private"))]
+#[cfg(all(test, not(feature = "__private")))]
 pub(crate) use physical::PhysicalEncoder;
-pub(crate) use write::{
-    PhysicalIntStreamKind, U32Physical, write_bool_stream, write_int_stream, write_stream_payload,
-};
+pub(crate) use write::write_stream_payload;

--- a/rust/mlt-core/src/encoder/stream/mod.rs
+++ b/rust/mlt-core/src/encoder/stream/mod.rs
@@ -19,6 +19,7 @@ pub use encoder::IntEncoder;
 pub use logical::LogicalEncoder;
 #[cfg(all(test, not(feature = "__private")))]
 pub(crate) use logical::LogicalEncoder;
+#[cfg(any(test, feature = "__private"))]
 pub use model::*;
 #[cfg(feature = "__private")]
 pub use physical::PhysicalEncoder;

--- a/rust/mlt-core/src/encoder/stream/model.rs
+++ b/rust/mlt-core/src/encoder/stream/model.rs
@@ -1,14 +1,18 @@
+#[cfg(any(test, feature = "__private"))]
 use std::io::Write;
 
+#[cfg(any(test, feature = "__private"))]
 use crate::decoder::StreamMeta;
 
 /// Owned variant of [`RawStream`](crate::decoder::RawStream).
+#[cfg(any(test, feature = "__private"))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct EncodedStream {
     pub meta: StreamMeta,
     pub(crate) data: Vec<u8>,
 }
 
+#[cfg(any(test, feature = "__private"))]
 impl EncodedStream {
     pub fn write_to<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
         writer.write_all(&self.data)

--- a/rust/mlt-core/src/encoder/stream/optimizer.rs
+++ b/rust/mlt-core/src/encoder/stream/optimizer.rs
@@ -49,7 +49,7 @@ impl DataProfile {
     /// Profile a `u32` sample in a single pass.
     #[must_use]
     #[expect(clippy::cast_precision_loss)]
-    fn profile<T>(sample: &[T::UInt]) -> Self
+    pub(crate) fn profile<T>(sample: &[T::UInt]) -> Self
     where
         T: ZigZag,
         <T as ZigZag>::UInt: WrappingSub,
@@ -101,20 +101,14 @@ impl DataProfile {
         }
     }
 
-    /// Profile a representative sample.
-    #[must_use]
-    pub(crate) fn from_values<T>(values: &[T::UInt]) -> Self
-    where
-        T: ZigZag,
-        <T as ZigZag>::UInt: WrappingSub,
-    {
-        if values.is_empty() {
-            return Self::default();
+    pub(crate) fn take_sample<T>(values: &[T]) -> &[T] {
+        let len = (values.len() / 100).clamp(MIN_SAMPLE, MAX_SAMPLE);
+        if values.len() <= len {
+            values
+        } else {
+            let start = (values.len() / 2).saturating_sub(len / 2);
+            &values[start..start + len]
         }
-
-        let target = sample_size(values.len());
-        let sample = block_sample(values, target);
-        Self::profile::<T>(sample)
     }
 
     /// Returns `true` if RLE is a sensible candidate based on this profile.
@@ -142,30 +136,6 @@ impl DataProfile {
     }
 }
 
-fn block_sample<T: Clone + Copy>(values: &[T], target: usize) -> &[T] {
-    if values.len() <= target {
-        return values;
-    }
-    // Pick a starting point (could be middle or random)
-    // and take a contiguous chunk to preserve RLE/Delta patterns.
-    let start = (values.len() / 2).saturating_sub(target / 2);
-    &values[start..start + target]
-}
-
-/// Compute the target sample size from the full stream length.
-///
-/// - Streams shorter than `MIN_SAMPLE` are sampled fully.
-/// - Larger streams are sampled at ~1 % of their length, clamped to
-///   `[MIN_SAMPLE, MAX_SAMPLE]`.
-#[inline]
-fn sample_size(len: usize) -> usize {
-    if len <= MIN_SAMPLE {
-        len
-    } else {
-        (len / 100).clamp(MIN_SAMPLE, MAX_SAMPLE)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -181,7 +151,7 @@ mod tests {
         // All-distinct stream -> avg_run_length == 1 -> no raw-RLE candidate.
         // But sequential data has constant deltas -> delta-RLE is viable.
         let data: Vec<u32> = (0..100).collect();
-        let profile = DataProfile::from_values::<i32>(&data);
+        let profile = DataProfile::profile::<i32>(DataProfile::take_sample(&data));
         assert!(profile.is_sorted);
         assert_profile_flags(&profile, true, false, true);
     }
@@ -189,7 +159,7 @@ mod tests {
     #[test]
     fn profile_constant_u32_uses_raw_and_delta_rle() {
         let data = vec![1234u32; 500];
-        let profile = DataProfile::from_values::<i32>(&data);
+        let profile = DataProfile::profile::<i32>(DataProfile::take_sample(&data));
         assert!(profile.is_sorted);
         assert_profile_flags(&profile, true, true, true);
     }
@@ -197,14 +167,15 @@ mod tests {
     #[test]
     fn profile_sequential_u64_uses_delta_rle_without_raw_rle() {
         let data: Vec<u64> = (0u64..500).collect();
-        let profile = DataProfile::from_values::<i64>(&data);
+        let profile = DataProfile::profile::<i64>(DataProfile::take_sample(&data));
         assert!(profile.is_sorted);
         assert_profile_flags(&profile, true, false, true);
     }
 
     #[test]
     fn profile_empty_has_no_optimizing_flags() {
-        let profile = DataProfile::from_values::<i32>(&[]);
+        let values: &[u32] = &[];
+        let profile = DataProfile::profile::<i32>(DataProfile::take_sample(values));
         assert!(!profile.is_sorted);
         assert_profile_flags(&profile, false, false, false);
     }

--- a/rust/mlt-core/src/encoder/stream/tests.rs
+++ b/rust/mlt-core/src/encoder/stream/tests.rs
@@ -1,7 +1,6 @@
 use proptest::prelude::*;
 use rstest::rstest;
 
-use super::write::write_int_stream;
 use crate::MltError;
 use crate::decoder::{
     DictionaryType, IntEncoding, LengthType, LogicalEncoding, LogicalValue, Morton, OffsetType,
@@ -13,8 +12,6 @@ use crate::encoder::{
 };
 use crate::test_helpers::{assert_empty, dec, parser};
 use crate::utils::BinarySerializer as _;
-
-const DATA_STREAM: StreamType = StreamType::Data(DictionaryType::None);
 
 fn roundtrip_stream<'a>(buffer: &'a mut Vec<u8>, stream: &EncodedStream) -> RawStream<'a> {
     buffer.clear();
@@ -161,8 +158,8 @@ fn test_fastpfor_roundtrip(#[case] values: Vec<u32>) {
         ExplicitEncoder::all(IntEncoder::fastpfor()),
     );
     let codecs = &mut Codecs::default();
-    let ctx = StreamCtx::prop(DATA_STREAM, "test");
-    write_int_stream::<[u32]>(&values, &ctx, &mut enc, codecs).unwrap();
+    let ctx = StreamCtx::prop_data("test");
+    codecs.write_int_stream(&values, &ctx, &mut enc).unwrap();
     let decoded_values = roundtrip_stream_u32s(&enc.data);
     assert_eq!(decoded_values, values);
 }
@@ -323,7 +320,8 @@ proptest! {
     ) {
         let widened: Vec<i32> = values.iter().map(|&v| i32::from(v)).collect();
         let mut enc = Encoder::with_explicit(Encoder::default().cfg, ExplicitEncoder::all(encoding));
-        write_int_stream::<[i32]>(&widened, &StreamCtx::prop(DATA_STREAM, "test"), &mut enc, &mut Codecs::default()).unwrap();
+        let mut codecs = Codecs::default();
+        codecs.write_int_stream(&widened, &StreamCtx::prop_data("test"), &mut enc).unwrap();
         let parsed_stream = assert_empty(RawStream::from_bytes(&enc.data, &mut parser()));
         let decoded_values = parsed_stream.decode_i8s(&mut dec()).unwrap();
 
@@ -337,7 +335,8 @@ proptest! {
     ) {
         let widened: Vec<u32> = values.iter().map(|&v| u32::from(v)).collect();
         let mut enc = Encoder::with_explicit(Encoder::default().cfg, ExplicitEncoder::all(encoding));
-        write_int_stream::<[u32]>(&widened, &StreamCtx::prop(DATA_STREAM, "test"), &mut enc, &mut Codecs::default()).unwrap();
+        let mut codecs = Codecs::default();
+        codecs.write_int_stream(&widened, &StreamCtx::prop_data("test"), &mut enc).unwrap();
         let parsed_stream = assert_empty(RawStream::from_bytes(&enc.data, &mut parser()));
         let decoded_values = parsed_stream.decode_u8s(&mut dec()).unwrap();
 
@@ -350,7 +349,8 @@ proptest! {
         encoding in any::<IntEncoder>()
     ) {
         let mut enc = Encoder::with_explicit(Encoder::default().cfg, ExplicitEncoder::all(encoding));
-        write_int_stream::<[u32]>(&values, &StreamCtx::prop(DATA_STREAM, "test"), &mut enc, &mut Codecs::default()).unwrap();
+        let mut codecs = Codecs::default();
+        codecs.write_int_stream(&values, &StreamCtx::prop_data("test"), &mut enc).unwrap();
         let decoded_values = roundtrip_stream_u32s(&enc.data);
         assert_eq!(decoded_values, values);
     }
@@ -361,7 +361,8 @@ proptest! {
         encoding in any::<IntEncoder>(),
     ) {
         let mut enc = Encoder::with_explicit(Encoder::default().cfg, ExplicitEncoder::all(encoding));
-        write_int_stream::<[i32]>(&values, &StreamCtx::prop(DATA_STREAM, "test"), &mut enc, &mut Codecs::default()).unwrap();
+        let mut codecs = Codecs::default();
+        codecs.write_int_stream(&values, &StreamCtx::prop_data("test"), &mut enc).unwrap();
         let parsed_stream = assert_empty(RawStream::from_bytes(&enc.data, &mut parser()));
         let decoded_values = parsed_stream.decode_i32s(&mut dec()).unwrap();
 
@@ -374,7 +375,8 @@ proptest! {
         encoding in encoding_no_fastpfor()
     ) {
         let mut enc = Encoder::with_explicit(Encoder::default().cfg, ExplicitEncoder::all(encoding));
-        write_int_stream::<[u64]>(&values, &StreamCtx::prop(DATA_STREAM, "test"), &mut enc, &mut Codecs::default()).unwrap();
+        let mut codecs = Codecs::default();
+        codecs.write_int_stream(&values, &StreamCtx::prop_data("test"), &mut enc).unwrap();
         let parsed_stream = assert_empty(RawStream::from_bytes(&enc.data, &mut parser()));
         let decoded_values = parsed_stream.decode_u64s(&mut dec()).unwrap();
 
@@ -387,7 +389,8 @@ proptest! {
         encoding in encoding_no_fastpfor()
     ) {
         let mut enc = Encoder::with_explicit(Encoder::default().cfg, ExplicitEncoder::all(encoding));
-        write_int_stream::<[i64]>(&values, &StreamCtx::prop(DATA_STREAM, "test"), &mut enc, &mut Codecs::default()).unwrap();
+        let mut codecs = Codecs::default();
+        codecs.write_int_stream(&values, &StreamCtx::prop_data("test"), &mut enc).unwrap();
         let parsed_stream = assert_empty(RawStream::from_bytes(&enc.data, &mut parser()));
         let decoded_values = parsed_stream.decode_i64s(&mut dec()).unwrap();
 

--- a/rust/mlt-core/src/encoder/stream/write.rs
+++ b/rust/mlt-core/src/encoder/stream/write.rs
@@ -1,7 +1,7 @@
 use bytemuck::{NoUninit, cast_slice};
 use fastpfor::AnyLenCodec as _;
 use integer_encoding::VarInt;
-use num_traits::{PrimInt, WrappingSub};
+use num_traits::PrimInt;
 use zigzag::ZigZag;
 
 use crate::MltError::UnsupportedPhysicalEncoding;
@@ -10,10 +10,10 @@ use crate::codecs::zigzag::{encode_zigzag, encode_zigzag_delta};
 use crate::decoder::{LogicalEncoding, PhysicalEncoding, StreamMeta, StreamType};
 use crate::encoder::Encoder;
 use crate::encoder::model::StreamCtx;
-use crate::encoder::stream::DataProfile;
-use crate::encoder::stream::codecs::{Codecs, LogicalCodecs, PhysicalCodecs};
-use crate::encoder::stream::logical::{LogicalEncoder, apply_rle};
+use crate::encoder::stream::codecs::{LogicalCodecs, PhysicalCodecs};
+use crate::encoder::stream::logical::apply_rle;
 use crate::encoder::stream::physical::PhysicalEncoder;
+use crate::encoder::writer::AltSession;
 
 #[inline]
 pub(crate) fn write_stream_payload(
@@ -28,61 +28,17 @@ pub(crate) fn write_stream_payload(
     Ok(())
 }
 
-pub(crate) fn write_bool_stream(
-    values: impl ExactSizeIterator<Item = bool>,
-    stream_type: StreamType,
-    enc: &mut Encoder,
-    codecs: &mut Codecs,
-) -> MltResult<()> {
-    let num_values = values.len();
-    let (logical, vals) = codecs.logical.encode_bools(values)?;
-    let meta = StreamMeta::new2(stream_type, logical, PhysicalEncoding::None, num_values)?;
-    write_stream_payload(&mut enc.data, meta, true, vals)
-}
-
 pub(crate) trait PhysicalIntStreamKind {
     type Value: Into<u64> + NoUninit + PrimInt;
     const FASTPFOR_ALLOWED: bool;
-
-    fn encode_physical<'a>(
-        physical: &'a mut PhysicalCodecs,
-        values: &'a [Self::Value],
-        physical_enc: PhysicalEncoder,
-    ) -> MltResult<(PhysicalEncoding, &'a [u8])> {
-        Ok(match physical_enc {
-            PhysicalEncoder::None => (PhysicalEncoding::None, Self::none(physical, values)),
-            PhysicalEncoder::VarInt => (PhysicalEncoding::VarInt, Self::varint(physical, values)),
-            PhysicalEncoder::FastPFOR => (
-                PhysicalEncoding::FastPFor256,
-                Self::fastpfor(physical, values)?,
-            ),
-        })
-    }
 
     #[cfg(target_endian = "little")]
     fn none<'a>(_physical: &'a mut PhysicalCodecs, values: &'a [Self::Value]) -> &'a [u8] {
         cast_slice(values)
     }
-
     #[cfg(not(target_endian = "little"))]
     fn none<'a>(physical: &'a mut PhysicalCodecs, values: &'a [Self::Value]) -> &'a [u8] {
-        physical.u8_tmp.clear();
-        for &v in values {
-            physical.u8_tmp.extend_from_slice(&v.to_le_bytes());
-        }
-        &physical.u8_tmp
-    }
-
-    fn varint<'a>(physical: &'a mut PhysicalCodecs, values: &'a [Self::Value]) -> &'a [u8] {
-        // encode_var writes to a stack buffer; avoids the Vec<u8> allocation
-        // that encode_var_vec() would produce for every value.
-        physical.u8_tmp.clear();
-        let mut buf = [0u8; 10];
-        for &v in values {
-            let n = v.into().encode_var(&mut buf);
-            physical.u8_tmp.extend_from_slice(&buf[..n]);
-        }
-        &physical.u8_tmp
+        compile_error!("PhysicalEncoding::none is not implemented for non-little-endian targets");
     }
 
     fn fastpfor<'a>(
@@ -91,10 +47,76 @@ pub(crate) trait PhysicalIntStreamKind {
     ) -> MltResult<&'a [u8]>;
 }
 
-pub(crate) struct U32Physical;
-pub(crate) struct U64Physical;
+impl PhysicalCodecs {
+    pub(crate) fn varint<T>(&mut self, values: &[T]) -> &[u8]
+    where
+        T: Copy + Into<u64>,
+    {
+        // encode_var writes to a stack buffer; avoids the Vec<u8> allocation
+        // that encode_var_vec() would produce for every value.
+        self.u8_tmp.clear();
+        let mut buf = [0u8; 10];
+        for &v in values {
+            let n = v.into().encode_var(&mut buf);
+            self.u8_tmp.extend_from_slice(&buf[..n]);
+        }
+        &self.u8_tmp
+    }
 
-impl PhysicalIntStreamKind for U32Physical {
+    pub(crate) fn fastpfor(&mut self, values: &[u32]) -> MltResult<&[u8]> {
+        self.u8_tmp.clear();
+        if !values.is_empty() {
+            self.u32_tmp.clear();
+            self.fastpfor.encode(values, &mut self.u32_tmp)?;
+            for word in &mut self.u32_tmp {
+                *word = word.to_be();
+            }
+            self.u8_tmp.extend_from_slice(cast_slice(&self.u32_tmp));
+        }
+        Ok(&self.u8_tmp)
+    }
+
+    /// Physically encode and write stream to the output.
+    pub(crate) fn write_encoded_as<P: PhysicalIntStreamKind + ?Sized>(
+        &mut self,
+        ctx: &StreamCtx,
+        enc: &mut Encoder,
+        le: LogicalEncoding,
+        values: &[P::Value],
+        encode_as: PhysicalEncoder,
+    ) -> MltResult<()> {
+        use PhysicalEncoding as PE;
+        let (pe, vals) = match encode_as {
+            PhysicalEncoder::None => (PE::None, P::none(self, values)),
+            PhysicalEncoder::VarInt => (PE::VarInt, self.varint(values)),
+            PhysicalEncoder::FastPFOR => (PE::FastPFor256, P::fastpfor(self, values)?),
+        };
+        let meta = StreamMeta::new2(ctx.stream_type, le, pe, values.len())?;
+        write_stream_payload(&mut enc.data, meta, false, vals)
+    }
+
+    pub(crate) fn write_alternatives<P: PhysicalIntStreamKind + ?Sized>(
+        &mut self,
+        alt: &mut AltSession<'_>,
+        values: &[P::Value],
+        logical: LogicalEncoding,
+        stream_type: StreamType,
+    ) -> MltResult<()> {
+        use PhysicalEncoding as PE;
+        if P::FASTPFOR_ALLOWED {
+            alt.with(|enc| {
+                let meta = StreamMeta::new2(stream_type, logical, PE::FastPFor256, values.len())?;
+                write_stream_payload(&mut enc.data, meta, false, P::fastpfor(self, values)?)
+            })?;
+        }
+        alt.with(|enc| {
+            let meta = StreamMeta::new2(stream_type, logical, PE::VarInt, values.len())?;
+            write_stream_payload(&mut enc.data, meta, false, self.varint(values))
+        })
+    }
+}
+
+impl PhysicalIntStreamKind for [u32] {
     type Value = u32;
     const FASTPFOR_ALLOWED: bool = true;
 
@@ -102,22 +124,11 @@ impl PhysicalIntStreamKind for U32Physical {
         physical: &'a mut PhysicalCodecs,
         values: &'a [Self::Value],
     ) -> MltResult<&'a [u8]> {
-        physical.u8_tmp.clear();
-        if !values.is_empty() {
-            physical.u32_tmp.clear();
-            physical.fastpfor.encode(values, &mut physical.u32_tmp)?;
-            for word in &mut physical.u32_tmp {
-                *word = word.to_be();
-            }
-            physical
-                .u8_tmp
-                .extend_from_slice(cast_slice(&physical.u32_tmp));
-        }
-        Ok(&physical.u8_tmp)
+        physical.fastpfor(values)
     }
 }
 
-impl PhysicalIntStreamKind for U64Physical {
+impl PhysicalIntStreamKind for [u64] {
     type Value = u64;
     const FASTPFOR_ALLOWED: bool = false;
 
@@ -131,268 +142,230 @@ impl PhysicalIntStreamKind for U64Physical {
 
 pub(crate) trait LogicalIntStreamKind {
     type Input;
-    type Profile: ZigZag;
-    type Physical: PhysicalIntStreamKind;
+    type Output: PhysicalIntStreamKind + ?Sized;
+    type Profile: ZigZag<UInt = <Self::Output as PhysicalIntStreamKind>::Value>;
+}
 
-    fn profile_values<'a>(
-        logical: &'a mut LogicalCodecs,
-        values: &'a Self,
-    ) -> &'a [<Self::Profile as ZigZag>::UInt];
+pub(crate) trait LogicalIntCodec<T: LogicalIntStreamKind + ?Sized> {
+    fn none<'a>(&'a mut self, values: &'a T) -> &'a [<T::Output as PhysicalIntStreamKind>::Value];
 
-    fn encode_logical<'a>(
-        logical: &'a mut LogicalCodecs,
-        values: &'a Self,
-        logical_enc: LogicalEncoder,
-    ) -> MltResult<(
-        LogicalEncoding,
-        &'a [<Self::Physical as PhysicalIntStreamKind>::Value],
-    )> {
-        Ok(match logical_enc {
-            LogicalEncoder::None => (LogicalEncoding::None, Self::none(logical, values)),
-            LogicalEncoder::Delta => (LogicalEncoding::Delta, Self::delta(logical, values)),
-            LogicalEncoder::Rle => Self::rle(logical, values)?,
-            LogicalEncoder::DeltaRle => Self::delta_rle(logical, values)?,
-        })
-    }
-
-    fn none<'a>(
-        logical: &'a mut LogicalCodecs,
-        values: &'a Self,
-    ) -> &'a [<Self::Physical as PhysicalIntStreamKind>::Value];
-
-    fn delta<'a>(
-        logical: &'a mut LogicalCodecs,
-        values: &'a Self,
-    ) -> &'a [<Self::Physical as PhysicalIntStreamKind>::Value];
+    fn delta<'a>(&'a mut self, values: &'a T) -> &'a [<T::Output as PhysicalIntStreamKind>::Value];
 
     fn rle<'a>(
-        logical: &'a mut LogicalCodecs,
-        values: &'a Self,
+        &'a mut self,
+        values: &'a T,
     ) -> MltResult<(
         LogicalEncoding,
-        &'a [<Self::Physical as PhysicalIntStreamKind>::Value],
+        &'a [<T::Output as PhysicalIntStreamKind>::Value],
     )>;
 
     fn delta_rle<'a>(
-        logical: &'a mut LogicalCodecs,
-        values: &'a Self,
+        &'a mut self,
+        values: &'a T,
     ) -> MltResult<(
         LogicalEncoding,
-        &'a [<Self::Physical as PhysicalIntStreamKind>::Value],
+        &'a [<T::Output as PhysicalIntStreamKind>::Value],
     )>;
+}
+
+fn encode_u8_as_u32<'a>(values: &[u8], target: &'a mut Vec<u32>) -> &'a [u32] {
+    target.clear();
+    target.extend(values.iter().map(|&v| u32::from(v)));
+    target
+}
+
+fn encode_i8_zigzag<'a>(values: &[i8], target: &'a mut Vec<u32>) -> &'a [u32] {
+    target.clear();
+    target.extend(values.iter().map(|&v| i32::encode(i32::from(v))));
+    target
+}
+
+fn encode_u8_delta<'a>(values: &[u8], target: &'a mut Vec<u32>) -> &'a [u32] {
+    target.clear();
+    target.reserve(values.len());
+    let mut prev = 0_i32;
+    for &v in values {
+        let v = i32::from(v);
+        target.push(i32::encode(v.wrapping_sub(prev)));
+        prev = v;
+    }
+    target
+}
+
+fn encode_i8_delta<'a>(values: &[i8], target: &'a mut Vec<u32>) -> &'a [u32] {
+    target.clear();
+    target.reserve(values.len());
+    let mut prev = 0_i32;
+    for &v in values {
+        let v = i32::from(v);
+        target.push(i32::encode(v.wrapping_sub(prev)));
+        prev = v;
+    }
+    target
+}
+
+impl LogicalIntStreamKind for [u8] {
+    type Input = u8;
+    type Output = [u32];
+    type Profile = i32;
+}
+
+impl LogicalIntCodec<[u8]> for LogicalCodecs {
+    fn none<'a>(&'a mut self, values: &'a [u8]) -> &'a [u32] {
+        encode_u8_as_u32(values, &mut self.u32_tmp)
+    }
+
+    fn delta<'a>(&'a mut self, values: &'a [u8]) -> &'a [u32] {
+        encode_u8_delta(values, &mut self.u32_tmp)
+    }
+
+    fn rle<'a>(&'a mut self, values: &'a [u8]) -> MltResult<(LogicalEncoding, &'a [u32])> {
+        let data = encode_u8_as_u32(values, &mut self.u32_tmp);
+        let meta = apply_rle(data, values.len(), &mut self.u32_tmp2)?;
+        Ok((LogicalEncoding::Rle(meta), &self.u32_tmp2))
+    }
+
+    fn delta_rle<'a>(&'a mut self, values: &'a [u8]) -> MltResult<(LogicalEncoding, &'a [u32])> {
+        let data = encode_u8_delta(values, &mut self.u32_tmp);
+        let meta = apply_rle(data, values.len(), &mut self.u32_tmp2)?;
+        Ok((LogicalEncoding::DeltaRle(meta), &self.u32_tmp2))
+    }
+}
+
+impl LogicalIntStreamKind for [i8] {
+    type Input = i8;
+    type Output = [u32];
+    type Profile = i32;
+}
+
+impl LogicalIntCodec<[i8]> for LogicalCodecs {
+    fn none<'a>(&'a mut self, values: &'a [i8]) -> &'a [u32] {
+        encode_i8_zigzag(values, &mut self.u32_tmp)
+    }
+
+    fn delta<'a>(&'a mut self, values: &'a [i8]) -> &'a [u32] {
+        encode_i8_delta(values, &mut self.u32_tmp)
+    }
+
+    fn rle<'a>(&'a mut self, values: &'a [i8]) -> MltResult<(LogicalEncoding, &'a [u32])> {
+        let data = encode_i8_zigzag(values, &mut self.u32_tmp);
+        let meta = apply_rle(data, values.len(), &mut self.u32_tmp2)?;
+        Ok((LogicalEncoding::Rle(meta), &self.u32_tmp2))
+    }
+
+    fn delta_rle<'a>(&'a mut self, values: &'a [i8]) -> MltResult<(LogicalEncoding, &'a [u32])> {
+        let data = encode_i8_delta(values, &mut self.u32_tmp);
+        let meta = apply_rle(data, values.len(), &mut self.u32_tmp2)?;
+        Ok((LogicalEncoding::DeltaRle(meta), &self.u32_tmp2))
+    }
 }
 
 impl LogicalIntStreamKind for [u32] {
     type Input = u32;
+    type Output = [u32];
     type Profile = i32;
-    type Physical = U32Physical;
+}
 
-    fn profile_values<'a>(_logical: &'a mut LogicalCodecs, values: &'a Self) -> &'a [u32] {
+impl LogicalIntCodec<[u32]> for LogicalCodecs {
+    fn none<'a>(&'a mut self, values: &'a [u32]) -> &'a [u32] {
         values
     }
 
-    fn none<'a>(_logical: &'a mut LogicalCodecs, values: &'a Self) -> &'a [u32] {
-        values
+    fn delta<'a>(&'a mut self, values: &'a [u32]) -> &'a [u32] {
+        encode_zigzag_delta(cast_slice::<u32, i32>(values), &mut self.u32_tmp)
     }
 
-    fn delta<'a>(logical: &'a mut LogicalCodecs, values: &'a Self) -> &'a [u32] {
-        encode_zigzag_delta(cast_slice::<u32, i32>(values), &mut logical.u32_tmp)
+    fn rle<'a>(&'a mut self, values: &'a [u32]) -> MltResult<(LogicalEncoding, &'a [u32])> {
+        let meta = apply_rle(values, values.len(), &mut self.u32_tmp)?;
+        Ok((LogicalEncoding::Rle(meta), &self.u32_tmp))
     }
 
-    fn rle<'a>(
-        logical: &'a mut LogicalCodecs,
-        values: &'a Self,
-    ) -> MltResult<(LogicalEncoding, &'a [u32])> {
-        let meta = apply_rle(values, values.len(), &mut logical.u32_tmp)?;
-        Ok((LogicalEncoding::Rle(meta), &logical.u32_tmp))
-    }
-
-    fn delta_rle<'a>(
-        logical: &'a mut LogicalCodecs,
-        values: &'a Self,
-    ) -> MltResult<(LogicalEncoding, &'a [u32])> {
-        let data = encode_zigzag_delta(cast_slice::<u32, i32>(values), &mut logical.u32_tmp);
-        let meta = apply_rle(data, values.len(), &mut logical.u32_tmp2)?;
-        Ok((LogicalEncoding::DeltaRle(meta), &logical.u32_tmp2))
+    fn delta_rle<'a>(&'a mut self, values: &'a [u32]) -> MltResult<(LogicalEncoding, &'a [u32])> {
+        let data = encode_zigzag_delta(cast_slice::<u32, i32>(values), &mut self.u32_tmp);
+        let meta = apply_rle(data, values.len(), &mut self.u32_tmp2)?;
+        Ok((LogicalEncoding::DeltaRle(meta), &self.u32_tmp2))
     }
 }
 
 impl LogicalIntStreamKind for [i32] {
     type Input = i32;
+    type Output = [u32];
     type Profile = i32;
-    type Physical = U32Physical;
+}
 
-    fn profile_values<'a>(logical: &'a mut LogicalCodecs, values: &'a Self) -> &'a [u32] {
-        encode_zigzag(values, &mut logical.u32_tmp)
+impl LogicalIntCodec<[i32]> for LogicalCodecs {
+    fn none<'a>(&'a mut self, values: &'a [i32]) -> &'a [u32] {
+        encode_zigzag(values, &mut self.u32_tmp)
     }
 
-    fn none<'a>(logical: &'a mut LogicalCodecs, values: &'a Self) -> &'a [u32] {
-        encode_zigzag(values, &mut logical.u32_tmp)
+    fn delta<'a>(&'a mut self, values: &'a [i32]) -> &'a [u32] {
+        encode_zigzag_delta(values, &mut self.u32_tmp)
     }
 
-    fn delta<'a>(logical: &'a mut LogicalCodecs, values: &'a Self) -> &'a [u32] {
-        encode_zigzag_delta(values, &mut logical.u32_tmp)
+    fn rle<'a>(&'a mut self, values: &'a [i32]) -> MltResult<(LogicalEncoding, &'a [u32])> {
+        let data = encode_zigzag(values, &mut self.u32_tmp);
+        let meta = apply_rle(data, values.len(), &mut self.u32_tmp2)?;
+        Ok((LogicalEncoding::Rle(meta), &self.u32_tmp2))
     }
 
-    fn rle<'a>(
-        logical: &'a mut LogicalCodecs,
-        values: &'a Self,
-    ) -> MltResult<(LogicalEncoding, &'a [u32])> {
-        let data = encode_zigzag(values, &mut logical.u32_tmp);
-        let meta = apply_rle(data, values.len(), &mut logical.u32_tmp2)?;
-        Ok((LogicalEncoding::Rle(meta), &logical.u32_tmp2))
-    }
-
-    fn delta_rle<'a>(
-        logical: &'a mut LogicalCodecs,
-        values: &'a Self,
-    ) -> MltResult<(LogicalEncoding, &'a [u32])> {
-        let data = encode_zigzag_delta(values, &mut logical.u32_tmp);
-        let meta = apply_rle(data, values.len(), &mut logical.u32_tmp2)?;
-        Ok((LogicalEncoding::DeltaRle(meta), &logical.u32_tmp2))
+    fn delta_rle<'a>(&'a mut self, values: &'a [i32]) -> MltResult<(LogicalEncoding, &'a [u32])> {
+        let data = encode_zigzag_delta(values, &mut self.u32_tmp);
+        let meta = apply_rle(data, values.len(), &mut self.u32_tmp2)?;
+        Ok((LogicalEncoding::DeltaRle(meta), &self.u32_tmp2))
     }
 }
 
 impl LogicalIntStreamKind for [u64] {
     type Input = u64;
+    type Output = [u64];
     type Profile = i64;
-    type Physical = U64Physical;
+}
 
-    fn profile_values<'a>(_logical: &'a mut LogicalCodecs, values: &'a Self) -> &'a [u64] {
+impl LogicalIntCodec<[u64]> for LogicalCodecs {
+    fn none<'a>(&'a mut self, values: &'a [u64]) -> &'a [u64] {
         values
     }
 
-    fn none<'a>(_logical: &'a mut LogicalCodecs, values: &'a Self) -> &'a [u64] {
-        values
+    fn delta<'a>(&'a mut self, values: &'a [u64]) -> &'a [u64] {
+        encode_zigzag_delta(cast_slice::<u64, i64>(values), &mut self.u64_tmp)
     }
 
-    fn delta<'a>(logical: &'a mut LogicalCodecs, values: &'a Self) -> &'a [u64] {
-        encode_zigzag_delta(cast_slice::<u64, i64>(values), &mut logical.u64_tmp)
+    fn rle<'a>(&'a mut self, values: &'a [u64]) -> MltResult<(LogicalEncoding, &'a [u64])> {
+        let meta = apply_rle(values, values.len(), &mut self.u64_tmp)?;
+        Ok((LogicalEncoding::Rle(meta), &self.u64_tmp))
     }
 
-    fn rle<'a>(
-        logical: &'a mut LogicalCodecs,
-        values: &'a Self,
-    ) -> MltResult<(LogicalEncoding, &'a [u64])> {
-        let meta = apply_rle(values, values.len(), &mut logical.u64_tmp)?;
-        Ok((LogicalEncoding::Rle(meta), &logical.u64_tmp))
-    }
-
-    fn delta_rle<'a>(
-        logical: &'a mut LogicalCodecs,
-        values: &'a Self,
-    ) -> MltResult<(LogicalEncoding, &'a [u64])> {
-        let data = encode_zigzag_delta(cast_slice::<u64, i64>(values), &mut logical.u64_tmp);
-        let meta = apply_rle(data, values.len(), &mut logical.u64_tmp2)?;
-        Ok((LogicalEncoding::DeltaRle(meta), &logical.u64_tmp2))
+    fn delta_rle<'a>(&'a mut self, values: &'a [u64]) -> MltResult<(LogicalEncoding, &'a [u64])> {
+        let data = encode_zigzag_delta(cast_slice::<u64, i64>(values), &mut self.u64_tmp);
+        let meta = apply_rle(data, values.len(), &mut self.u64_tmp2)?;
+        Ok((LogicalEncoding::DeltaRle(meta), &self.u64_tmp2))
     }
 }
 
 impl LogicalIntStreamKind for [i64] {
     type Input = i64;
+    type Output = [u64];
     type Profile = i64;
-    type Physical = U64Physical;
-
-    fn profile_values<'a>(logical: &'a mut LogicalCodecs, values: &'a Self) -> &'a [u64] {
-        encode_zigzag(values, &mut logical.u64_tmp)
-    }
-
-    fn none<'a>(logical: &'a mut LogicalCodecs, values: &'a Self) -> &'a [u64] {
-        encode_zigzag(values, &mut logical.u64_tmp)
-    }
-
-    fn delta<'a>(logical: &'a mut LogicalCodecs, values: &'a Self) -> &'a [u64] {
-        encode_zigzag_delta(values, &mut logical.u64_tmp)
-    }
-
-    fn rle<'a>(
-        logical: &'a mut LogicalCodecs,
-        values: &'a Self,
-    ) -> MltResult<(LogicalEncoding, &'a [u64])> {
-        let data = encode_zigzag(values, &mut logical.u64_tmp);
-        let meta = apply_rle(data, values.len(), &mut logical.u64_tmp2)?;
-        Ok((LogicalEncoding::Rle(meta), &logical.u64_tmp2))
-    }
-
-    fn delta_rle<'a>(
-        logical: &'a mut LogicalCodecs,
-        values: &'a Self,
-    ) -> MltResult<(LogicalEncoding, &'a [u64])> {
-        let data = encode_zigzag_delta(values, &mut logical.u64_tmp);
-        let meta = apply_rle(data, values.len(), &mut logical.u64_tmp2)?;
-        Ok((LogicalEncoding::DeltaRle(meta), &logical.u64_tmp2))
-    }
 }
 
-pub(crate) fn write_int_stream<L: AsRef<[L::Input]> + LogicalIntStreamKind + ?Sized>(
-    values: &L,
-    ctx: &StreamCtx<'_>,
-    enc: &mut Encoder,
-    codecs: &mut Codecs,
-) -> MltResult<()>
-where
-    <L::Profile as ZigZag>::UInt: WrappingSub,
-{
-    use LogicalEncoding as LE;
-
-    let stream = ctx.stream_type;
-
-    // FIXME: does StreamMeta encode values.len() or vals1.len()?
-    if let Some(int_enc) = enc.override_int_enc(ctx) {
-        let (logical, vals1) = L::encode_logical(&mut codecs.logical, values, int_enc.logical)?;
-        let (phys, vals2) =
-            L::Physical::encode_physical(&mut codecs.physical, vals1, int_enc.physical)?;
-        let meta = StreamMeta::new2(stream, logical, phys, vals1.len())?;
-        return write_stream_payload(&mut enc.data, meta, false, vals2);
+impl LogicalIntCodec<[i64]> for LogicalCodecs {
+    fn none<'a>(&'a mut self, values: &'a [i64]) -> &'a [u64] {
+        encode_zigzag(values, &mut self.u64_tmp)
     }
 
-    if values.as_ref().is_empty() {
-        let vals1 = L::none(&mut codecs.logical, values);
-        let vals2 = L::Physical::none(&mut codecs.physical, vals1);
-        let meta = StreamMeta::new2(stream, LE::None, PhysicalEncoding::None, vals1.len())?;
-        return write_stream_payload(&mut enc.data, meta, false, vals2);
+    fn delta<'a>(&'a mut self, values: &'a [i64]) -> &'a [u64] {
+        encode_zigzag_delta(values, &mut self.u64_tmp)
     }
 
-    let Codecs { logical, physical } = codecs;
-    let mut alt = enc.try_alternatives();
+    fn rle<'a>(&'a mut self, values: &'a [i64]) -> MltResult<(LogicalEncoding, &'a [u64])> {
+        let data = encode_zigzag(values, &mut self.u64_tmp);
+        let meta = apply_rle(data, values.len(), &mut self.u64_tmp2)?;
+        Ok((LogicalEncoding::Rle(meta), &self.u64_tmp2))
+    }
 
-    // FIXME: we zigzag-encode everything, look at a section of it,
-    //        drop the rest, and repeat zigzag later
-    let vals = L::profile_values(logical, values);
-    let profile = DataProfile::from_values::<L::Profile>(vals);
-
-    if profile.delta_is_beneficial() && (profile.rle_is_viable() || profile.delta_rle_is_viable()) {
-        let (logical, values) = L::delta_rle(logical, values)?;
-        write_alternatives::<L::Physical>(&mut alt, physical, values, logical, stream)?;
+    fn delta_rle<'a>(&'a mut self, values: &'a [i64]) -> MltResult<(LogicalEncoding, &'a [u64])> {
+        let data = encode_zigzag_delta(values, &mut self.u64_tmp);
+        let meta = apply_rle(data, values.len(), &mut self.u64_tmp2)?;
+        Ok((LogicalEncoding::DeltaRle(meta), &self.u64_tmp2))
     }
-    if profile.delta_is_beneficial() {
-        let values = L::delta(logical, values);
-        write_alternatives::<L::Physical>(&mut alt, physical, values, LE::Delta, stream)?;
-    }
-    if profile.rle_is_viable() {
-        let (logical, values) = L::rle(logical, values)?;
-        write_alternatives::<L::Physical>(&mut alt, physical, values, logical, stream)?;
-    }
-    let values = L::none(logical, values);
-    write_alternatives::<L::Physical>(&mut alt, physical, values, LE::None, stream)
-}
-
-fn write_alternatives<P: PhysicalIntStreamKind>(
-    alt: &mut crate::encoder::writer::AltSession<'_>,
-    physical: &mut PhysicalCodecs,
-    values: &[P::Value],
-    logical: LogicalEncoding,
-    stream_type: StreamType,
-) -> MltResult<()> {
-    use PhysicalEncoding as PE;
-    if P::FASTPFOR_ALLOWED {
-        alt.with(|enc| {
-            let meta = StreamMeta::new2(stream_type, logical, PE::FastPFor256, values.len())?;
-            write_stream_payload(&mut enc.data, meta, false, P::fastpfor(physical, values)?)
-        })?;
-    }
-    alt.with(|enc| {
-        let meta = StreamMeta::new2(stream_type, logical, PE::VarInt, values.len())?;
-        write_stream_payload(&mut enc.data, meta, false, P::varint(physical, values))
-    })
 }

--- a/rust/mlt-core/src/utils/serialize.rs
+++ b/rust/mlt-core/src/utils/serialize.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 
 use integer_encoding::VarIntWriter;
 
+#[cfg(any(test, feature = "__private"))]
 use crate::encoder::EncodedStream;
 use crate::{MltError, MltResult};
 
@@ -17,6 +18,7 @@ pub trait BinarySerializer: Write + VarIntWriter + Sized {
     }
 
     /// Reverses `RawStream::from_bytes` — writes a stream header then the stream data bytes.
+    #[cfg(any(test, feature = "__private"))]
     fn write_stream(&mut self, stream: &EncodedStream) -> io::Result<()> {
         let byte_length = u32::try_from(stream.data.len()).map_err(MltError::from)?;
         stream.meta.write_to(self, false, byte_length)?;


### PR DESCRIPTION
more encoder work, streamlining it to use logical and physical encoders for temp storage

* sample is now taken before zigzag encoding
* normalize scalar encoding