### PR TITLE
fix(rust): accept .pbf in convert

### DIFF
--- a/rust/mlt/src/convert/files.rs
+++ b/rust/mlt/src/convert/files.rs
@@ -73,7 +73,7 @@ fn format_dedup_line(stats: &DedupStats, cache: &EncodedCache) -> String {
 fn is_convert_extension(path: &Path) -> bool {
     matches!(
         path.extension().and_then(OsStr::to_str),
-        Some("mlt" | "mvt")
+        Some("mlt" | "mvt" | "pbf")
     )
 }
 
@@ -161,7 +161,7 @@ pub fn convert_files(
 
     let processed = stats.hits.load(Ordering::Relaxed) + stats.encoded.load(Ordering::Relaxed);
     if processed == 0 {
-        eprintln!("No .mlt or .mvt files found in {}", input.display());
+        eprintln!("No .mlt, .mvt, or .pbf files found in {}", input.display());
         return Ok(());
     }
     eprintln!("{}", format_dedup_line(&stats, &cache));

--- a/rust/mlt/src/convert/mod.rs
+++ b/rust/mlt/src/convert/mod.rs
@@ -89,7 +89,7 @@ impl TileFormat {
     #[must_use]
     pub fn from_path(path: &Path) -> Self {
         match path.extension().and_then(std::ffi::OsStr::to_str) {
-            Some("mvt") => Self::Mvt,
+            Some("mvt" | "pbf") => Self::Mvt,
             _ => Self::Mlt,
         }
     }
@@ -112,7 +112,7 @@ enum SortMode {
 
 #[derive(Args)]
 pub struct ConvertArgs {
-    /// Input: a directory with .mlt/.mvt tiles, a single tile file, an .mbtiles database
+    /// Input: a directory with .mlt/.mvt/.pbf tiles, a single tile file, an .mbtiles database
     input: PathBuf,
     /// Output: a directory for re-encoded .mlt files, an .mbtiles database or a .pmtiles file
     output: PathBuf,

--- a/rust/mlt/src/main.rs
+++ b/rust/mlt/src/main.rs
@@ -40,7 +40,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Convert .mlt and .mvt tiles in a directory tree to re-encoded .mlt files
+    /// Convert .mlt, .mvt, and .pbf tiles in a directory tree to re-encoded .mlt files
     Convert(ConvertArgs),
     /// Parse a tile file (.mlt, .mvt, .pbf) and dump raw layer data without decoding
     Dump(DumpArgs),


### PR DESCRIPTION
Given that MVTs are saved as either MVT/PBFs, but the rust's command for conversion mlt convert <in_dir> <out_dir> only expects the dir to contain MVT file format alone, I propose updating the rust command to read PBFs too.