### PR TITLE
chore(rust): enforce non-empty layer name

### DIFF
--- a/cpp/src/mlt/metadata/tileset.cpp
+++ b/cpp/src/mlt/metadata/tileset.cpp
@@ -55,6 +55,9 @@ Column decodeColumn(BufferStream& tileData) {
 
 FeatureTable decodeFeatureTable(BufferStream& tileData) {
     auto name = decodeString(tileData);
+    if (name.empty()) {
+        throw std::runtime_error("Missing layer name");
+    }
     const auto extent = decodeVarint<std::uint32_t>(tileData);
     const auto columnCount = decodeVarint<std::uint32_t>(tileData);
     auto columns = util::generateVector<Column>(columnCount, [&](auto) { return decodeColumn(tileData); });

--- a/cpp/test/test_decode.cpp
+++ b/cpp/test/test_decode.cpp
@@ -125,6 +125,13 @@ TEST(Decode, SimplePointBoolean) {
     EXPECT_EQ(feature.getID(), 1);
 }
 
+TEST(Decode, RejectsEmptyLayerName) {
+    const std::string metadata{"\0\x80\x20\0", 4};
+    auto stream = mlt::BufferStream({metadata.data(), metadata.size()});
+
+    EXPECT_THROW(mlt::metadata::tileset::decodeFeatureTable(stream), std::runtime_error);
+}
+
 TEST(Decode, SimpleLineBoolean) {
     const auto tile = loadTile(basePath / "simple/line-boolean.mlt");
     // TODO: check properties, geometry, etc.

--- a/cpp/test/test_decode.cpp
+++ b/cpp/test/test_decode.cpp
@@ -4,6 +4,7 @@
 #include <mlt/geometry.hpp>
 #include <mlt/metadata/tileset.hpp>
 #include <mlt/tile.hpp>
+#include <mlt/util/buffer_stream.hpp>
 
 #include <cstdlib>
 #include <exception>

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/data/Layer.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/data/Layer.java
@@ -1,7 +1,16 @@
 package org.maplibre.mlt.data;
 
+import java.util.Objects;
 import java.util.SequencedCollection;
 import org.jetbrains.annotations.NotNull;
 
 public record Layer(
-    @NotNull String name, @NotNull SequencedCollection<Feature> features, int tileExtent) {}
+    @NotNull String name, @NotNull SequencedCollection<Feature> features, int tileExtent) {
+  public Layer {
+    Objects.requireNonNull(name);
+    Objects.requireNonNull(features);
+    if (name.isEmpty()) {
+      throw new IllegalArgumentException("Missing layer name");
+    }
+  }
+}

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/metadata/tileset/MltMetadata.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/metadata/tileset/MltMetadata.java
@@ -98,6 +98,9 @@ public final class MltMetadata {
 
     public FeatureTable {
       Objects.requireNonNull(name);
+      if (name.isEmpty()) {
+        throw new IllegalArgumentException("Missing layer name");
+      }
       columns = (columns != null) ? columns : new ArrayList<>();
     }
 

--- a/java/mlt-core/src/test/java/org/maplibre/mlt/metadata/tileset/MltMetadataColumnTest.java
+++ b/java/mlt-core/src/test/java/org/maplibre/mlt/metadata/tileset/MltMetadataColumnTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.maplibre.mlt.data.Layer;
 
 class MltMetadataColumnTest {
   @Test
@@ -55,6 +56,21 @@ class MltMetadataColumnTest {
     final var col =
         new MltMetadata.Column(MltMetadata.scalarFieldType(MltMetadata.ScalarType.STRING, true));
     assertEquals(MltMetadata.ColumnScope.FEATURE, col.columnScope());
+  }
+
+  @Test
+  void rejectsEmptyFeatureTableName() {
+    assertThrows(IllegalArgumentException.class, () -> new MltMetadata.FeatureTable(""));
+  }
+
+  @Test
+  void rejectsEmptyLayerName() {
+    assertThrows(IllegalArgumentException.class, () -> new Layer("", List.of(), 4096));
+  }
+
+  @Test
+  void rejectsNullLayerFeatures() {
+    assertThrows(NullPointerException.class, () -> new Layer("layer", null, 4096));
   }
 
   @Test

--- a/rust/mlt-core/src/convert/mvt/decode.rs
+++ b/rust/mlt-core/src/convert/mvt/decode.rs
@@ -5,16 +5,20 @@ use std::collections::{BTreeMap, HashMap};
 use fast_mvt::{MvtLayer, MvtReaderRef, MvtValue};
 use serde_json::Value;
 
-use crate::MltResult;
 use crate::decoder::{PropValue, TileFeature, TileLayer};
 use crate::geojson::{Feature, FeatureCollection};
+use crate::{MltError, MltResult};
 
 /// Parse MVT bytes into a list of layers, each holding its raw features.
 ///
 /// This is the single place where the `fast-mvt` API is called; both
 /// [`mvt_to_feature_collection`] and [`mvt_to_tile_layers`] build on top of it.
 fn read_mvt_layers(data: &[u8]) -> MltResult<Vec<MvtLayer>> {
-    Ok(MvtReaderRef::new(data)?.to_tile()?.layers)
+    let layers = MvtReaderRef::new(data)?.to_tile()?.layers;
+    if layers.iter().any(|layer| layer.name.is_empty()) {
+        return Err(MltError::MissingLayerName);
+    }
+    Ok(layers)
 }
 
 /// Parse MVT binary data and convert to a [`FeatureCollection`].
@@ -52,14 +56,20 @@ pub fn mvt_to_feature_collection(data: impl AsRef<[u8]>) -> MltResult<FeatureCol
 /// determines its type, with `I64`+`U64` widened to `I64` and `F32`+`F64` widened
 /// to `F64`; all other type conflicts fall back to `Str`.
 pub fn mvt_to_tile_layers(data: impl AsRef<[u8]>) -> MltResult<Vec<TileLayer>> {
-    Ok(read_mvt_layers(data.as_ref())?
+    read_mvt_layers(data.as_ref())?
         .into_iter()
-        .map(TileLayer::from)
-        .collect())
+        .map(TileLayer::try_from)
+        .collect::<Result<Vec<_>, _>>()
 }
 
-impl From<MvtLayer> for TileLayer {
-    fn from(layer: MvtLayer) -> Self {
+impl TryFrom<MvtLayer> for TileLayer {
+    type Error = MltError;
+
+    fn try_from(layer: MvtLayer) -> Result<Self, Self::Error> {
+        if layer.name.is_empty() {
+            return Err(MltError::MissingLayerName);
+        }
+
         // First pass: collect property names (insertion-ordered) and infer column types.
         let mut col_names: Vec<String> = Vec::new();
         let mut col_index: HashMap<String, usize> = HashMap::new();
@@ -103,12 +113,12 @@ impl From<MvtLayer> for TileLayer {
             });
         }
 
-        Self {
+        Ok(Self {
             name: layer.name,
             extent: layer.extent.get(),
             property_names: col_names,
             features: tile_features,
-        }
+        })
     }
 }
 

--- a/rust/mlt-core/src/convert/mvt/encode.rs
+++ b/rust/mlt-core/src/convert/mvt/encode.rs
@@ -3,13 +3,16 @@
 
 use fast_mvt::{DEFAULT_EXTENT, MvtExtent, MvtTileBuilder, MvtValue};
 
-use crate::MltResult;
 use crate::decoder::{PropValue, TileLayer};
+use crate::{MltError, MltResult};
 
 /// Encode row-oriented [`TileLayer`]s as MVT (Mapbox Vector Tile) bytes.
 pub fn tile_layers_to_mvt(layers: Vec<TileLayer>) -> MltResult<Vec<u8>> {
     let mut tile = MvtTileBuilder::with_capacity(layers.len());
     for layer in layers {
+        if layer.name.is_empty() {
+            return Err(MltError::MissingLayerName);
+        }
         let extent = MvtExtent::new(layer.extent).unwrap_or(DEFAULT_EXTENT);
         let mut mvt_layer = tile.layer_with_capacity(layer.name, layer.features.len())?;
         mvt_layer.extent(extent);
@@ -62,6 +65,21 @@ mod tests {
         let bytes = tile_layers_to_mvt(Vec::new()).unwrap();
         let decoded = mvt_to_tile_layers(bytes).unwrap();
         assert!(decoded.is_empty());
+    }
+
+    #[test]
+    fn rejects_empty_layer_name() {
+        let layer = TileLayer {
+            name: String::new(),
+            extent: 4096,
+            property_names: vec![],
+            features: vec![],
+        };
+
+        assert!(matches!(
+            tile_layers_to_mvt(vec![layer]),
+            Err(MltError::MissingLayerName)
+        ));
     }
 
     /// `ClosePath` repeats the first vertex; an input with the closing

--- a/rust/mlt-core/src/decoder/root.rs
+++ b/rust/mlt-core/src/decoder/root.rs
@@ -3,8 +3,8 @@ use usize_cast::IntoUsize as _;
 use crate::LazyParsed::Raw;
 use crate::MltError::{
     BufferUnderflow, GeometryWithoutStreams, InvalidSharedDictStreamCount, MissingGeometry,
-    MultipleGeometryColumns, MultipleIdColumns, SharedDictRequiresStreams, TrailingLayerData,
-    UnexpectedStructChildCount, UnsupportedStringStreamCount,
+    MissingLayerName, MultipleGeometryColumns, MultipleIdColumns, SharedDictRequiresStreams,
+    TrailingLayerData, UnexpectedStructChildCount, UnsupportedStringStreamCount,
 };
 use crate::codecs::varint::parse_varint;
 use crate::decoder::{
@@ -265,6 +265,9 @@ impl<'a> Layer01<'a, Lazy> {
     /// Parse `v01::Layer` metadata, reserving decoded memory against the parser's budget.
     pub(crate) fn from_bytes(input: &'a [u8], parser: &mut Parser) -> MltResult<Self> {
         let (input, layer_name) = parse_string(input)?;
+        if layer_name.is_empty() {
+            return Err(MissingLayerName);
+        }
         let (input, extent) = parse_varint::<u32>(input)?;
         let (input, column_count) = parse_varint::<u32>(input)?;
 
@@ -642,5 +645,26 @@ fn scalar<'a>(name: &'a str, opt: Option<RawStream<'a>>, value: RawStream<'a>) -
         name,
         presence: RawPresence(opt),
         data: value,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{MltError, Parser};
+
+    #[test]
+    fn parse_layers_rejects_empty_layer_name() {
+        let bytes = [
+            5, // layer size: tag byte + 4-byte body
+            1, // tag 0x01
+            0, // empty layer name
+            0x80, 0x20, // extent 4096
+            0,    // column count
+        ];
+
+        assert!(matches!(
+            Parser::default().parse_layers(&bytes),
+            Err(MltError::MissingLayerName)
+        ));
     }
 }

--- a/ts/src/metadata/tileset/embeddedTilesetMetadataDecoder.spec.ts
+++ b/ts/src/metadata/tileset/embeddedTilesetMetadataDecoder.spec.ts
@@ -198,7 +198,7 @@ describe("embeddedTilesetMetadataDecoder", () => {
     describe("decodeEmbeddedTileSetMetadata", () => {
         it("should decode tileset with STRUCT column", () => {
             const buffer = concatenateBuffers(
-                encodeFieldName(""),
+                encodeFieldName("layer"),
                 encodeTypeCode(4096),
                 encodeChildCount(1),
                 encodeTypeCode(STRUCT_TYPE_CODE),
@@ -211,8 +211,21 @@ describe("embeddedTilesetMetadataDecoder", () => {
             const [metadata, extent] = decodeEmbeddedTileSetMetadata(buffer, new IntWrapper(0));
 
             expect(extent).toBe(4096);
-            expect(metadata.featureTables[0].name).toBe("");
+            expect(metadata.featureTables[0].name).toBe("layer");
             expect(metadata.featureTables[0].columns[0].complexType.children).toHaveLength(1);
+        });
+
+        it("should throw error for empty layer name", () => {
+            const buffer = concatenateBuffers(
+                encodeFieldName(""),
+                encodeTypeCode(4096),
+                encodeChildCount(1),
+                encodeTypeCode(4),
+            );
+
+            expect(() => {
+                decodeEmbeddedTileSetMetadata(buffer, new IntWrapper(0));
+            }).toThrow("Missing layer name");
         });
 
         it("should decode logical ID metadata with implicit id column name", () => {

--- a/ts/src/metadata/tileset/embeddedTilesetMetadataDecoder.ts
+++ b/ts/src/metadata/tileset/embeddedTilesetMetadataDecoder.ts
@@ -113,6 +113,9 @@ export function decodeEmbeddedTileSetMetadata(bytes: Uint8Array, offset: IntWrap
 
     const table = {} as FeatureTableSchema;
     table.name = decodeString(bytes, offset);
+    if (table.name.length === 0) {
+        throw new Error("Missing layer name");
+    }
     const extent = decodeVarintInt32(bytes, offset, 1)[0] >>> 0;
 
     const columnCount = decodeVarintInt32(bytes, offset, 1)[0] >>> 0;

--- a/ts/src/vector/featureTable.ts
+++ b/ts/src/vector/featureTable.ts
@@ -22,7 +22,11 @@ export default class FeatureTable {
         private readonly _idVector?: IdVector,
         private readonly _propertyVectors?: Vector[],
         private readonly _extent = 4096,
-    ) {}
+    ) {
+        if (_name.length === 0) {
+            throw new Error("Missing layer name");
+        }
+    }
 
     get name(): string {
         return this._name;


### PR DESCRIPTION
ai-gened enforcement that ensures that we do not have zero-length layer names.  MVT spec has it non-explicitly, but it seems some implementations actually enforce this, so easier to make it explicit