### PR TITLE
fix(java): Only use space-filling curves in geometry encoding if the coordinate range is supported

### DIFF
--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/GeometryEncoder.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/GeometryEncoder.java
@@ -48,6 +48,7 @@ import org.maplibre.mlt.metadata.stream.PhysicalLevelTechnique;
 import org.maplibre.mlt.metadata.stream.PhysicalStreamType;
 import org.maplibre.mlt.metadata.stream.StreamMetadata;
 import org.maplibre.mlt.util.ExceptionUtil;
+import org.maplibre.mlt.util.OptionalUtil;
 
 public class GeometryEncoder {
 
@@ -240,10 +241,12 @@ public class GeometryEncoder {
 
     final var dictBeatsPlain =
         dictionaryEncodedSize.map(s -> s < plainVertexBufferSize).orElse(false);
-    final var dictBeatsMorton = isLessThan(dictionaryEncodedSize, mortonDictionaryEncodedSize);
+    final var dictBeatsMorton =
+        OptionalUtil.isLessThan(dictionaryEncodedSize, mortonDictionaryEncodedSize);
     final var mortonBeatsPlain =
         mortonDictionaryEncodedSize.map(s -> s < plainVertexBufferSize).orElse(false);
-    final var mortonBeatsDict = isLessThan(mortonDictionaryEncodedSize, dictionaryEncodedSize);
+    final var mortonBeatsDict =
+        OptionalUtil.isLessThan(mortonDictionaryEncodedSize, dictionaryEncodedSize);
 
     if (dictBeatsPlain && dictBeatsMorton) {
       selectedVertexOffsets = vertexDictionaryOffsets.get();
@@ -277,21 +280,6 @@ public class GeometryEncoder {
     result.addAll(selectedVertexStream);
     return new EncodedGeometryColumn(
         numStreams + 1, result, vertexLimits.max, geometryColumnSorted);
-  }
-
-  private static <T extends Comparable<T>> boolean isLessThan(Optional<T> a, Optional<T> b) {
-    return isLessThan(a, b, Comparator.<T>naturalOrder());
-  }
-
-  /// Compare two Optional values, treating empty as greater than any present value
-  private static <T> boolean isLessThan(Optional<T> a, Optional<T> b, Comparator<T> comparator) {
-    if (a.isEmpty()) {
-      return false;
-    } else if (b.isEmpty()) {
-      return true;
-    } else {
-      return comparator.compare(a.get(), b.get()) < 0;
-    }
   }
 
   private static record MinMax<T>(T min, T max) {}

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/GeometryEncoder.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/GeometryEncoder.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.IntStream;
@@ -33,6 +34,7 @@ import org.locationtech.jts.geom.Polygon;
 import org.maplibre.mlt.converter.ConversionConfig.IntegerEncodingOption;
 import org.maplibre.mlt.converter.geometry.GeometryType;
 import org.maplibre.mlt.converter.geometry.GeometryUtils;
+import org.maplibre.mlt.converter.geometry.Hilbert;
 import org.maplibre.mlt.converter.geometry.HilbertCurve;
 import org.maplibre.mlt.converter.geometry.SpaceFillingCurve;
 import org.maplibre.mlt.converter.geometry.Vertex;
@@ -46,6 +48,7 @@ import org.maplibre.mlt.metadata.stream.OffsetType;
 import org.maplibre.mlt.metadata.stream.PhysicalLevelTechnique;
 import org.maplibre.mlt.metadata.stream.PhysicalStreamType;
 import org.maplibre.mlt.metadata.stream.StreamMetadata;
+import org.maplibre.mlt.util.ExceptionUtil;
 
 public class GeometryEncoder {
 
@@ -63,7 +66,7 @@ public class GeometryEncoder {
       List<Geometry> geometries,
       PhysicalLevelTechnique physicalLevelTechnique,
       SortSettings sortSettings,
-      boolean useMortonEncoding,
+      boolean enableMortonEncoding,
       boolean enableTessellation,
       boolean encodePolygonOutlines,
       @Nullable URI tessellateSource,
@@ -98,36 +101,39 @@ public class GeometryEncoder {
      * */
 
     final var vertexLimits = getVertexLimits(vertexBuffer);
-    final var hilbertCurve = new HilbertCurve(vertexLimits.min, vertexLimits.max);
-    final var zOrderCurve = new ZOrderCurve(vertexLimits.min, vertexLimits.max);
+    final var tryHilbertEncoding = HilbertCurve.isRangeSupported(vertexLimits.min, vertexLimits.max);
+    final var tryMortonEncoding = enableMortonEncoding && ZOrderCurve.isRangeSupported(vertexLimits.min, vertexLimits.max);
+    final Optional<HilbertCurve> hilbertCurve = tryHilbertEncoding ? Optional.of(new HilbertCurve(vertexLimits.min, vertexLimits.max)) : Optional.empty();
+    final Optional<ZOrderCurve> zOrderCurve = tryMortonEncoding ? Optional.of(new ZOrderCurve(vertexLimits.min, vertexLimits.max)) : Optional.empty();
 
     // TODO: if the ratio is lower than 2 dictionary encoding has not to be considered?
-    final var vertexDictionary = addVerticesToDictionary(vertexBuffer, hilbertCurve);
-    final var vertexDictionaryHilbertIndexes = vertexDictionary.getLeft();
-    final var vertexDictionaryHilbertMap = reverseMap(vertexDictionaryHilbertIndexes);
-    final var vertexDictionaryVertices = vertexDictionary.getRight();
-    final var vertexDictionaryOffsets =
-        getVertexOffsets(vertexBuffer, vertexDictionaryHilbertMap::get, hilbertCurve);
-    final var zigZagDeltaVertexDictionary = zigZagDeltaEncodeVertices(vertexDictionaryVertices);
-    final var mortonEncodedDictionary =
-        useMortonEncoding ? addVerticesToMortonDictionary(vertexBuffer, zOrderCurve) : null;
-    final var mortonEncodedDictionaryOffsets =
-        useMortonEncoding
-            ? getVertexOffsets(vertexBuffer, reverseMap(mortonEncodedDictionary)::get, zOrderCurve)
-            : null;
+
+    final var vertexDictionary = hilbertCurve.map(c -> addVerticesToDictionary(vertexBuffer, c));
+    final var vertexDictionaryHilbertIndexes = vertexDictionary.map(Pair::getLeft);
+    final var vertexDictionaryHilbertMap = vertexDictionaryHilbertIndexes.map(GeometryEncoder::reverseMap);
+    final var vertexDictionaryVertices = vertexDictionary.map(Pair::getRight);
+    final var vertexDictionaryOffsets = hilbertCurve.flatMap(c -> vertexDictionaryHilbertMap.map(m -> getVertexOffsets(vertexBuffer, m::get, c)));
+    final var zigZagDeltaVertexDictionary = vertexDictionaryVertices.map(GeometryEncoder::zigZagDeltaEncodeVertices);
+    final var mortonEncodedDictionary = zOrderCurve.map(c -> addVerticesToMortonDictionary(vertexBuffer, c));
+    final var mortonEncodedDictionaryOffsets = zOrderCurve.flatMap(c ->  mortonEncodedDictionary.map(d -> 
+      getVertexOffsets(vertexBuffer, reverseMap(d)::get, c)
+    ));
+    if (tryHilbertEncoding && vertexDictionaryOffsets.isEmpty()) {
+      int x = 0;
+    }
 
     // TODO: refactor this simple approach to also work with mixed geometries
     var geometryColumnSorted = false;
     if (sortSettings.isSortable && numGeometries.isEmpty() && numRings.isEmpty()) {
       if (numParts.size() == sortSettings.featureIds.size()) {
         /* Currently the VertexOffsets are only sorted if all geometries in the geometry column are of type LineString */
-        if (useMortonEncoding) {
+        if (mortonEncodedDictionaryOffsets.isPresent()) {
           GeometryUtils.sortVertexOffsets(
-              numParts, mortonEncodedDictionaryOffsets, sortSettings.featureIds());
+              numParts, mortonEncodedDictionaryOffsets.get(), sortSettings.featureIds());
           geometryColumnSorted = true;
         }
-      } else if (numParts.isEmpty()) {
-        GeometryUtils.sortPoints(vertexBuffer, hilbertCurve, sortSettings.featureIds);
+      } else if (numParts.isEmpty() && hilbertCurve.isPresent()) {
+        GeometryUtils.sortPoints(vertexBuffer, hilbertCurve.get(), sortSettings.featureIds);
         geometryColumnSorted = true;
       }
     }
@@ -145,31 +151,27 @@ public class GeometryEncoder {
             .encodedValues
             .length;
     final var encodedMortonEncodedDictionaryOffsetsSize =
-        useMortonEncoding
-            ? IntegerEncoder.encodeInt(
-                    mortonEncodedDictionaryOffsets, physicalLevelTechnique, false, encodingOption)
+    mortonEncodedDictionaryOffsets.map(o -> IntegerEncoder.encodeInt(o, physicalLevelTechnique, false, encodingOption)
                 .encodedValues
-                .length
-            : 0;
+                .length);
     final var encodedDictionaryOffsetsSize =
-        IntegerEncoder.encodeInt(
-                vertexDictionaryOffsets, physicalLevelTechnique, false, encodingOption)
+        vertexDictionaryOffsets.map(o -> IntegerEncoder.encodeInt(
+                o, physicalLevelTechnique, false, encodingOption)
             .encodedValues
-            .length;
+            .length);
     final var encodedVertexDictionarySize =
-        IntegerEncoder.encodeInt(
-                zigZagDeltaVertexDictionary, physicalLevelTechnique, false, encodingOption)
+        zigZagDeltaVertexDictionary.map(d -> IntegerEncoder.encodeInt(
+                d, physicalLevelTechnique, false, encodingOption)
             .encodedValues
-            .length;
+            .length);
     final var encodedMortonVertexDictionarySize =
-        useMortonEncoding
-            ? IntegerEncoder.encodeMortonCodes(mortonEncodedDictionary, physicalLevelTechnique)
+        mortonEncodedDictionary.map(ExceptionUtil.unchecked(d ->
+            IntegerEncoder.encodeMortonCodes(d, physicalLevelTechnique)
                 .encodedValues
-                .length
-            : 0;
-    final var dictionaryEncodedSize = encodedDictionaryOffsetsSize + encodedVertexDictionarySize;
+                .length));
+    final var dictionaryEncodedSize = encodedDictionaryOffsetsSize.flatMap(a -> encodedVertexDictionarySize.map(b -> a + b));
     final var mortonDictionaryEncodedSize =
-        encodedMortonEncodedDictionaryOffsetsSize + encodedMortonVertexDictionarySize;
+        encodedMortonEncodedDictionaryOffsetsSize.flatMap(a -> encodedMortonVertexDictionarySize.map(b -> a + b));
     // TODO: end
 
     final var result =
@@ -216,22 +218,23 @@ public class GeometryEncoder {
 
     @NotNull final ArrayList<byte[]> selectedVertexStream;
     @Nullable final int[] selectedVertexOffsets;
-    if (plainVertexBufferSize <= dictionaryEncodedSize
-        && (!useMortonEncoding || plainVertexBufferSize <= mortonDictionaryEncodedSize)) {
+
+    if (dictionaryEncodedSize.map(s -> plainVertexBufferSize <= s).orElse(true)
+        && mortonDictionaryEncodedSize.map(s -> plainVertexBufferSize <= s).orElse(true)) {
       selectedVertexStream = encodedVertexBufferStream;
       selectedVertexOffsets = null;
-    } else if (!useMortonEncoding || dictionaryEncodedSize <= mortonDictionaryEncodedSize) {
-      selectedVertexOffsets = vertexDictionaryOffsets;
+    } else if (dictionaryEncodedSize.map(dictSize -> mortonDictionaryEncodedSize.map(mortonSize -> dictSize <= mortonSize).orElse(true)).orElse(false)) {
+      selectedVertexOffsets = vertexDictionaryOffsets.get();
       selectedVertexStream =
-          encodeVertexBuffer(zigZagDeltaVertexDictionary, physicalLevelTechnique);
+          encodeVertexBuffer(zigZagDeltaVertexDictionary.get(), physicalLevelTechnique);
       geometryColumnSorted = false;
     } else { // Morton
-      selectedVertexOffsets = mortonEncodedDictionaryOffsets;
+      selectedVertexOffsets = mortonEncodedDictionaryOffsets.get();
       selectedVertexStream =
           IntegerEncoder.encodeMortonStream(
-              mortonEncodedDictionary,
-              zOrderCurve.numBits(),
-              zOrderCurve.coordinateShift(),
+              mortonEncodedDictionary.get(),
+              zOrderCurve.get().numBits(),
+              zOrderCurve.get().coordinateShift(),
               physicalLevelTechnique);
     }
 
@@ -265,26 +268,6 @@ public class GeometryEncoder {
       if (y > maxVertexValue) maxVertexValue = y;
     }
     return new MinMax<Integer>(minVertexValue, maxVertexValue);
-  }
-
-  /// Non-tessellation overload
-  private static void prepareGeometry(
-      List<Geometry> geometries,
-      ArrayList<Integer> numGeometries,
-      ArrayList<Integer> geometryTypes,
-      ArrayList<Vertex> vertexBuffer,
-      ArrayList<Integer> numParts,
-      ArrayList<Integer> numRings) {
-    prepareGeometry(
-        geometries,
-        numGeometries,
-        geometryTypes,
-        vertexBuffer,
-        numParts,
-        numRings,
-        null,
-        null,
-        null);
   }
 
   /// Break geometry down into encodable components

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/GeometryEncoder.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/GeometryEncoder.java
@@ -34,7 +34,6 @@ import org.locationtech.jts.geom.Polygon;
 import org.maplibre.mlt.converter.ConversionConfig.IntegerEncodingOption;
 import org.maplibre.mlt.converter.geometry.GeometryType;
 import org.maplibre.mlt.converter.geometry.GeometryUtils;
-import org.maplibre.mlt.converter.geometry.Hilbert;
 import org.maplibre.mlt.converter.geometry.HilbertCurve;
 import org.maplibre.mlt.converter.geometry.SpaceFillingCurve;
 import org.maplibre.mlt.converter.geometry.Vertex;
@@ -101,23 +100,38 @@ public class GeometryEncoder {
      * */
 
     final var vertexLimits = getVertexLimits(vertexBuffer);
-    final var tryHilbertEncoding = HilbertCurve.isRangeSupported(vertexLimits.min, vertexLimits.max);
-    final var tryMortonEncoding = enableMortonEncoding && ZOrderCurve.isRangeSupported(vertexLimits.min, vertexLimits.max);
-    final Optional<HilbertCurve> hilbertCurve = tryHilbertEncoding ? Optional.of(new HilbertCurve(vertexLimits.min, vertexLimits.max)) : Optional.empty();
-    final Optional<ZOrderCurve> zOrderCurve = tryMortonEncoding ? Optional.of(new ZOrderCurve(vertexLimits.min, vertexLimits.max)) : Optional.empty();
+    final var tryHilbertEncoding =
+        HilbertCurve.isRangeSupported(vertexLimits.min, vertexLimits.max);
+    final var tryMortonEncoding =
+        enableMortonEncoding && ZOrderCurve.isRangeSupported(vertexLimits.min, vertexLimits.max);
+    final Optional<HilbertCurve> hilbertCurve =
+        tryHilbertEncoding
+            ? Optional.of(new HilbertCurve(vertexLimits.min, vertexLimits.max))
+            : Optional.empty();
+    final Optional<ZOrderCurve> zOrderCurve =
+        tryMortonEncoding
+            ? Optional.of(new ZOrderCurve(vertexLimits.min, vertexLimits.max))
+            : Optional.empty();
 
     // TODO: if the ratio is lower than 2 dictionary encoding has not to be considered?
 
     final var vertexDictionary = hilbertCurve.map(c -> addVerticesToDictionary(vertexBuffer, c));
     final var vertexDictionaryHilbertIndexes = vertexDictionary.map(Pair::getLeft);
-    final var vertexDictionaryHilbertMap = vertexDictionaryHilbertIndexes.map(GeometryEncoder::reverseMap);
+    final var vertexDictionaryHilbertMap =
+        vertexDictionaryHilbertIndexes.map(GeometryEncoder::reverseMap);
     final var vertexDictionaryVertices = vertexDictionary.map(Pair::getRight);
-    final var vertexDictionaryOffsets = hilbertCurve.flatMap(c -> vertexDictionaryHilbertMap.map(m -> getVertexOffsets(vertexBuffer, m::get, c)));
-    final var zigZagDeltaVertexDictionary = vertexDictionaryVertices.map(GeometryEncoder::zigZagDeltaEncodeVertices);
-    final var mortonEncodedDictionary = zOrderCurve.map(c -> addVerticesToMortonDictionary(vertexBuffer, c));
-    final var mortonEncodedDictionaryOffsets = zOrderCurve.flatMap(c ->  mortonEncodedDictionary.map(d -> 
-      getVertexOffsets(vertexBuffer, reverseMap(d)::get, c)
-    ));
+    final var vertexDictionaryOffsets =
+        hilbertCurve.flatMap(
+            c -> vertexDictionaryHilbertMap.map(m -> getVertexOffsets(vertexBuffer, m::get, c)));
+    final var zigZagDeltaVertexDictionary =
+        vertexDictionaryVertices.map(GeometryEncoder::zigZagDeltaEncodeVertices);
+    final var mortonEncodedDictionary =
+        zOrderCurve.map(c -> addVerticesToMortonDictionary(vertexBuffer, c));
+    final var mortonEncodedDictionaryOffsets =
+        zOrderCurve.flatMap(
+            c ->
+                mortonEncodedDictionary.map(
+                    d -> getVertexOffsets(vertexBuffer, reverseMap(d)::get, c)));
 
     // TODO: refactor this simple approach to also work with mixed geometries
     var geometryColumnSorted = false;
@@ -148,27 +162,35 @@ public class GeometryEncoder {
             .encodedValues
             .length;
     final var encodedMortonEncodedDictionaryOffsetsSize =
-    mortonEncodedDictionaryOffsets.map(o -> IntegerEncoder.encodeInt(o, physicalLevelTechnique, false, encodingOption)
-                .encodedValues
-                .length);
+        mortonEncodedDictionaryOffsets.map(
+            o ->
+                IntegerEncoder.encodeInt(o, physicalLevelTechnique, false, encodingOption)
+                    .encodedValues
+                    .length);
     final var encodedDictionaryOffsetsSize =
-        vertexDictionaryOffsets.map(o -> IntegerEncoder.encodeInt(
-                o, physicalLevelTechnique, false, encodingOption)
-            .encodedValues
-            .length);
+        vertexDictionaryOffsets.map(
+            o ->
+                IntegerEncoder.encodeInt(o, physicalLevelTechnique, false, encodingOption)
+                    .encodedValues
+                    .length);
     final var encodedVertexDictionarySize =
-        zigZagDeltaVertexDictionary.map(d -> IntegerEncoder.encodeInt(
-                d, physicalLevelTechnique, false, encodingOption)
-            .encodedValues
-            .length);
+        zigZagDeltaVertexDictionary.map(
+            d ->
+                IntegerEncoder.encodeInt(d, physicalLevelTechnique, false, encodingOption)
+                    .encodedValues
+                    .length);
     final var encodedMortonVertexDictionarySize =
-        mortonEncodedDictionary.map(ExceptionUtil.unchecked(d ->
-            IntegerEncoder.encodeMortonCodes(d, physicalLevelTechnique)
-                .encodedValues
-                .length));
-    final var dictionaryEncodedSize = encodedDictionaryOffsetsSize.flatMap(a -> encodedVertexDictionarySize.map(b -> a + b));
+        mortonEncodedDictionary.map(
+            ExceptionUtil.unchecked(
+                d ->
+                    IntegerEncoder.encodeMortonCodes(d, physicalLevelTechnique)
+                        .encodedValues
+                        .length));
+    final var dictionaryEncodedSize =
+        encodedDictionaryOffsetsSize.flatMap(a -> encodedVertexDictionarySize.map(b -> a + b));
     final var mortonDictionaryEncodedSize =
-        encodedMortonEncodedDictionaryOffsetsSize.flatMap(a -> encodedMortonVertexDictionarySize.map(b -> a + b));
+        encodedMortonEncodedDictionaryOffsetsSize.flatMap(
+            a -> encodedMortonVertexDictionarySize.map(b -> a + b));
     // TODO: end
 
     final var result =
@@ -216,16 +238,19 @@ public class GeometryEncoder {
     @NotNull final ArrayList<byte[]> selectedVertexStream;
     @Nullable final int[] selectedVertexOffsets;
 
-    if (dictionaryEncodedSize.map(s -> plainVertexBufferSize <= s).orElse(true)
-        && mortonDictionaryEncodedSize.map(s -> plainVertexBufferSize <= s).orElse(true)) {
-      selectedVertexStream = encodedVertexBufferStream;
-      selectedVertexOffsets = null;
-    } else if (dictionaryEncodedSize.map(dictSize -> mortonDictionaryEncodedSize.map(mortonSize -> dictSize <= mortonSize).orElse(true)).orElse(false)) {
+    final var dictBeatsPlain =
+        dictionaryEncodedSize.map(s -> s < plainVertexBufferSize).orElse(false);
+    final var dictBeatsMorton = isLessThan(dictionaryEncodedSize, mortonDictionaryEncodedSize);
+    final var mortonBeatsPlain =
+        mortonDictionaryEncodedSize.map(s -> s < plainVertexBufferSize).orElse(false);
+    final var mortonBeatsDict = isLessThan(mortonDictionaryEncodedSize, dictionaryEncodedSize);
+
+    if (dictBeatsPlain && dictBeatsMorton) {
       selectedVertexOffsets = vertexDictionaryOffsets.get();
       selectedVertexStream =
           encodeVertexBuffer(zigZagDeltaVertexDictionary.get(), physicalLevelTechnique);
       geometryColumnSorted = false;
-    } else { // Morton
+    } else if (mortonBeatsPlain && mortonBeatsDict) {
       selectedVertexOffsets = mortonEncodedDictionaryOffsets.get();
       selectedVertexStream =
           IntegerEncoder.encodeMortonStream(
@@ -233,6 +258,9 @@ public class GeometryEncoder {
               zOrderCurve.get().numBits(),
               zOrderCurve.get().coordinateShift(),
               physicalLevelTechnique);
+    } else {
+      selectedVertexStream = encodedVertexBufferStream;
+      selectedVertexOffsets = null;
     }
 
     if (selectedVertexOffsets != null && selectedVertexOffsets.length > 0) {
@@ -249,6 +277,21 @@ public class GeometryEncoder {
     result.addAll(selectedVertexStream);
     return new EncodedGeometryColumn(
         numStreams + 1, result, vertexLimits.max, geometryColumnSorted);
+  }
+
+  private static <T extends Comparable<T>> boolean isLessThan(Optional<T> a, Optional<T> b) {
+    return isLessThan(a, b, Comparator.<T>naturalOrder());
+  }
+
+  /// Compare two Optional values, treating empty as greater than any present value
+  private static <T> boolean isLessThan(Optional<T> a, Optional<T> b, Comparator<T> comparator) {
+    if (a.isEmpty()) {
+      return false;
+    } else if (b.isEmpty()) {
+      return true;
+    } else {
+      return comparator.compare(a.get(), b.get()) < 0;
+    }
   }
 
   private static record MinMax<T>(T min, T max) {}

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/GeometryEncoder.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/GeometryEncoder.java
@@ -118,9 +118,6 @@ public class GeometryEncoder {
     final var mortonEncodedDictionaryOffsets = zOrderCurve.flatMap(c ->  mortonEncodedDictionary.map(d -> 
       getVertexOffsets(vertexBuffer, reverseMap(d)::get, c)
     ));
-    if (tryHilbertEncoding && vertexDictionaryOffsets.isEmpty()) {
-      int x = 0;
-    }
 
     // TODO: refactor this simple approach to also work with mixed geometries
     var geometryColumnSorted = false;

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/geometry/SpaceFillingCurve.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/geometry/SpaceFillingCurve.java
@@ -26,8 +26,8 @@ public abstract class SpaceFillingCurve {
     this.minBound = minVertexValue;
     this.maxBound = maxVertexValue;
 
-    if (numBits > 16) {
-      throw new IllegalArgumentException("The specified tile buffer size is not supported");
+    if (numBits > MAX_SUPPORTED_BITS) {
+      throw new IllegalArgumentException("Tile coordinate span " + this.tileExtent + " is too large");
     }
   }
 
@@ -43,6 +43,9 @@ public abstract class SpaceFillingCurve {
   }
 
   private static int getCoordinateShift(int minVertexValue) {
+    if (minVertexValue == Integer.MIN_VALUE) {
+      return Integer.MAX_VALUE;
+    }
     return (minVertexValue < 0) ? Math.abs(minVertexValue) : 0;
   }
 

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/geometry/SpaceFillingCurve.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/geometry/SpaceFillingCurve.java
@@ -27,7 +27,8 @@ public abstract class SpaceFillingCurve {
     this.maxBound = maxVertexValue;
 
     if (numBits > MAX_SUPPORTED_BITS) {
-      throw new IllegalArgumentException("Tile coordinate span " + this.tileExtent + " is too large");
+      throw new IllegalArgumentException(
+          "Tile coordinate span " + this.tileExtent + " is too large");
     }
   }
 

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/geometry/SpaceFillingCurve.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/geometry/SpaceFillingCurve.java
@@ -27,8 +27,7 @@ public abstract class SpaceFillingCurve {
     this.maxBound = maxVertexValue;
 
     if (numBits > 16) {
-      throw new IllegalArgumentException(
-          "The specified tile buffer size is not supported");
+      throw new IllegalArgumentException("The specified tile buffer size is not supported");
     }
   }
 

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/geometry/SpaceFillingCurve.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/geometry/SpaceFillingCurve.java
@@ -7,18 +7,29 @@ public abstract class SpaceFillingCurve {
   private final int minBound;
   private final int maxBound;
 
+  public static final int MAX_SUPPORTED_BITS = 16;
+  public static final int MAX_SUPPORTED_RANGE = (1 << MAX_SUPPORTED_BITS) - 1;
+
+  public static boolean isRangeSupported(int minVertexValue, int maxVertexValue) {
+    return (maxVertexValue + getCoordinateShift(minVertexValue)) <= MAX_SUPPORTED_RANGE;
+  }
+
   public SpaceFillingCurve(int minVertexValue, int maxVertexValue) {
     // TODO: fix tile buffer problem
     /* Each tile can have a buffer around, which means the coordinate values are extended beyond the specified tileExtent.
      * Currently we are extending size tile size be half of to the size into each direction, which works well for the test tilesets.
      * But this leads to problems if the tile coordinates are not within this boundaries.
      * */
-    coordinateShift = minVertexValue < 0 ? Math.abs(minVertexValue) : 0;
+    this.coordinateShift = getCoordinateShift(minVertexValue);
     this.tileExtent = maxVertexValue + coordinateShift;
     this.numBits = (int) Math.ceil((Math.log(this.tileExtent + 1) / Math.log(2)));
-    ;
-    minBound = minVertexValue;
-    maxBound = maxVertexValue;
+    this.minBound = minVertexValue;
+    this.maxBound = maxVertexValue;
+
+    if (numBits > 16) {
+      throw new IllegalArgumentException(
+          "The specified tile buffer size is not supported");
+    }
   }
 
   protected void validateCoordinates(Vertex vertex) {
@@ -30,6 +41,10 @@ public abstract class SpaceFillingCurve {
       throw new IllegalArgumentException(
           "The specified tile buffer size is currently not supported.");
     }
+  }
+
+  private static int getCoordinateShift(int minVertexValue) {
+    return (minVertexValue < 0) ? Math.abs(minVertexValue) : 0;
   }
 
   public abstract int encode(Vertex vertex);

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/util/ExceptionUtil.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/util/ExceptionUtil.java
@@ -1,0 +1,22 @@
+package org.maplibre.mlt.util;
+
+import java.util.function.Function;
+
+public class ExceptionUtil {
+    @FunctionalInterface
+    public interface ThrowingFunction<T, R, E extends Exception> {
+        R apply(T t) throws E;
+    }
+
+    /// Wraps a function that throws a checked exception in a RuntimeException, allowing
+    /// it to be used in contexts that don't allow checked exceptions, e.g., streams.
+    public static <T, R, E extends Exception> Function<T, R> unchecked(ThrowingFunction<T, R, E> f) {
+        return t -> {
+            try {
+                return f.apply(t);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+}

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/util/ExceptionUtil.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/util/ExceptionUtil.java
@@ -1,5 +1,7 @@
 package org.maplibre.mlt.util;
 
+import org.apache.commons.lang3.exception.UncheckedException;
+
 import java.util.function.Function;
 
 public class ExceptionUtil {
@@ -14,8 +16,10 @@ public class ExceptionUtil {
     return t -> {
       try {
         return f.apply(t);
+      } catch (RuntimeException e) {
+        throw e;
       } catch (Exception e) {
-        throw new RuntimeException(e);
+        throw new UncheckedException(e);
       }
     };
   }

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/util/ExceptionUtil.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/util/ExceptionUtil.java
@@ -1,8 +1,7 @@
 package org.maplibre.mlt.util;
 
-import org.apache.commons.lang3.exception.UncheckedException;
-
 import java.util.function.Function;
+import org.apache.commons.lang3.exception.UncheckedException;
 
 public class ExceptionUtil {
   @FunctionalInterface

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/util/ExceptionUtil.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/util/ExceptionUtil.java
@@ -3,20 +3,20 @@ package org.maplibre.mlt.util;
 import java.util.function.Function;
 
 public class ExceptionUtil {
-    @FunctionalInterface
-    public interface ThrowingFunction<T, R, E extends Exception> {
-        R apply(T t) throws E;
-    }
+  @FunctionalInterface
+  public interface ThrowingFunction<T, R, E extends Exception> {
+    R apply(T t) throws E;
+  }
 
-    /// Wraps a function that throws a checked exception in a RuntimeException, allowing
-    /// it to be used in contexts that don't allow checked exceptions, e.g., streams.
-    public static <T, R, E extends Exception> Function<T, R> unchecked(ThrowingFunction<T, R, E> f) {
-        return t -> {
-            try {
-                return f.apply(t);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        };
-    }
+  /// Wraps a function that throws a checked exception in a RuntimeException, allowing
+  /// it to be used in contexts that don't allow checked exceptions, e.g., streams.
+  public static <T, R, E extends Exception> Function<T, R> unchecked(ThrowingFunction<T, R, E> f) {
+    return t -> {
+      try {
+        return f.apply(t);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    };
+  }
 }

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/util/OptionalUtil.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/util/OptionalUtil.java
@@ -1,0 +1,38 @@
+package org.maplibre.mlt.util;
+
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import org.jetbrains.annotations.NotNull;
+
+public class OptionalUtil {
+  /// Compare two Optional values with the specified comparator.
+  // Empty is not less than any value, and any value is less than empty.
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  public static <T extends Comparable<T>> boolean isLessThan(
+      @NotNull Optional<T> a, @NotNull Optional<T> b) {
+    return isLessThan(a, b, Comparator.<T>naturalOrder());
+  }
+
+  /// Compare two Optional values.
+  // Empty is not less than any value, and any value is less than empty.
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  private static <T> boolean isLessThan(
+      @NotNull Optional<T> a, @NotNull Optional<T> b, @NotNull Comparator<T> comparator) {
+    if (a.isEmpty()) {
+      return false;
+    }
+    if (b.isEmpty()) {
+      return true;
+    }
+    return comparator.compare(a.get(), b.get()) < 0;
+  }
+
+  /// Map two Optional values to a single Optional value using the specified function.
+  /// The result is empty if either input is empty.
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  public static <T, U, V> Optional<V> map(
+      Optional<T> a, Optional<U> b, BiFunction<? super T, ? super U, ? extends V> f) {
+    return a.flatMap(av -> b.map(bv -> f.apply(av, bv)));
+  }
+}

--- a/java/mlt-core/src/test/java/org/maplibre/mlt/converter/geometry/HilbertCurveTest.java
+++ b/java/mlt-core/src/test/java/org/maplibre/mlt/converter/geometry/HilbertCurveTest.java
@@ -27,14 +27,16 @@ public class HilbertCurveTest {
 
   @Test
   public void consecutiveIndices_areAxisAdjacentAtLevel6() {
-    int level = 6;
-    int maxCoordinate = (1 << level) - 1;
+    final int level = 6;
+    final int maxCoordinate = (1 << level) - 1;
     final var curve = new HilbertCurve(0, maxCoordinate);
-
-    int maxIndexExclusive = 1 << (2 * level);
-    for (int index = 0; index < maxIndexExclusive - 1; index++) {
-      final var a = curve.decode(index);
-      final var b = curve.decode(index + 1);
+    final long maxIndexExclusive = 1L << (2L * level);
+    final long step = Math.max(1L, maxIndexExclusive / 4096L);
+    for (long index = 0; index < maxIndexExclusive - 1; index += step) {
+      final int currentIndex = (int) index;
+      final int nextIndex = (int) (index + 1);
+      final var a = curve.decode(currentIndex);
+      final var b = curve.decode(nextIndex);
       final int manhattan = Math.abs(a[0] - b[0]) + Math.abs(a[1] - b[1]);
       assertEquals(1, manhattan, "Hilbert curve should move one grid step per index increment");
     }
@@ -46,7 +48,7 @@ public class HilbertCurveTest {
   }
 
   private static void assertRoundTripForLevel(int level) {
-    int maxCoordinate = (1 << level) - 1;
+    final int maxCoordinate = (1 << level) - 1;
     final var curve = new HilbertCurve(0, maxCoordinate);
 
     assertRoundTrip(curve, 0, 0);

--- a/java/mlt-core/src/test/java/org/maplibre/mlt/converter/geometry/HilbertCurveTest.java
+++ b/java/mlt-core/src/test/java/org/maplibre/mlt/converter/geometry/HilbertCurveTest.java
@@ -66,6 +66,7 @@ public class HilbertCurveTest {
   private static void assertRoundTrip(HilbertCurve curve, int x, int y) {
     final int index = curve.encode(new Vertex(x, y));
     final int[] decoded = curve.decode(index);
-    assertArrayEquals(new int[] {x, y}, decoded, "Coordinate should round-trip through encode/decode");
+    assertArrayEquals(
+        new int[] {x, y}, decoded, "Coordinate should round-trip through encode/decode");
   }
 }

--- a/java/mlt-core/src/test/java/org/maplibre/mlt/converter/geometry/HilbertCurveTest.java
+++ b/java/mlt-core/src/test/java/org/maplibre/mlt/converter/geometry/HilbertCurveTest.java
@@ -1,0 +1,71 @@
+package org.maplibre.mlt.converter.geometry;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class HilbertCurveTest {
+
+  @Test
+  public void level1_hasExpectedStandardOrder() {
+    final var curve = new HilbertCurve(0, 1);
+    assertArrayEquals(new int[] {0, 0}, curve.decode(0));
+    assertArrayEquals(new int[] {0, 1}, curve.decode(1));
+    assertArrayEquals(new int[] {1, 1}, curve.decode(2));
+    assertArrayEquals(new int[] {1, 0}, curve.decode(3));
+  }
+
+  @ParameterizedTest(name = "level={0}")
+  @ValueSource(ints = {1, 2, 5, 10, 16})
+  public void encodeDecode_roundTripsForRepresentativeLevels(int level) {
+    assertRoundTripForLevel(level);
+  }
+
+  @Test
+  public void consecutiveIndices_areAxisAdjacentAtLevel6() {
+    int level = 6;
+    int maxCoordinate = (1 << level) - 1;
+    final var curve = new HilbertCurve(0, maxCoordinate);
+
+    int maxIndexExclusive = 1 << (2 * level);
+    for (int index = 0; index < maxIndexExclusive - 1; index++) {
+      final var a = curve.decode(index);
+      final var b = curve.decode(index + 1);
+      final int manhattan = Math.abs(a[0] - b[0]) + Math.abs(a[1] - b[1]);
+      assertEquals(1, manhattan, "Hilbert curve should move one grid step per index increment");
+    }
+  }
+
+  @Test
+  public void throwsWhenLevelIsAboveMaximumAllowed() {
+    assertThrows(IllegalArgumentException.class, () -> assertRoundTripForLevel(17));
+  }
+
+  private static void assertRoundTripForLevel(int level) {
+    int maxCoordinate = (1 << level) - 1;
+    final var curve = new HilbertCurve(0, maxCoordinate);
+
+    assertRoundTrip(curve, 0, 0);
+    assertRoundTrip(curve, maxCoordinate, 0);
+    assertRoundTrip(curve, 0, maxCoordinate);
+    assertRoundTrip(curve, maxCoordinate, maxCoordinate);
+    assertRoundTrip(curve, maxCoordinate / 2, maxCoordinate / 2);
+
+    final int step = Math.max(1, maxCoordinate / 7);
+    for (int y = 0; y <= maxCoordinate; y += step) {
+      for (int x = 0; x <= maxCoordinate; x += step) {
+        assertRoundTrip(curve, x, y);
+      }
+    }
+  }
+
+  private static void assertRoundTrip(HilbertCurve curve, int x, int y) {
+    final int index = curve.encode(new Vertex(x, y));
+    final int[] decoded = curve.decode(index);
+    assertArrayEquals(new int[] {x, y}, decoded, "Coordinate should round-trip through encode/decode");
+  }
+}

--- a/java/mlt-core/src/test/java/org/maplibre/mlt/converter/geometry/ZOrderCurveTest.java
+++ b/java/mlt-core/src/test/java/org/maplibre/mlt/converter/geometry/ZOrderCurveTest.java
@@ -54,15 +54,15 @@ public class ZOrderCurveTest {
   }
 
   private static void assertStaticDecodeMatchesInstanceDecode(int level) {
-    int maxCoordinate = (1 << level) - 1;
+    final int maxCoordinate = (1 << level) - 1;
     final var curve = new ZOrderCurve(0, maxCoordinate);
-
-    int maxIndexExclusive = 1 << (2 * level);
-    int step = Math.max(1, maxIndexExclusive / 32);
-    for (int index = 0; index < maxIndexExclusive; index += step) {
+    final long maxIndexExclusive = 1L << (2L * level);
+    final long step = Math.max(1L, maxIndexExclusive / 32L);
+    for (long index = 0; index < maxIndexExclusive; index += step) {
+      final int sampledIndex = (int) index;
       assertArrayEquals(
-          curve.decode(index),
-          ZOrderCurve.decode(index, curve.numBits(), curve.coordinateShift()),
+          curve.decode(sampledIndex),
+          ZOrderCurve.decode(sampledIndex, curve.numBits(), curve.coordinateShift()),
           "Static decode should match instance decode");
     }
   }

--- a/java/mlt-core/src/test/java/org/maplibre/mlt/converter/geometry/ZOrderCurveTest.java
+++ b/java/mlt-core/src/test/java/org/maplibre/mlt/converter/geometry/ZOrderCurveTest.java
@@ -70,6 +70,7 @@ public class ZOrderCurveTest {
   private static void assertRoundTrip(ZOrderCurve curve, int x, int y) {
     final int index = curve.encode(new Vertex(x, y));
     final int[] decoded = curve.decode(index);
-    assertArrayEquals(new int[] {x, y}, decoded, "Coordinate should round-trip through encode/decode");
+    assertArrayEquals(
+        new int[] {x, y}, decoded, "Coordinate should round-trip through encode/decode");
   }
 }

--- a/java/mlt-core/src/test/java/org/maplibre/mlt/converter/geometry/ZOrderCurveTest.java
+++ b/java/mlt-core/src/test/java/org/maplibre/mlt/converter/geometry/ZOrderCurveTest.java
@@ -1,0 +1,75 @@
+package org.maplibre.mlt.converter.geometry;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class ZOrderCurveTest {
+
+  @Test
+  public void level1_hasExpectedStandardOrder() {
+    final var curve = new ZOrderCurve(0, 1);
+    assertArrayEquals(new int[] {0, 0}, curve.decode(0));
+    assertArrayEquals(new int[] {1, 0}, curve.decode(1));
+    assertArrayEquals(new int[] {0, 1}, curve.decode(2));
+    assertArrayEquals(new int[] {1, 1}, curve.decode(3));
+  }
+
+  @ParameterizedTest(name = "level={0}")
+  @ValueSource(ints = {1, 2, 5, 10, 16})
+  public void encodeDecode_roundTripsForRepresentativeLevels(int level) {
+    assertRoundTripForLevel(level);
+  }
+
+  @ParameterizedTest(name = "level={0}")
+  @ValueSource(ints = {1, 2, 5, 10, 16})
+  public void staticDecode_matchesInstanceDecodeForRepresentativeLevels(int level) {
+    assertStaticDecodeMatchesInstanceDecode(level);
+  }
+
+  @Test
+  public void throwsWhenLevelIsAboveMaximumAllowed() {
+    assertThrows(IllegalArgumentException.class, () -> assertRoundTripForLevel(17));
+  }
+
+  private static void assertRoundTripForLevel(int level) {
+    final int maxCoordinate = (1 << level) - 1;
+    final var curve = new ZOrderCurve(0, maxCoordinate);
+
+    assertRoundTrip(curve, 0, 0);
+    assertRoundTrip(curve, maxCoordinate, 0);
+    assertRoundTrip(curve, 0, maxCoordinate);
+    assertRoundTrip(curve, maxCoordinate, maxCoordinate);
+    assertRoundTrip(curve, maxCoordinate / 2, maxCoordinate / 2);
+
+    final int step = Math.max(1, maxCoordinate / 7);
+    for (int y = 0; y <= maxCoordinate; y += step) {
+      for (int x = 0; x <= maxCoordinate; x += step) {
+        assertRoundTrip(curve, x, y);
+      }
+    }
+  }
+
+  private static void assertStaticDecodeMatchesInstanceDecode(int level) {
+    int maxCoordinate = (1 << level) - 1;
+    final var curve = new ZOrderCurve(0, maxCoordinate);
+
+    int maxIndexExclusive = 1 << (2 * level);
+    int step = Math.max(1, maxIndexExclusive / 32);
+    for (int index = 0; index < maxIndexExclusive; index += step) {
+      assertArrayEquals(
+          curve.decode(index),
+          ZOrderCurve.decode(index, curve.numBits(), curve.coordinateShift()),
+          "Static decode should match instance decode");
+    }
+  }
+
+  private static void assertRoundTrip(ZOrderCurve curve, int x, int y) {
+    final int index = curve.encode(new Vertex(x, y));
+    final int[] decoded = curve.decode(index);
+    assertArrayEquals(new int[] {x, y}, decoded, "Coordinate should round-trip through encode/decode");
+  }
+}

--- a/java/mlt-core/src/test/java/org/maplibre/mlt/util/OptionalUtilTest.java
+++ b/java/mlt-core/src/test/java/org/maplibre/mlt/util/OptionalUtilTest.java
@@ -1,0 +1,100 @@
+package org.maplibre.mlt.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class OptionalUtilTest {
+  @Test
+  void isLessThanBothEmpty() {
+    assertFalse(OptionalUtil.isLessThan(Optional.<Integer>empty(), Optional.<Integer>empty()));
+  }
+
+  @Test
+  void isLessThan_whenLeftEmptyAndRightPresent_returnsFalse() {
+    assertFalse(OptionalUtil.isLessThan(Optional.<Integer>empty(), Optional.of(10)));
+  }
+
+  @Test
+  void isLessThan_whenLeftPresentAndRightEmpty_returnsTrue() {
+    assertTrue(OptionalUtil.isLessThan(Optional.of(10), Optional.<Integer>empty()));
+  }
+
+  @Test
+  void isLessThanLess() {
+    assertTrue(OptionalUtil.isLessThan(Optional.of(10), Optional.of(20)));
+  }
+
+  @Test
+  void isLessThanEqual() {
+    assertFalse(OptionalUtil.isLessThan(Optional.of(20), Optional.of(20)));
+  }
+
+  @Test
+  void isLessThanGreater() {
+    assertFalse(OptionalUtil.isLessThan(Optional.of(30), Optional.of(20)));
+  }
+
+  @Test
+  void isLessThanSupportsComparableTypes() {
+    assertTrue(OptionalUtil.isLessThan(Optional.of("a"), Optional.of("b")));
+    assertFalse(OptionalUtil.isLessThan(Optional.of("b"), Optional.of("a")));
+  }
+
+  @Test
+  void isLessThanThrowsWhenOptional1Nulls() {
+    assertThrows(NullPointerException.class, () -> OptionalUtil.isLessThan(null, Optional.of(1)));
+  }
+
+  @Test
+  void isLessThanThrowsWhenOptional2Null() {
+    assertThrows(NullPointerException.class, () -> OptionalUtil.isLessThan(Optional.of(1), null));
+  }
+
+  @Test
+  void mapReturnsMappedValue() {
+    final var result = OptionalUtil.map(Optional.of(2), Optional.of(3), Integer::sum);
+    assertEquals(Optional.of(5), result);
+  }
+
+  @Test
+  void mapEmptyWhenOptional1Empty() {
+    final var result = OptionalUtil.map(Optional.<Integer>empty(), Optional.of(3), Integer::sum);
+    assertEquals(Optional.empty(), result);
+  }
+
+  @Test
+  void mapEmptyWhenOptional2Empty() {
+    final var result = OptionalUtil.map(Optional.of(2), Optional.<Integer>empty(), Integer::sum);
+    assertEquals(Optional.empty(), result);
+  }
+
+  @Test
+  void mapBothEmpty() {
+    final var result =
+        OptionalUtil.map(Optional.<Integer>empty(), Optional.<Integer>empty(), Integer::sum);
+    assertEquals(Optional.empty(), result);
+  }
+
+  @Test
+  void mapThrowsWhenOptional1Null() {
+    assertThrows(
+        NullPointerException.class, () -> OptionalUtil.map(null, Optional.of(1), Integer::sum));
+  }
+
+  @Test
+  void mapThrowsWhenOptional2Null() {
+    assertThrows(
+        NullPointerException.class, () -> OptionalUtil.map(Optional.of(1), null, Integer::sum));
+  }
+
+  @Test
+  void mapThrowsWhenFunctionNull() {
+    assertThrows(
+        NullPointerException.class, () -> OptionalUtil.map(Optional.of(1), Optional.of(2), null));
+  }
+}


### PR DESCRIPTION
- Add tests and max-level check for space-filling curves.
- Only consider Hilbert/Morton curves if the vertex span is within their supported range.
