### PR TITLE
fix(rust): `allow_fastpfor` not consulted for precomputed geometry stream

### DIFF
--- a/rust/mlt-core/src/encoder/geometry/encode.rs
+++ b/rust/mlt-core/src/encoder/geometry/encode.rs
@@ -505,12 +505,15 @@ fn write_geo_precomputed_stream(
             let meta = StreamMeta::new2(ctx.stream_type, logical, PE::None, 0)?;
             write_stream_payload(&mut enc.data, meta, false, &[])?;
         } else {
+            let allow_fastpfor = enc.cfg.allow_fastpfor;
             let mut alt = enc.try_alternatives();
-            alt.with(|enc| {
-                let vals = physical.fastpfor(data)?;
-                let meta = StreamMeta::new2(ctx.stream_type, logical, PE::FastPFor256, data.len())?;
-                write_stream_payload(&mut enc.data, meta, false, vals)
-            })?;
+            if allow_fastpfor {
+                alt.with(|enc| {
+                    let vals = physical.fastpfor(data)?;
+                    let meta = StreamMeta::new2(ctx.stream_type, logical, PE::FastPFor256, data.len())?;
+                    write_stream_payload(&mut enc.data, meta, false, vals)
+                })?;
+            }
             alt.with(|enc| {
                 let vals = physical.varint(data);
                 let meta = StreamMeta::new2(ctx.stream_type, logical, PE::VarInt, data.len())?;

--- a/rust/mlt-core/src/encoder/geometry/encode.rs
+++ b/rust/mlt-core/src/encoder/geometry/encode.rs
@@ -510,7 +510,8 @@ fn write_geo_precomputed_stream(
             if allow_fastpfor {
                 alt.with(|enc| {
                     let vals = physical.fastpfor(data)?;
-                    let meta = StreamMeta::new2(ctx.stream_type, logical, PE::FastPFor256, data.len())?;
+                    let meta =
+                        StreamMeta::new2(ctx.stream_type, logical, PE::FastPFor256, data.len())?;
                     write_stream_payload(&mut enc.data, meta, false, vals)
                 })?;
             }


### PR DESCRIPTION
Before 0110faf2 I saw the error:

 > [MapLibre] [event]:ParseTile [code]:-1 [message]:MLT parse failed: FastPFOR decoding is not enabled. Configure with MLT_WITH_FASTPFOR=ON                                                                              

After 0110faf2 it becomes:

 > [MapLibre] [event]:ParseTile [code]:-1 [message]:MLT parse failed: FastPfor encoding for geometries is not yet supported.    

This fixes the other place we were using fastpfor