### PR TITLE
fix(rust): clear losing sort-trial buffers between encode trials

### DIFF
--- a/rust/mlt-core/src/encoder/optimizer.rs
+++ b/rust/mlt-core/src/encoder/optimizer.rs
@@ -125,6 +125,13 @@ impl TileLayer {
                 enc = layer.encode_into(enc, &mut codecs)?;
                 if enc.total_len() < best.total_len() {
                     best = enc.preserve_results();
+                } else {
+                    // The losing trial's bytes must be dropped so the next trial
+                    // encodes into a clean buffer. `preserve_results` only empties
+                    // `enc` when a trial wins; without this, the next `encode_into`
+                    // would append to the loser's bytes and overcount its
+                    // `total_len`, so later trials could never win.
+                    enc.clear_results();
                 }
             }
             // Last strategy: consume self, no clone

--- a/rust/mlt-core/src/encoder/writer.rs
+++ b/rust/mlt-core/src/encoder/writer.rs
@@ -265,6 +265,21 @@ impl Encoder {
         self.hdr.len() + self.meta.len() + self.data.len()
     }
 
+    /// Empty the output buffers (`hdr`/`meta`/`data`) so this encoder can be
+    /// reused for the next sort trial, keeping their allocated capacity and the
+    /// seeded curve/FSST caches.
+    ///
+    /// Unlike [`Self::preserve_results`] (which moves the buffers out into the
+    /// kept "best" result), this is used when a trial loses: its bytes must be
+    /// discarded, otherwise the next trial's `encode_into` would append to them
+    /// and over-count its `total_len`.
+    pub(crate) fn clear_results(&mut self) {
+        debug_assert!(self.alt_stack.is_empty(), "Alternatives stack is not empty");
+        self.hdr.clear();
+        self.meta.clear();
+        self.data.clear();
+    }
+
     /// Concatenate `hdr + meta + data` into a single buffer **without** a
     /// tag/size prefix.
     ///


### PR DESCRIPTION
Previously, this bug means we encode Plain way too often..