### PR TITLE
docs: list mlt CLI, mlt-wasm/mlt-ffi, and QGIS plugin on implementation status

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -20,4 +20,14 @@
 | [maplibre-tile-spec/java](https://github.com/maplibre/maplibre-tile-spec/tree/main/java) | Java | Encoder | |
 | [maplibre-tile-spec/rust/mlt](https://github.com/maplibre/maplibre-tile-spec/blob/main/rust/mlt/README.md) | Rust | Decoder / Encoder | Includes bundled `mlt` CLI, TUI, and conversion tooling. |
 | [maplibre-tile-spec/rust/mlt-wasm](https://github.com/maplibre/maplibre-tile-spec/tree/main/rust/mlt-wasm) | Rust / WASM | Decoder | |
-| [maplibre-tile-spec/rust/mlt-ffi](https://github.com/maplibre/maplibre-tile-spec/tree/main/rust/mlt-ffi) | Rust / FFI | Decoder / Encoder | Foreign-function bindings exposing MLT/MVT conversion. |
+| [maplibre-tile-spec/rust/mlt-core](https://github.com/maplibre/maplibre-tile-spec/blob/main/rust/mlt-core/README.md) | Rust | Decoder / Encoder | Used in Martin. Includes bundled `mlt` CLI, TUI, and conversion tooling. |
+| [maplibre-tile-spec/rust/mlt-wasm](https://github.com/maplibre/maplibre-tile-spec/tree/main/rust/mlt-wasm) | Rust / WASM | Decoder | Uses `mlt-core` |
+| [maplibre-tile-spec/rust/mlt-py](https://github.com/maplibre/maplibre-tile-spec/tree/main/rust/mlt-py) | Rust / [PyO3](https://pyo3.rs/). | Decoder / Encoder | Exposes `mlt-core` to the python communtiy via [PyO3](https://pyo3.rs/). |
+| [maplibre-tile-spec/rust/mlt-ffi](https://github.com/maplibre/maplibre-tile-spec/tree/main/rust/mlt-ffi) | Rust / FFI | Decoder / Encoder | Foreign-function bindings for `mlt-core` to the java/kotlin, cpp and c community |
+
+## Supporting tooling
+
+| Tool | Language | Type | Notes |
+|---|---|---|---|
+| [maplibre-tile-spec/rust/mlt](https://github.com/maplibre/maplibre-tile-spec/blob/main/rust/mlt/README.md) | Rust | Decoder / Encoder | `mlt` CLI, TUI, and conversion tooling. |
+

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -8,7 +8,7 @@
 | [MapLibre GL JS](https://maplibre.org/maplibre-gl-js/) | Supported since version 5.12.0. PR: [#6570](https://github.com/maplibre/maplibre-gl-js/pull/6570). |
 | Planetiler | Can generate tiles in MLT since version [0.10.0](https://github.com/onthegomap/planetiler/releases/tag/v0.10.0). |
 | PMTiles | Can store MLT, see [PMTiles v3 spec - Tile Type](https://github.com/protomaps/PMTiles/blob/main/spec/v3/spec.md#tile-type-tt). |
-| [Martin tile server](https://maplibre.org/martin/) | Can detect and serve MLT since version [1.3.0](https://github.com/maplibre/martin/releases/tag/martin-v1.3.0). PR: [#2512](https://github.com/maplibre/martin/pull/2512). |
+| [Martin tile server](https://maplibre.org/martin/) | Can detect and serve MLT since version [1.3.0](https://github.com/maplibre/martin/releases/tag/martin-v1.3.0). PR: [#2512](https://github.com/maplibre/martin/pull/2512).<br>Can automatically convert between MLT and MVT depending on headers since [1.9.0](https://github.com/maplibre/martin/releases/tag/martin-v1.9.0). [docs](https://maplibre.org/martin/using-guides/mlt/) |
 | [QGIS plugin](https://github.com/maplibre/maplibre-tile-spec/tree/main/qgis) | Opens MLT files in QGIS via the Rust `mlt` parser. See [qgis/README.md](https://github.com/maplibre/maplibre-tile-spec/blob/main/qgis/README.md). |
 
 ## Implementations

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -9,6 +9,7 @@
 | Planetiler | Can generate tiles in MLT since version [0.10.0](https://github.com/onthegomap/planetiler/releases/tag/v0.10.0). |
 | PMTiles | Can store MLT, see [PMTiles v3 spec - Tile Type](https://github.com/protomaps/PMTiles/blob/main/spec/v3/spec.md#tile-type-tt). |
 | [Martin tile server](https://maplibre.org/martin/) | Can detect and serve MLT since version [1.3.0](https://github.com/maplibre/martin/releases/tag/martin-v1.3.0). PR: [#2512](https://github.com/maplibre/martin/pull/2512). |
+| [QGIS plugin](https://github.com/maplibre/maplibre-tile-spec/tree/main/qgis) | Opens MLT files in QGIS via the Rust `mlt` parser. See [qgis/README.md](https://github.com/maplibre/maplibre-tile-spec/blob/main/qgis/README.md). |
 
 ## Implementations
 
@@ -17,4 +18,6 @@
 | [maplibre-tile-spec/cpp](https://github.com/maplibre/maplibre-tile-spec/tree/main/cpp) | C++ | Decoder | Used by MapLibre Native |
 | [maplibre-tile-spec/js](https://github.com/maplibre/maplibre-tile-spec/tree/main/js) | TypeScript | Decoder | Used by MapLibre GL JS |
 | [maplibre-tile-spec/java](https://github.com/maplibre/maplibre-tile-spec/tree/main/java) | Java | Encoder | |
-| [maplibre-tile-spec/rust/mlt](https://github.com/maplibre/maplibre-tile-spec/tree/main/rust/mlt) | Rust | Decoder / Encoder | |
+| [maplibre-tile-spec/rust/mlt](https://github.com/maplibre/maplibre-tile-spec/blob/main/rust/mlt/README.md) | Rust | Decoder / Encoder | Includes bundled `mlt` CLI, TUI, and conversion tooling. |
+| [maplibre-tile-spec/rust/mlt-wasm](https://github.com/maplibre/maplibre-tile-spec/tree/main/rust/mlt-wasm) | Rust / WASM | Decoder | |
+| [maplibre-tile-spec/rust/mlt-ffi](https://github.com/maplibre/maplibre-tile-spec/tree/main/rust/mlt-ffi) | Rust / FFI | Decoder / Encoder | Foreign-function bindings exposing MLT/MVT conversion. |

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -30,4 +30,3 @@
 | Tool | Language | Type | Notes |
 |---|---|---|---|
 | [maplibre-tile-spec/rust/mlt](https://github.com/maplibre/maplibre-tile-spec/blob/main/rust/mlt/README.md) | Rust | Decoder / Encoder | `mlt` CLI, TUI, and conversion tooling. |
-


### PR DESCRIPTION
## What

Updates `docs/implementation-status.md` to give a fuller picture of how MLT can be produced and consumed on the Rust side and which tools integrate with it, as requested in the issue.

- Link the `rust/mlt` row to its [CLI README](https://github.com/maplibre/maplibre-tile-spec/blob/main/rust/mlt/README.md) and note the bundled `mlt` CLI, TUI, and conversion tooling, so users can find the CLI to encode/decode individual tile payloads.
- Add an `mlt-wasm` implementation row (Rust / WASM, decoder).
- Add an `mlt-ffi` implementation row (Rust / FFI, decoder/encoder conversion bindings).
- Add a QGIS plugin row to the Integrations table, pointing at `qgis/`.

## Why

The implementation-status page previously listed the Rust implementation only as a bare tree link and omitted `mlt-wasm`, `mlt-ffi`, and the QGIS plugin entirely.

## Notes

Documentation-only; no spec, encoder, or decoder logic is touched. Every added link resolves to an existing path on `main` (`rust/mlt/README.md`, `rust/mlt-wasm/`, `rust/mlt-ffi/`, `qgis/`, `qgis/README.md`), and the markdown tables keep their existing column counts.

Closes #1387
