### PR TITLE
fix(java): correct fastpfor config option to enable-fastpfor

### DIFF
--- a/java/encoding-server/convert.mjs
+++ b/java/encoding-server/convert.mjs
@@ -142,7 +142,7 @@ function convertTileResponse(filePath, res) {
     mltPath +
     (config.noids ? " --noids" : "") +
     (config.fsst ? " --fsst" : "") +
-    (config.fastpfor ? " --fastpfor" : "") +
+    (config.fastpfor ? " --enable-fastpfor" : "") +
     (config.nomorton ? " --nomorton" : "") +
     (config.outlines ? ` --outlines ${config.outlines}` : "") +
     (config.tessellate ? " --tessellate" : "") +


### PR DESCRIPTION
From the encoder-server, this fix adjusts the `fastpfor` option to map correctly to the expected `enable-fastpfor` cli flag.