### PR TITLE
perf(rust): use mimalloc as the global allocator for the mlt CLI

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3281,6 +3281,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3529,6 +3538,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3578,6 +3596,7 @@ dependencies = [
  "indicatif",
  "martin-tile-utils",
  "mbtiles",
+ "mimalloc",
  "mlt-core",
  "moka",
  "pmtiles",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -47,8 +47,8 @@ insta = "1.47.2"
 integer-encoding = "4.0.2"
 js-sys = "0.3"
 martin-tile-utils = "0.7"
-mimalloc = "0.1.52"
 mbtiles = { version = "0.17", default-features = false, features = ["transcode"] }
+mimalloc = "0.1.52"
 mlt-core = { version = "0.10.0", path = "mlt-core" }
 moka = { version = "0.12", features = ["sync"] }
 num-traits = "0.2.19"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -47,6 +47,7 @@ insta = "1.47.2"
 integer-encoding = "4.0.2"
 js-sys = "0.3"
 martin-tile-utils = "0.7"
+mimalloc = "0.1.52"
 mbtiles = { version = "0.17", default-features = false, features = ["transcode"] }
 mlt-core = { version = "0.10.0", path = "mlt-core" }
 moka = { version = "0.12", features = ["sync"] }

--- a/rust/mlt/Cargo.toml
+++ b/rust/mlt/Cargo.toml
@@ -36,6 +36,7 @@ hotpath.workspace = true
 indicatif.workspace = true
 martin-tile-utils.workspace = true
 mbtiles.workspace = true
+mimalloc.workspace = true
 mlt-core.workspace = true
 moka.workspace = true
 pmtiles.workspace = true

--- a/rust/mlt/src/main.rs
+++ b/rust/mlt/src/main.rs
@@ -8,6 +8,12 @@ use std::process::exit;
 use anyhow::Result as AnyResult;
 use clap::{Parser, Subcommand, ValueEnum};
 
+// hotpath-alloc installs its own global allocator to track allocations, so it
+// can't coexist with ours.
+#[cfg(not(feature = "hotpath-alloc"))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use crate::convert::{ConvertArgs, convert};
 use crate::dump::{AfterDump, DumpArgs, dump};
 use crate::ls::{LsArgs, ls};


### PR DESCRIPTION
gains us 1-1.5 cpu cores spend idling for a bit higher RSS.
Likely a good trade