### PR TITLE
refactor(rust): split convert into from_files/from_mbtiles/common and add --sort all

### DIFF
--- a/rust/mlt/src/convert/common.rs
+++ b/rust/mlt/src/convert/common.rs
@@ -1,0 +1,111 @@
+use std::time::{Duration, Instant};
+
+use anyhow::{Result as AnyResult, anyhow};
+use bytes::Bytes;
+use indicatif::{ProgressBar, ProgressStyle};
+use martin_tile_utils::Encoding;
+use mlt_core::encoder::EncoderConfig;
+use moka::sync::Cache;
+use pmtiles::TileCoord;
+use size_format::SizeFormatterSI;
+use xxhash_rust::xxh3::xxh3_64;
+
+use super::{encode_one, whole_rate_per_sec};
+
+/// Cap on the encoding cache (which encoded `Bytes` to keep around).
+pub const ENCODE_CACHE_BYTES: u64 = 512 * 1024 * 1024;
+/// Cap on the tile cache track size (in bytes).
+pub const MAX_TILE_CACHE_TRACK_SIZE_BYTES: usize = 1024;
+const PROGRESS_BAR_TEMPLATE: &str = "  {bar:40.cyan/blue} {pos}/{len} tiles [{rate}, eta {eta}]";
+
+pub fn make_progress_bar(total: u64) -> ProgressBar {
+    let bar = ProgressBar::new(total);
+    bar.set_style(
+        ProgressStyle::default_bar()
+            .template(PROGRESS_BAR_TEMPLATE)
+            .expect("invalid bar template")
+            .with_key("rate", whole_rate_per_sec),
+    );
+    bar.enable_steady_tick(Duration::from_millis(200));
+    bar
+}
+
+/// Build the bounded, byte-weighted cache used to dedup encoded tiles.
+pub fn make_encode_cache() -> Cache<u64, Bytes> {
+    Cache::builder()
+        .max_capacity(ENCODE_CACHE_BYTES)
+        .weigher(|_, v: &Bytes| u32::try_from(v.len()).unwrap_or(u32::MAX))
+        .build()
+}
+
+/// Encode one source tile MVT → MLT, deduplicating through `cache`.
+///
+/// Only small tiles (ocean, empty land, ...) actually repeat across a tileset;
+/// big city tiles are essentially unique, so tiles over
+/// [`MAX_TILE_CACHE_TRACK_SIZE_BYTES`] skip the hash + cache (any rare repeat
+/// still dedups when the container is written). Returns the encoded bytes and
+/// whether they came from the cache. Mirrors `files.rs` and the mbtiles
+/// transcoder.
+pub fn encode_tile(
+    cache: &Cache<u64, Bytes>,
+    data: &[u8],
+    encoding: Encoding,
+    cfg: EncoderConfig,
+) -> AnyResult<(Bytes, bool)> {
+    if data.len() > MAX_TILE_CACHE_TRACK_SIZE_BYTES {
+        return Ok((encode_one(data.to_vec(), encoding, cfg)?, false));
+    }
+    let mut hit = true;
+    let encoded = cache
+        .try_get_with(xxh3_64(data), || {
+            hit = false;
+            encode_one(data.to_vec(), encoding, cfg)
+        })
+        .map_err(|e| anyhow!("{e}"))?;
+    Ok((encoded, hit))
+}
+
+/// Running totals for a container-to-container conversion, matching the
+/// summary line printed by every tileset conversion.
+#[derive(Default)]
+pub struct TileStats {
+    written: u64,
+    cache_hits: u64,
+    cache_encoded: u64,
+    bytes_in: u64,
+    bytes_out: u64,
+}
+
+impl TileStats {
+    pub fn record(&mut self, encoded_len: u64, bytes_in: u64, hit: bool) {
+        self.written += 1;
+        if hit {
+            self.cache_hits += 1;
+        } else {
+            self.cache_encoded += 1;
+            self.bytes_in += bytes_in;
+            self.bytes_out += encoded_len;
+        }
+    }
+
+    pub fn print_summary(&self, start: Instant) {
+        eprintln!(
+            "  converted {} tiles ({} unique encoded, {} cache hits, {:.1}B -> {:.1}B) in {:.1?}",
+            self.written,
+            self.cache_encoded,
+            self.cache_hits,
+            SizeFormatterSI::new(self.bytes_in),
+            SizeFormatterSI::new(self.bytes_out),
+            start.elapsed(),
+        );
+    }
+}
+
+/// One encoded tile leaving the pipeline: its coordinate, the MLT bytes, the
+/// source MVT size, and whether the encode was served from the dedup cache.
+pub struct EncodedTile {
+    pub coord: TileCoord,
+    pub data: Bytes,
+    pub bytes_in: u64,
+    pub hit: bool,
+}

