### PR TITLE
fix(java): JSON unsigned handling

### DIFF
--- a/java/mlt-core/src/main/java/org/maplibre/mlt/data/unsigned/U32.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/data/unsigned/U32.java
@@ -1,5 +1,7 @@
 package org.maplibre.mlt.data.unsigned;
 
+import java.math.BigInteger;
+
 public record U32(int value) implements Unsigned {
 
   public static U32 of(long value) {
@@ -21,6 +23,11 @@ public record U32(int value) implements Unsigned {
   @Override
   public Integer intValue() {
     return value;
+  }
+
+  @Override
+  public BigInteger bigIntValue() {
+    return BigInteger.valueOf(longValue());
   }
 
   @Override

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/data/unsigned/U64.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/data/unsigned/U64.java
@@ -30,6 +30,12 @@ public record U64(long value) implements Unsigned {
   }
 
   @Override
+  public BigInteger bigIntValue() {
+    final var bigInt = BigInteger.valueOf(value);
+    return (value < 0) ? bigInt.add(BigInteger.ONE.shiftLeft(64)) : bigInt;
+  }
+
+  @Override
   public Long longValue() {
     return value;
   }

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/data/unsigned/U8.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/data/unsigned/U8.java
@@ -1,5 +1,7 @@
 package org.maplibre.mlt.data.unsigned;
 
+import java.math.BigInteger;
+
 public record U8(byte value) implements Unsigned {
 
   public static U8 of(int value) {
@@ -17,6 +19,11 @@ public record U8(byte value) implements Unsigned {
   @Override
   public Integer intValue() {
     return Byte.toUnsignedInt(value);
+  }
+
+  @Override
+  public BigInteger bigIntValue() {
+    return BigInteger.valueOf(longValue());
   }
 
   @Override

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/data/unsigned/Unsigned.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/data/unsigned/Unsigned.java
@@ -1,5 +1,7 @@
 package org.maplibre.mlt.data.unsigned;
 
+import java.math.BigInteger;
+
 /**
  * Represents an unsigned integer of a fixed bit width (8, 32, or 64 bits).
  *
@@ -11,6 +13,8 @@ public sealed interface Unsigned permits U8, U32, U64 {
   Byte byteValue();
 
   Integer intValue();
+
+  BigInteger bigIntValue();
 
   Long longValue();
 

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/json/Json.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/json/Json.java
@@ -18,6 +18,9 @@ import org.maplibre.mlt.data.Layer;
 import org.maplibre.mlt.data.MapLibreTile;
 import org.maplibre.mlt.data.MapboxVectorTile;
 import org.maplibre.mlt.data.Property;
+import org.maplibre.mlt.data.unsigned.U32;
+import org.maplibre.mlt.data.unsigned.U64;
+import org.maplibre.mlt.data.unsigned.U8;
 
 /** Utility for converting MVT and MLT tiles to JSON and GeoJSON. */
 public final class Json {
@@ -122,6 +125,9 @@ public final class Json {
                       entry -> floatsAsStrings(entry.getValue()),
                       Json::failOnDuplicate,
                       LinkedHashMap::new));
+      case U8 u -> u.intValue();
+      case U32 u -> u.longValue();
+      case U64 u -> u.bigIntValue();
       default -> obj;
     };
   }

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/json/Json.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/json/Json.java
@@ -111,18 +111,18 @@ public final class Json {
   }
 
   /** Recursively replace Float/Double NaN and +/-Infinity with GeoJSON string tokens. */
-  private static Object floatsAsStrings(Object obj) {
+  private static Object propertyValues(Object obj) {
     return switch (obj) {
       case Float value -> floatToken(value);
       case Double value -> doubleToken(value);
       case Iterable<?> iterable ->
-          StreamSupport.stream(iterable.spliterator(), false).map(Json::floatsAsStrings).toList();
+          StreamSupport.stream(iterable.spliterator(), false).map(Json::propertyValues).toList();
       case Map<?, ?> map ->
           map.entrySet().stream()
               .collect(
                   Collectors.toMap(
                       Map.Entry::getKey,
-                      entry -> floatsAsStrings(entry.getValue()),
+                      entry -> propertyValues(entry.getValue()),
                       Json::failOnDuplicate,
                       LinkedHashMap::new));
       case U8 u -> u.intValue();
@@ -192,7 +192,7 @@ public final class Json {
     final var props = getSortedNonNullProperties(feature);
     props.put("_layer", layer.name());
     props.put("_extent", layer.tileExtent());
-    featureMap.put("properties", floatsAsStrings(props));
+    featureMap.put("properties", propertyValues(props));
 
     final var geom = feature.getGeometry();
     featureMap.put("geometry", geom == null ? null : geometryToGeoJson(geom, gson));

--- a/java/mlt-core/src/test/java/org/maplibre/mlt/data/unsigned/UnsignedTest.java
+++ b/java/mlt-core/src/test/java/org/maplibre/mlt/data/unsigned/UnsignedTest.java
@@ -78,6 +78,12 @@ class UnsignedTest {
   }
 
   @Test
+  void testU8BigIntValue() {
+    assertEquals(BigInteger.ZERO, U8.of(0).bigIntValue());
+    assertEquals(BigInteger.valueOf(255), U8.of(255).bigIntValue());
+  }
+
+  @Test
   void testU32OfValidValues() {
     // Test boundary values
     final var u32Zero = U32.of(0);
@@ -140,6 +146,12 @@ class UnsignedTest {
     assertTrue(u32 instanceof Unsigned, "U32 should implement Unsigned");
     assertNotNull(u32.intValue());
     assertNotNull(u32.longValue());
+  }
+
+  @Test
+  void testU32BigIntValue() {
+    assertEquals(BigInteger.ZERO, U32.of(0).bigIntValue());
+    assertEquals(BigInteger.valueOf(0xFFFFFFFFL), U32.of(0xFFFFFFFFL).bigIntValue());
   }
 
   @Test
@@ -221,6 +233,17 @@ class UnsignedTest {
     final var u64 = U64.of(BigInteger.valueOf(1000000L));
     assertTrue(u64 instanceof Unsigned, "U64 should implement Unsigned");
     assertNotNull(u64.longValue());
+  }
+
+  @Test
+  void testU64BigIntValue() {
+    assertEquals(BigInteger.ZERO, U64.of(BigInteger.ZERO).bigIntValue());
+    assertEquals(
+        new BigInteger("9223372036854775808"),
+        U64.of(new BigInteger("9223372036854775808")).bigIntValue());
+    assertEquals(
+        new BigInteger("18446744073709551615"),
+        U64.of(new BigInteger("18446744073709551615")).bigIntValue());
   }
 
   @Test

--- a/java/mlt-core/src/test/java/org/maplibre/mlt/json/JsonTest.java
+++ b/java/mlt-core/src/test/java/org/maplibre/mlt/json/JsonTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -19,6 +20,9 @@ import org.maplibre.mlt.data.Layer;
 import org.maplibre.mlt.data.MLTFeature;
 import org.maplibre.mlt.data.MapLibreTile;
 import org.maplibre.mlt.data.MapboxVectorTile;
+import org.maplibre.mlt.data.unsigned.U32;
+import org.maplibre.mlt.data.unsigned.U64;
+import org.maplibre.mlt.data.unsigned.U8;
 
 class JsonTest {
   private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
@@ -136,6 +140,45 @@ class JsonTest {
     assertEquals("f64::NAN", props.get("f64nan").getAsString());
     assertEquals("f64::INFINITY", props.get("f64inf").getAsString());
     assertEquals("f64::NEG_INFINITY", props.get("f64neg").getAsString());
+  }
+
+  @Test
+  void unsignedPropertValues() {
+    final var maxU64 = new BigInteger("18446744073709551615");
+
+    final var nested = new LinkedHashMap<String, Object>();
+    nested.put("u32", U32.of(0xFFFFFFFFL));
+    nested.put("list", List.of(U8.of(1), U64.of(maxU64)));
+
+    final var properties = new LinkedHashMap<String, Object>();
+    properties.put("u8", U8.of(255));
+    properties.put("u64", U64.of(maxU64));
+    properties.put("nested", nested);
+
+    final var props =
+        JsonParser.parseString(
+                Json.toGeoJson(
+                    mltOf(
+                        layer(
+                            "roads",
+                            4096,
+                            feature(
+                                1,
+                                GEOMETRY_FACTORY.createPoint(new Coordinate(0, 0)),
+                                properties))),
+                    false))
+            .getAsJsonObject()
+            .getAsJsonArray("features")
+            .get(0)
+            .getAsJsonObject()
+            .getAsJsonObject("properties");
+
+    assertEquals(255, props.get("u8").getAsInt());
+    assertEquals(maxU64, props.get("u64").getAsBigInteger());
+    assertEquals(0xFFFFFFFFL, props.getAsJsonObject("nested").get("u32").getAsLong());
+    assertEquals(1, props.getAsJsonObject("nested").getAsJsonArray("list").get(0).getAsInt());
+    assertEquals(
+        maxU64, props.getAsJsonObject("nested").getAsJsonArray("list").get(1).getAsBigInteger());
   }
 
   @Test

--- a/java/mlt-tools/src/main/java/org/maplibre/mlt/tools/SyntheticMltUtil.java
+++ b/java/mlt-tools/src/main/java/org/maplibre/mlt/tools/SyntheticMltUtil.java
@@ -32,6 +32,7 @@ import org.maplibre.mlt.converter.MltConverter;
 import org.maplibre.mlt.data.Feature;
 import org.maplibre.mlt.data.Layer;
 import org.maplibre.mlt.data.MLTFeature;
+import org.maplibre.mlt.data.MapLibreTile;
 import org.maplibre.mlt.data.MapboxVectorTile;
 import org.maplibre.mlt.decoder.MltDecoder;
 import org.maplibre.mlt.json.Json;
@@ -297,7 +298,11 @@ class SyntheticMltUtil {
       var metadata = MltConverter.createTilesetMetadata(tile, columnMappings, config.includeIds());
       var mlt = MltConverter.encode(tile, metadata, config, null);
       Files.write(SYNTHETICS_DIR.resolve(fileName + ".mlt"), mlt, StandardOpenOption.CREATE_NEW);
+      final String expected = Json.toGeoJson(new MapLibreTile(layers), true) + "\n";
       final String json = Json.toGeoJson(MltDecoder.decodeMlTile(mlt), true) + "\n";
+      if (!expected.equals(json)) {
+        throw new RuntimeException("MLT round-trip failed for " + fileName);
+      }
       Files.writeString(
           SYNTHETICS_DIR.resolve(fileName + ".json"), json, StandardOpenOption.CREATE_NEW);
     } catch (Exception e) {

--- a/java/mlt-tools/src/main/java/org/maplibre/mlt/tools/SyntheticMltUtil.java
+++ b/java/mlt-tools/src/main/java/org/maplibre/mlt/tools/SyntheticMltUtil.java
@@ -292,19 +292,28 @@ class SyntheticMltUtil {
       throws IOException {
     try {
       System.out.println("Generating: " + fileName);
-      var config = cfg.build();
-      var tile = new MapboxVectorTile(layers);
+      final var config = cfg.build();
+      final var tile = new MapboxVectorTile(layers);
       final var columnMappings = buildColumnMappings(config);
-      var metadata = MltConverter.createTilesetMetadata(tile, columnMappings, config.includeIds());
-      var mlt = MltConverter.encode(tile, metadata, config, null);
-      Files.write(SYNTHETICS_DIR.resolve(fileName + ".mlt"), mlt, StandardOpenOption.CREATE_NEW);
-      final String expected = Json.toGeoJson(new MapLibreTile(layers), true) + "\n";
-      final String json = Json.toGeoJson(MltDecoder.decodeMlTile(mlt), true) + "\n";
-      if (!expected.equals(json)) {
-        throw new RuntimeException("MLT round-trip failed for " + fileName);
+      final var metadata =
+          MltConverter.createTilesetMetadata(tile, columnMappings, config.includeIds());
+      final var mlt = MltConverter.encode(tile, metadata, config, null);
+      final var unEncodedJSON = Json.toGeoJson(new MapLibreTile(layers), true) + "\n";
+      final var decodedJSON = Json.toGeoJson(MltDecoder.decodeMlTile(mlt), true) + "\n";
+      if (!unEncodedJSON.equals(decodedJSON)) {
+        throw new RuntimeException(
+            "MLT round-trip failed for "
+                + fileName
+                + " \nUn-encoded:\n"
+                + unEncodedJSON
+                + "\nDecoded:\n"
+                + decodedJSON);
       }
+      Files.write(SYNTHETICS_DIR.resolve(fileName + ".mlt"), mlt, StandardOpenOption.CREATE_NEW);
       Files.writeString(
-          SYNTHETICS_DIR.resolve(fileName + ".json"), json, StandardOpenOption.CREATE_NEW);
+          SYNTHETICS_DIR.resolve(fileName + ".json"), decodedJSON, StandardOpenOption.CREATE_NEW);
+    } catch (RuntimeException e) {
+      throw e;
     } catch (Exception e) {
       throw new IOException("Error writing MLT file " + fileName, e);
     }


### PR DESCRIPTION
In debugging nested value encoding, I found it helpful to add a round-trip check to the synthetic writing to catch issues earlier.  This failed on some existing cases for two reasons:

- The `U64` values were being written as `{"value": 42}` instead of just `42`
- The value itself was printed as signed

Adjusting the JSON output to recognize unsigned values and print them appropriately resolves all the mismatches without needing to change any of the cases.