### PR TITLE
Provide mlt cli version

### DIFF
--- a/rust/mlt/src/main.rs
+++ b/rust/mlt/src/main.rs
@@ -32,6 +32,7 @@ fn main() -> AnyResult<()> {
 
 #[derive(Parser)]
 #[command(name = "mlt", about = "MapLibre Tile format utilities")]
+#[command(version = env!("CARGO_PKG_VERSION"))]
 struct Cli {
     #[command(subcommand)]
     command: Commands,


### PR DESCRIPTION
Gives mlt cli version by running `mlt --version`

```shell
❯ ./target/release/mlt --version
mlt 0.1.14
```