--- a/rust/mlt/src/convert/from_files.rs
+++ b/rust/mlt/src/convert/from_files.rs
@@ -89,12 +89,7 @@ struct WalkCtx<'a> {
     stats: &'a DedupStats,
 }
 
-pub fn convert_files(
-    input: &Path,
-    output: &Path,
-    cfg: EncoderConfig,
-    to: TileFormat,
-) -> AnyResult<()> {
+pub fn convert(input: &Path, output: &Path, cfg: EncoderConfig, to: TileFormat) -> AnyResult<()> {
     // For a single file, use the parent so `strip_prefix` yields just the filename.
     let base = if input.is_dir() {
         input

--- a/rust/mlt/src/convert/from_mbtiles.rs
+++ b/rust/mlt/src/convert/from_mbtiles.rs
@@ -2,40 +2,40 @@ use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use anyhow::{Result as AnyResult, anyhow, bail};
-use bytes::Bytes;
 use futures::StreamExt;
-use indicatif::{ProgressBar, ProgressStyle};
 use martin_tile_utils::{Encoding, Format};
 use mbtiles::{MbtType, Mbtiles, MbtilesTranscoder, Metadata};
 use mlt_core::encoder::EncoderConfig;
-use moka::sync::Cache;
 use pmtiles::{PmTilesWriter, TileCoord, TileType};
 use size_format::SizeFormatterSI;
 use usize_cast::FromUsize as _;
-use xxhash_rust::xxh3::xxh3_64;
 
-use super::{MbtFormat, encode_one};
-use crate::convert::{ContainerFormat, whole_rate_per_sec};
+use super::common::{
+    ENCODE_CACHE_BYTES, EncodedTile, MAX_TILE_CACHE_TRACK_SIZE_BYTES, TileStats, encode_tile,
+    make_encode_cache, make_progress_bar,
+};
+use super::{ContainerFormat, MbtFormat, encode_one};
 
-/// Cap on the encoding cache (which encoded `Bytes` to keep around).
-const ENCODE_CACHE_BYTES: u64 = 512 * 1024 * 1024;
-/// Cap on the tile cache track size (in bytes).
-const MAX_TILE_CACHE_TRACK_SIZE_BYTES: usize = 1024;
-const PROGRESS_BAR_TEMPLATE: &str = "  {bar:40.cyan/blue} {pos}/{len} tiles [{rate}, eta {eta}]";
-
-fn make_progress_bar(total: u64) -> ProgressBar {
-    let bar = ProgressBar::new(total);
-    bar.set_style(
-        ProgressStyle::default_bar()
-            .template(PROGRESS_BAR_TEMPLATE)
-            .expect("invalid bar template")
-            .with_key("rate", whole_rate_per_sec),
-    );
-    bar.enable_steady_tick(Duration::from_millis(200));
-    bar
+/// Re-encode an `.mbtiles` input (MVT) into the requested container.
+pub async fn convert(
+    input: &Path,
+    output: (&Path, ContainerFormat),
+    cfg: EncoderConfig,
+    mbtiles_format: Option<MbtFormat>,
+) -> AnyResult<()> {
+    match output {
+        (output, ContainerFormat::Mbtiles) => {
+            convert_mbtiles_to_mbtiles(input, output, mbtiles_format, cfg).await
+        }
+        (output, ContainerFormat::Pmtiles) => convert_mbtiles_to_pmtiles(input, output, cfg).await,
+        (output, ContainerFormat::Files) => bail!(
+            "Output must be either an .mbtiles or a .pmtiles file when input is an .mbtiles file, got: {}",
+            output.display()
+        ),
+    }
 }
 
 #[derive(Default)]
@@ -73,25 +73,6 @@ async fn get_metadata(input: &Path) -> AnyResult<(Encoding, MbtType, Metadata, u
         .fetch_one(&mut src_conn)
         .await? as u64;
     Ok((tile_info.encoding, src_type, meta, total))
-}
-
-pub async fn convert_tiles(
-    input: (&Path, ContainerFormat),
-    output: (&Path, ContainerFormat),
-    cfg: EncoderConfig,
-    mbtiles_format: Option<MbtFormat>,
-) -> AnyResult<()> {
-    match (input, output) {
-        ((input, ContainerFormat::Mbtiles), (output, ContainerFormat::Mbtiles)) => {
-            convert_mbtiles_to_mbtiles(input, output, mbtiles_format, cfg).await?;
-        }
-        ((input, ContainerFormat::Mbtiles), (output, ContainerFormat::Pmtiles)) => {
-            convert_mbtiles_to_pmtiles(input, output, cfg).await?;
-        }
-        ((_, from), (_, to)) => bail!("Converting from {from:?} to {to:?} not supported yet"),
-    }
-
-    Ok(())
 }
 
 async fn convert_mbtiles_to_mbtiles(
@@ -185,10 +166,7 @@ async fn convert_mbtiles_to_pmtiles(
 
     let parallelism = thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
 
-    let cache: Cache<u64, Bytes> = Cache::builder()
-        .max_capacity(ENCODE_CACHE_BYTES)
-        .weigher(|_, v: &Bytes| u32::try_from(v.len()).unwrap_or(u32::MAX))
-        .build();
+    let cache = make_encode_cache();
 
     let mbt = Mbtiles::new(input)?;
     let mut conn = mbt.open_readonly().await?;
@@ -208,53 +186,36 @@ async fn convert_mbtiles_to_pmtiles(
         })
         .map(|(coord, data)| {
             let cache = cache.clone();
-            tokio::task::spawn_blocking(move || -> AnyResult<(TileCoord, Bytes, u64, bool)> {
-                let bytes_in = u64::from_usize(data.len());
-                let mut hit = true;
-                let key = xxh3_64(&data);
-                let encoded = cache
-                    .try_get_with(key, || -> AnyResult<Bytes> {
-                        hit = false;
-                        encode_one(data, encoding, cfg)
-                    })
-                    .map_err(|e| anyhow!("{e}"))?;
-                Ok((coord, encoded, bytes_in, hit))
+            tokio::task::spawn_blocking(move || -> AnyResult<EncodedTile> {
+                let bytes_in = data.len() as u64;
+                let (data, hit) = encode_tile(&cache, &data, encoding, cfg)?;
+                Ok(EncodedTile {
+                    coord,
+                    data,
+                    bytes_in,
+                    hit,
+                })
             })
         })
         .buffer_unordered((parallelism - 1).max(1));
     tokio::pin!(encoded);
 
-    let mut written: u64 = 0;
-    let mut cache_hits: u64 = 0;
-    let mut cache_encoded: u64 = 0;
-    let mut bytes_in: u64 = 0;
-    let mut bytes_out: u64 = 0;
+    let mut stats = TileStats::default();
     while let Some(joined) = encoded.next().await {
-        let (coord, data, in_size, hit) = joined??;
-        if hit {
-            cache_hits += 1;
-        } else {
-            cache_encoded += 1;
-            bytes_in += in_size;
-            bytes_out += u64::from_usize(data.len());
-        }
+        let EncodedTile {
+            coord,
+            data,
+            bytes_in,
+            hit,
+        } = joined??;
         stream_writer.add_tile(coord, &data)?;
-        written += 1;
+        stats.record(data.len() as u64, bytes_in, hit);
         bar.inc(1);
     }
 
     stream_writer.finalize()?;
     bar.finish_and_clear();
-
-    eprintln!(
-        "  converted {} tiles ({} unique encoded, {} cache hits, {:.1}B -> {:.1}B) in {:.1?}",
-        written,
-        cache_encoded,
-        cache_hits,
-        SizeFormatterSI::new(bytes_in),
-        SizeFormatterSI::new(bytes_out),
-        start.elapsed(),
-    );
+    stats.print_summary(start);
 
     Ok(())
 }

--- a/rust/mlt/src/convert/mod.rs
+++ b/rust/mlt/src/convert/mod.rs
@@ -1,5 +1,6 @@
-mod files;
-mod tileset;
+mod common;
+mod from_files;
+mod from_mbtiles;
 
 use std::path::{Path, PathBuf};
 
@@ -97,9 +98,17 @@ impl TileFormat {
 
 #[derive(Clone, Default, ValueEnum)]
 enum SortMode {
-    /// Try all sort strategies and keep the smallest result
+    /// Try no-sort and Z-order (Morton) sort, keep the smaller (default).
+    ///
+    /// Morton wins ~8% of layers and captures nearly all of the spatial gain;
+    /// Hilbert and feature-ID sort each win <1% of layers while each doubling
+    /// the per-layer encode work, so they are excluded here and only tried
+    /// under `all`.
     #[default]
     Auto,
+    /// Try every sort strategy (no-sort, Morton, Hilbert, feature-ID) and keep
+    /// the smallest. Slowest, for marginally smaller output.
+    All,
     /// Do not reorder features (original order only)
     None,
     /// Only try Z-order (Morton) curve sort
@@ -147,9 +156,12 @@ impl ConvertArgs {
 pub fn convert(args: &ConvertArgs) -> AnyResult<()> {
     let cfg = EncoderConfig {
         tessellate: args.tessellate,
-        try_spatial_morton_sort: matches!(args.sort, SortMode::Auto | SortMode::Morton),
-        try_spatial_hilbert_sort: matches!(args.sort, SortMode::Auto | SortMode::Hilbert),
-        try_id_sort: matches!(args.sort, SortMode::Auto | SortMode::Id),
+        try_spatial_morton_sort: matches!(
+            args.sort,
+            SortMode::Auto | SortMode::All | SortMode::Morton
+        ),
+        try_spatial_hilbert_sort: matches!(args.sort, SortMode::All | SortMode::Hilbert),
+        try_id_sort: matches!(args.sort, SortMode::All | SortMode::Id),
         allow_shared_dict: !args.no_shared_dict,
         ..Default::default()
     };
@@ -174,19 +186,20 @@ pub fn convert(args: &ConvertArgs) -> AnyResult<()> {
             );
         }
 
+        let output = (args.output.as_path(), args.output_container());
         return tokio::runtime::Builder::new_current_thread()
             .enable_io()
             .enable_time()
             .build()?
-            .block_on(tileset::convert_tiles(
-                (&args.input, args.input_container()),
-                (&args.output, args.output_container()),
+            .block_on(from_mbtiles::convert(
+                &args.input,
+                output,
                 cfg,
                 args.mbtiles_format,
             ));
     }
 
-    files::convert_files(&args.input, &args.output, cfg, args.to)
+    from_files::convert(&args.input, &args.output, cfg, args.to)
 }
 
 fn convert_mlt_buffer(buffer: &[u8], cfg: EncoderConfig) -> AnyResult<Vec<u8>> {


### PR DESCRIPTION
This removes Hilbert and ID from the auto option as they together only gain <0.5% in size for >30% in runtime, so likely not in the auto set