### PR TITLE
docs: Fix list format

### DIFF
--- a/docs/encodings.md
+++ b/docs/encodings.md
@@ -130,6 +130,7 @@ A bit-aligned null suppression technique that compresses integers using a minima
 Uses a patched approach to store exceptions (outliers) separately, keeping the overall bit width small.
 
 Refer to:
+
 - <https://arxiv.org/pdf/1209.2137.pdf>
 - <https://ayende.com/blog/199524-C/integer-compression-the-fastpfor-code>
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -21,6 +21,7 @@ Each `FeatureTable` is preceded by a `FeatureTableMetadata` that describes `Feat
 The visual appearance of a tile is usually defined by a [MapLibre Style](https://maplibre.org/maplibre-style-spec/), which specifies how features are rendered.
 
 Each feature must have
+
 - a `geometry` column (type based on the OGC's Simple Feature Access Model (SFA), excluding support for `GeometryCollection` types)
 - an optional `id` column
 - optional property columns
@@ -45,6 +46,7 @@ A stream is a sequence of values of a known length in a continuous memory chunk,
 Streams include additional metadata, such as their size and encoding type.
 
 For example, a nullable string property column might have:
+
 - A **`present` stream** (a bit flag indicating the presence of a value).
 - A **`length` stream** (describing the number of characters for each string).
 - A **`data` stream** (containing the actual UTF-8 encoded string values).
@@ -120,6 +122,7 @@ Each `FeatureTable` is preceded by a `FeatureTableMetadata` section describing i
     Should the size of the upcoming metadata and table be part of that structure?
 
 A FeatureTable consists of any number of the following sequences:
+
 - The size of the upcoming `FeatureTableMetadata` (varint-encoded).
 - The size of the upcoming `FeatureTable` (varint-encoded).
 - One `FeatureTableMetadata` section.
@@ -494,6 +497,7 @@ If geometries (mainly polygons) are pre-tessellated for direct GPU use, `NumTria
 ### Property Columns
 
 Feature properties are divided into `feature-scoped` and `vertex-scoped` properties.
+
 - **Feature-scoped**: One value per feature.
 - **Vertex-scoped**: One value per vertex in the VertexBuffer per feature (modeling M-coordinates from GIS).
 
@@ -509,6 +513,7 @@ A property column can use any data type from the [type system](#type-system).
 # Example Layouts
 
 The following examples illustrate the layout of a `FeatureTable` in storage. The color scheme is:
+
 - **Blue boxes**:
   Logical constructs, not persisted.
   Fields are reconstructed from streams based on TileSet metadata.
@@ -571,6 +576,7 @@ The MLT in-memory format incorporates ideas from analytical in-memory formats li
 It is also designed for future parallel processing on the GPU within compute shaders.
 
 The main design goals for the MLT in-memory format are:
+
 - Define a platform-agnostic representation to avoid expensive materialization costs, especially for strings.
 - Maximize CPU throughput by optimizing memory layout for cache locality and SIMD instructions.
 - Allow random (preferably constant-time) access to all data for parallel processing on GPUs (compute shaders).


### PR DESCRIPTION
Currently, lists are not rendered correctly on <https://maplibre.org/maplibre-tile-spec/specification/>. For example, this part

<img width="600" alt="image" src="https://github.com/user-attachments/assets/02f8d233-ca05-49d0-aeab-898c5912a12f" />

should have a list like this

<img width="600" alt="image" src="https://github.com/user-attachments/assets/75191db8-ecf4-4ace-95b2-d84bfa6d0e36" />

This pull request fixes the format by adding a blank line before a list.