### PR TITLE
chore(rust): release

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2379,7 +2379,7 @@ dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -2630,7 +2630,7 @@ dependencies = [
 
 [[package]]
 name = "mlt"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arbitrary",
  "bitvec",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-py"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "mlt-core",
  "pyo3",
@@ -2723,7 +2723,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-wasm"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "js-sys",
  "mlt-core",
@@ -3202,7 +3202,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 1.0.2",
+ "siphasher 1.0.3",
 ]
 
 [[package]]
@@ -3988,9 +3988,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -4637,9 +4637,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
 dependencies = [
  "serde_core",
  "serde_with_macros",
@@ -4647,9 +4647,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4777,9 +4777,9 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "size_format"
@@ -5314,7 +5314,7 @@ dependencies = [
  "phf",
  "sha2",
  "signal-hook",
- "siphasher 1.0.2",
+ "siphasher 1.0.3",
  "terminfo",
  "termios",
  "thiserror 1.0.69",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -45,7 +45,7 @@ integer-encoding = "4.0.2"
 js-sys = "0.3"
 martin-tile-utils = "0.7"
 mbtiles = { version = "0.17", default-features = false, features = ["transcode"] }
-mlt-core = { version = "0.9.0", path = "mlt-core" }
+mlt-core = { version = "0.9.1", path = "mlt-core" }
 moka = { version = "0.12", features = ["sync"] }
 mvt = "0.13.0"
 mvt-reader = "2.3.0"

--- a/rust/mlt-core/CHANGELOG.md
+++ b/rust/mlt-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-core-v0.9.0...rust-mlt-core-v0.9.1) - 2026-05-05
+
+### Added
+
+- *(rust)* MLT -> MVT write support ([#1369](https://github.com/maplibre/maplibre-tile-spec/pull/1369))
+
 ## [0.9.0](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-core-v0.8.0...rust-mlt-core-v0.9.0) - 2026-04-29
 
 ### Added

--- a/rust/mlt-core/Cargo.toml
+++ b/rust/mlt-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-core"
 description = "MapLibre Tile library code"
-version = "0.9.0"
+version = "0.9.1"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/rust/mlt-py/CHANGELOG.md
+++ b/rust/mlt-py/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.12...python-mlt-v0.1.13) - 2026-05-05
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.12](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.11...python-mlt-v0.1.12) - 2026-04-29
 
 ### Other

--- a/rust/mlt-py/Cargo.toml
+++ b/rust/mlt-py/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-py"
 description = "Python bindings for MapLibre Tile (MLT) format via PyO3"
-version = "0.1.12"
+version = "0.1.13"
 readme = "README.md"
 repository.workspace = true
 edition.workspace = true

--- a/rust/mlt-py/pyproject.toml
+++ b/rust/mlt-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "maplibre-tiles"
-version = "0.1.12"
+version = "0.1.13"
 description = "Python bindings for MapLibre Tile (MLT) format"
 requires-python = ">=3.10"
 license = { text = "MIT OR Apache-2.0" }

--- a/rust/mlt-wasm/CHANGELOG.md
+++ b/rust/mlt-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-wasm-v0.1.6...rust-mlt-wasm-v0.1.7) - 2026-05-05
+
+### Other
+
+- updated the following local packages: mlt-core
+
 ## [0.1.6](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-wasm-v0.1.5...rust-mlt-wasm-v0.1.6) - 2026-04-29
 
 ### Other

--- a/rust/mlt-wasm/Cargo.toml
+++ b/rust/mlt-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-wasm"
 description = "WebAssembly bindings for the MapLibre Tile (MLT) format"
-version = "0.1.6"
+version = "0.1.7"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/rust/mlt-wasm/package-lock.json
+++ b/rust/mlt-wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/mlt-wasm",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/mlt-wasm",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@mapbox/point-geometry": "1.1.0"

--- a/rust/mlt-wasm/package.json
+++ b/rust/mlt-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/mlt-wasm",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "WebAssembly-backed MapLibre Tile (MLT) decoder",
   "type": "module",
   "main": "dist/index.js",

--- a/rust/mlt/CHANGELOG.md
+++ b/rust/mlt/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.11...rust-mlt-v0.1.12) - 2026-05-05
+
+### Added
+
+- *(rust)* MLT -> MVT write support ([#1369](https://github.com/maplibre/maplibre-tile-spec/pull/1369))
+
 ## [0.1.11](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.10...rust-mlt-v0.1.11) - 2026-04-29
 
 ### Added

--- a/rust/mlt/Cargo.toml
+++ b/rust/mlt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt"
 description = "MapLibre Tile Tools"
-version = "0.1.11"
+version = "0.1.12"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `mlt-core`: 0.9.0 -> 0.9.1 (✓ API compatible changes)
* `mlt`: 0.1.11 -> 0.1.12
* `mlt-py`: 0.1.12 -> 0.1.13
* `mlt-wasm`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

## `mlt-core`

<blockquote>

## [0.9.1](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-core-v0.9.0...rust-mlt-core-v0.9.1) - 2026-05-05

### Added

- *(rust)* MLT -> MVT write support ([#1369](https://github.com/maplibre/maplibre-tile-spec/pull/1369))
</blockquote>

## `mlt`

<blockquote>

## [0.1.12](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.11...rust-mlt-v0.1.12) - 2026-05-05

### Added

- *(rust)* MLT -> MVT write support ([#1369](https://github.com/maplibre/maplibre-tile-spec/pull/1369))
</blockquote>

## `mlt-py`

<blockquote>

## [0.1.13](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.12...python-mlt-v0.1.13) - 2026-05-05

### Other

- update Cargo.toml dependencies
</blockquote>

## `mlt-wasm`

<blockquote>

## [0.1.7](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-wasm-v0.1.6...rust-mlt-wasm-v0.1.7) - 2026-05-05

### Other

- updated the following local packages: mlt-core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).