### PR TITLE
fix(rust): integer encoding alternative: tie goes to None

### DIFF
--- a/rust/mlt-core/src/encoder/stream/codecs.rs
+++ b/rust/mlt-core/src/encoder/stream/codecs.rs
@@ -189,9 +189,7 @@ impl Codecs {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::decoder::{LogicalEncoding, RawStream};
-    use crate::encoder::Encoder;
-    use crate::encoder::model::StreamCtx;
+    use crate::decoder::RawStream;
     use crate::test_helpers::{assert_empty, parser};
 
     #[test]

--- a/rust/mlt-core/src/encoder/stream/codecs.rs
+++ b/rust/mlt-core/src/encoder/stream/codecs.rs
@@ -143,6 +143,13 @@ impl Codecs {
         let Self { logical, physical } = self;
         let mut alt = enc.try_alternatives();
 
+        physical.write_alternatives::<Output<T>>(
+            &mut alt,
+            logical.none(values),
+            LE::None,
+            ctx.stream_type,
+        )?;
+
         let sample = logical.none(DataProfile::take_sample(values));
         let profile = DataProfile::profile::<<[T] as LogicalIntStreamKind>::Profile>(sample);
 
@@ -175,7 +182,32 @@ impl Codecs {
                 ctx.stream_type,
             )?;
         }
-        let values = logical.none(values);
-        physical.write_alternatives::<Output<T>>(&mut alt, values, LE::None, ctx.stream_type)
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::decoder::{LogicalEncoding, RawStream};
+    use crate::encoder::Encoder;
+    use crate::encoder::model::StreamCtx;
+    use crate::test_helpers::{assert_empty, parser};
+
+    #[test]
+    fn single_value_uses_none_encoding() {
+        // A single constant integer should be encoded with LogicalEncoding::None,
+        // not Delta — there is nothing to delta-encode, and None is simpler and
+        // produces a value the decoder can read directly without any transform.
+        let mut enc = Encoder::default();
+        let mut codecs = Codecs::default();
+        let ctx = StreamCtx::prop_data("test");
+        codecs.write_int_stream(&[4u32], &ctx, &mut enc).unwrap();
+        let stream = assert_empty(RawStream::from_bytes(&enc.data, &mut parser()));
+        assert_eq!(
+            stream.meta.encoding.logical,
+            LogicalEncoding::None,
+            "single-value stream should use None, not Delta"
+        );
     }
 }


### PR DESCRIPTION
When encoding a single integer, Delta and None were equally efficient. Because we tried Delta first it would win the `Alternatives` race. 

I think it's more intuitive to default to `None` in this case. It should also be a tiny be more efficient. We're talking tiny streams here, so I doubt it's measurable. 

My real motivation is that this works around https://github.com/maplibre/maplibre-gl-js/issues/7659, but it seems like a slightly more reasonable behavior anyway.

(For a more principled fix to https://github.com/maplibre/maplibre-gl-js/issues/7659, see https://github.com/maplibre/maplibre-tile-spec/pull/1391)