### PR TITLE
chore(cpp): disable annoying MSVC warning

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -94,6 +94,7 @@ add_cxx_compiler_flag(-fstrict-aliasing)
 add_cxx_compiler_flag(-wd4061) # MSVC: enum member not handled in switch
 add_cxx_compiler_flag(-wd4514) # MSVC: unreferenced inline function has been removed
 add_cxx_compiler_flag(-wd4710) # MSVC: function not inlined
+add_cxx_compiler_flag(-wd4711) # MSVC: function selected for inline expansion
 add_cxx_compiler_flag(-wd4820) # MSVC: padding added after data member
 
 foreach(_target mlt-cpp mlt-cpp-encoder)


### PR DESCRIPTION
MSVC emits a warning "function selected for inline expansion" on every such function at level 4, making the output difficult to use where there is a real issue