### PR TITLE
chore(rust): release

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -37,9 +37,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -491,7 +491,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.14",
+ "h2 0.4.15",
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
@@ -834,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.1"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1131,7 +1131,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1483,7 +1483,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -2230,7 +2229,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2335,9 +2334,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2727,7 +2726,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.14",
+ "h2 0.4.15",
  "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
@@ -3001,7 +3000,7 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
  "unit-prefix",
  "web-time",
 ]
@@ -3536,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "mlt"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3572,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-core"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "arbitrary",
  "bitvec",
@@ -3613,7 +3612,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-ffi"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
@@ -3622,7 +3621,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-py"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "mlt-core",
  "pyo3",
@@ -3643,7 +3642,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-wasm"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "js-sys",
  "mlt-core",
@@ -4046,7 +4045,7 @@ checksum = "d0984e668274d34691bc2b262ef0d115de5fa9973bcdee7ae32213f93099153e"
 dependencies = [
  "bytecount",
  "fnv",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -4895,7 +4894,7 @@ dependencies = [
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -4947,7 +4946,7 @@ dependencies = [
  "strum",
  "time",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -6557,7 +6556,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
 dependencies = [
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -6620,12 +6619,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -6637,15 +6635,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -7029,7 +7027,7 @@ checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools 0.14.0",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -7040,9 +7038,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -50,7 +50,7 @@ js-sys = "0.3"
 martin-tile-utils = "0.7"
 mbtiles = { version = "0.17", default-features = false, features = ["transcode"] }
 mimalloc = "0.1.52"
-mlt-core = { version = "0.10.1", path = "mlt-core" }
+mlt-core = { version = "0.11.0", path = "mlt-core" }
 moka = { version = "0.12", features = ["sync"] }
 num-traits = "0.2.19"
 num_enum = "0.7.6"

--- a/rust/mlt-core/CHANGELOG.md
+++ b/rust/mlt-core/CHANGELOG.md
@@ -1,4 +1,4 @@
-allow_fastpfor# Changelog
+# Changelog
 
 All notable changes to this project will be documented in this file.
 
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-core-v0.10.1...rust-mlt-core-v0.11.0) - 2026-06-15
+
+### Added
+
+- *(py)* make `mlt.encode_geojson` configurable ([#1427](https://github.com/maplibre/maplibre-tile-spec/pull/1427))
+
+### Fixed
+
+- *(rust)* clear losing sort-trial buffers between encode trials ([#1432](https://github.com/maplibre/maplibre-tile-spec/pull/1432))
+
+### Other
+
+- *(rust)* enforce non-empty layer name ([#1423](https://github.com/maplibre/maplibre-tile-spec/pull/1423))
+- *(rust)* remove unnecessary conversions ([#1421](https://github.com/maplibre/maplibre-tile-spec/pull/1421))
+allow_fastpfor
 ## [0.10.1](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-core-v0.10.0...rust-mlt-core-v0.10.1) - 2026-06-13
 
 ### Fixed

--- a/rust/mlt-core/Cargo.toml
+++ b/rust/mlt-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-core"
 description = "MapLibre Tile library code"
-version = "0.10.1"
+version = "0.11.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/rust/mlt-ffi/CHANGELOG.md
+++ b/rust/mlt-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-ffi-v0.1.5...rust-mlt-ffi-v0.1.6) - 2026-06-15
+
+### Added
+
+- *(py)* make `mlt.encode_geojson` configurable ([#1427](https://github.com/maplibre/maplibre-tile-spec/pull/1427))
+
 ## [0.1.5](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-ffi-v0.1.4...rust-mlt-ffi-v0.1.5) - 2026-06-13
 
 ### Other

--- a/rust/mlt-ffi/Cargo.toml
+++ b/rust/mlt-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-ffi"
 description = "Diplomat FFI bindings for mlt-core"
-version = "0.1.5"
+version = "0.1.6"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/rust/mlt-py/CHANGELOG.md
+++ b/rust/mlt-py/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.19](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.18...python-mlt-v0.1.19) - 2026-06-15
+
+### Added
+
+- *(py)* make `mlt.encode_geojson` configurable ([#1427](https://github.com/maplibre/maplibre-tile-spec/pull/1427))
+- *(py)* add encode_mvt to encode a whole MVT tile to MLT ([#1425](https://github.com/maplibre/maplibre-tile-spec/pull/1425))
+
 ## [0.1.18](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.17...python-mlt-v0.1.18) - 2026-06-13
 
 ### Other

--- a/rust/mlt-py/Cargo.toml
+++ b/rust/mlt-py/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-py"
 description = "Python bindings for MapLibre Tile (MLT) format via PyO3"
-version = "0.1.18"
+version = "0.1.19"
 readme = "README.md"
 repository.workspace = true
 edition.workspace = true

--- a/rust/mlt-wasm/CHANGELOG.md
+++ b/rust/mlt-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-wasm-v0.1.11...rust-mlt-wasm-v0.1.12) - 2026-06-15
+
+### Other
+
+- updated the following local packages: mlt-core
+
 ## [0.1.11](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-wasm-v0.1.10...rust-mlt-wasm-v0.1.11) - 2026-06-13
 
 ### Other

--- a/rust/mlt-wasm/Cargo.toml
+++ b/rust/mlt-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-wasm"
 description = "WebAssembly bindings for the MapLibre Tile (MLT) format"
-version = "0.1.11"
+version = "0.1.12"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/rust/mlt/CHANGELOG.md
+++ b/rust/mlt/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.16...rust-mlt-v0.1.17) - 2026-06-15
+
+### Added
+
+- *(rust)* pmtiles to pmtiles transcoding ([#1411](https://github.com/maplibre/maplibre-tile-spec/pull/1411))
+- *(py)* make `mlt.encode_geojson` configurable ([#1427](https://github.com/maplibre/maplibre-tile-spec/pull/1427))
+
+### Other
+
+- *(rust)* use mimalloc as the global allocator for the mlt CLI ([#1433](https://github.com/maplibre/maplibre-tile-spec/pull/1433))
+- *(rust)* split convert into from_files/from_mbtiles/common and add --sort all ([#1434](https://github.com/maplibre/maplibre-tile-spec/pull/1434))
+
 ## [0.1.16](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.15...rust-mlt-v0.1.16) - 2026-06-13
 
 ### Fixed

--- a/rust/mlt/Cargo.toml
+++ b/rust/mlt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt"
 description = "MapLibre Tile Tools"
-version = "0.1.16"
+version = "0.1.17"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `mlt-core`: 0.10.1 -> 0.11.0 (⚠ API breaking changes)
* `mlt`: 0.1.16 -> 0.1.17
* `mlt-ffi`: 0.1.5 -> 0.1.6
* `mlt-py`: 0.1.18 -> 0.1.19
* `mlt-wasm`: 0.1.11 -> 0.1.12

### ⚠ `mlt-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field EncoderConfig.allow_fastpfor in /tmp/.tmpTWlNUA/maplibre-tile-spec/rust/mlt-core/src/encoder/model.rs:75

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field allow_fpf of struct EncoderConfig, previously in file /tmp/.tmp7izV24/mlt-core/src/encoder/model.rs:75
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `mlt-core`

<blockquote>

## [0.11.0](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-core-v0.10.1...rust-mlt-core-v0.11.0) - 2026-06-15

### Added

- *(py)* make `mlt.encode_geojson` configurable ([#1427](https://github.com/maplibre/maplibre-tile-spec/pull/1427))

### Fixed

- *(rust)* clear losing sort-trial buffers between encode trials ([#1432](https://github.com/maplibre/maplibre-tile-spec/pull/1432))

### Other

- *(rust)* enforce non-empty layer name ([#1423](https://github.com/maplibre/maplibre-tile-spec/pull/1423))
- *(rust)* remove unnecessary conversions ([#1421](https://github.com/maplibre/maplibre-tile-spec/pull/1421))
allow_fastpfor
</blockquote>

## `mlt`

<blockquote>

## [0.1.17](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.16...rust-mlt-v0.1.17) - 2026-06-15

### Added

- *(rust)* pmtiles to pmtiles transcoding ([#1411](https://github.com/maplibre/maplibre-tile-spec/pull/1411))
- *(py)* make `mlt.encode_geojson` configurable ([#1427](https://github.com/maplibre/maplibre-tile-spec/pull/1427))

### Other

- *(rust)* use mimalloc as the global allocator for the mlt CLI ([#1433](https://github.com/maplibre/maplibre-tile-spec/pull/1433))
- *(rust)* split convert into from_files/from_mbtiles/common and add --sort all ([#1434](https://github.com/maplibre/maplibre-tile-spec/pull/1434))
</blockquote>

## `mlt-ffi`

<blockquote>

## [0.1.6](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-ffi-v0.1.5...rust-mlt-ffi-v0.1.6) - 2026-06-15

### Added

- *(py)* make `mlt.encode_geojson` configurable ([#1427](https://github.com/maplibre/maplibre-tile-spec/pull/1427))
</blockquote>

## `mlt-py`

<blockquote>

## [0.1.19](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.18...python-mlt-v0.1.19) - 2026-06-15

### Added

- *(py)* make `mlt.encode_geojson` configurable ([#1427](https://github.com/maplibre/maplibre-tile-spec/pull/1427))
- *(py)* add encode_mvt to encode a whole MVT tile to MLT ([#1425](https://github.com/maplibre/maplibre-tile-spec/pull/1425))
</blockquote>

## `mlt-wasm`

<blockquote>

## [0.1.12](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-wasm-v0.1.11...rust-mlt-wasm-v0.1.12) - 2026-06-15

### Other

- updated the following local packages: mlt-core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).