### PR TITLE
chore(rust): release

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -783,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -813,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -908,9 +908,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "bytes-utils"
@@ -3519,7 +3519,7 @@ dependencies = [
 
 [[package]]
 name = "mlt"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-core"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "arbitrary",
  "bitvec",
@@ -3596,7 +3596,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-ffi"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
@@ -3605,7 +3605,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-py"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "mlt-core",
  "pyo3",
@@ -3626,7 +3626,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-wasm"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "js-sys",
  "mlt-core",
@@ -6017,9 +6017,9 @@ dependencies = [
 
 [[package]]
 name = "sqlite-compressions"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36cabe89311e64642e71729033dafd645847faeb95c6cd74952c1ee5b7ef1f94"
+checksum = "db38d6781aea4fee12f3bc8234235a28b8740d147c00faa759d401c6c0c6abef"
 dependencies = [
  "bsdiff",
  "flate2",
@@ -6028,13 +6028,13 @@ dependencies = [
 
 [[package]]
 name = "sqlite-hashes"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b2f14e4a076a0ae2813a27fd83f9702720caf4dfc83c96c19c204c2ca6ccee"
+checksum = "b848e500315157245a63c875db7bea01a6e8f876184f316886a813f931f87f96"
 dependencies = [
- "digest 0.10.7",
+ "digest 0.11.3",
  "hex",
- "md-5 0.10.6",
+ "md-5 0.11.0",
  "rusqlite",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -50,7 +50,7 @@ js-sys = "0.3"
 martin-tile-utils = "0.7"
 mbtiles = { version = "0.17", default-features = false, features = ["transcode"] }
 mimalloc = "0.1.52"
-mlt-core = { version = "0.11.1", path = "mlt-core" }
+mlt-core = { version = "0.12.0", path = "mlt-core" }
 moka = { version = "0.12", features = ["sync"] }
 num-traits = "0.2.19"
 num_enum = "0.7.6"

--- a/rust/mlt-core/CHANGELOG.md
+++ b/rust/mlt-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-core-v0.11.1...rust-mlt-core-v0.12.0) - 2026-06-19
+
+### Other
+
+- *(rust)* rm pub fields, builder pattern ([#1428](https://github.com/maplibre/maplibre-tile-spec/pull/1428))
+
 ## [0.11.1](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-core-v0.11.0...rust-mlt-core-v0.11.1) - 2026-06-18
 
 ### Fixed

--- a/rust/mlt-core/Cargo.toml
+++ b/rust/mlt-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-core"
 description = "MapLibre Tile library code"
-version = "0.11.1"
+version = "0.12.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/rust/mlt-ffi/CHANGELOG.md
+++ b/rust/mlt-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-ffi-v0.1.7...rust-mlt-ffi-v0.1.8) - 2026-06-19
+
+### Other
+
+- *(rust)* rm pub fields, builder pattern ([#1428](https://github.com/maplibre/maplibre-tile-spec/pull/1428))
+
 ## [0.1.7](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-ffi-v0.1.6...rust-mlt-ffi-v0.1.7) - 2026-06-18
 
 ### Other

--- a/rust/mlt-ffi/Cargo.toml
+++ b/rust/mlt-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-ffi"
 description = "Diplomat FFI bindings for mlt-core"
-version = "0.1.7"
+version = "0.1.8"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/rust/mlt-py/CHANGELOG.md
+++ b/rust/mlt-py/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.21](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.20...python-mlt-v0.1.21) - 2026-06-19
+
+### Other
+
+- *(rust)* rm pub fields, builder pattern ([#1428](https://github.com/maplibre/maplibre-tile-spec/pull/1428))
+
 ## [0.1.20](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.19...python-mlt-v0.1.20) - 2026-06-18
 
 ### Other

--- a/rust/mlt-py/Cargo.toml
+++ b/rust/mlt-py/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-py"
 description = "Python bindings for MapLibre Tile (MLT) format via PyO3"
-version = "0.1.20"
+version = "0.1.21"
 readme = "README.md"
 repository.workspace = true
 edition.workspace = true

--- a/rust/mlt-wasm/CHANGELOG.md
+++ b/rust/mlt-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-wasm-v0.1.13...rust-mlt-wasm-v0.1.14) - 2026-06-19
+
+### Other
+
+- *(rust)* rm pub fields, builder pattern ([#1428](https://github.com/maplibre/maplibre-tile-spec/pull/1428))
+
 ## [0.1.13](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-wasm-v0.1.12...rust-mlt-wasm-v0.1.13) - 2026-06-18
 
 ### Other

--- a/rust/mlt-wasm/Cargo.toml
+++ b/rust/mlt-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-wasm"
 description = "WebAssembly bindings for the MapLibre Tile (MLT) format"
-version = "0.1.13"
+version = "0.1.14"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/rust/mlt/CHANGELOG.md
+++ b/rust/mlt/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.19](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.18...rust-mlt-v0.1.19) - 2026-06-19
+
+### Other
+
+- *(rust)* rm pub fields, builder pattern ([#1428](https://github.com/maplibre/maplibre-tile-spec/pull/1428))
+
 ## [0.1.18](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.17...rust-mlt-v0.1.18) - 2026-06-18
 
 ### Other

--- a/rust/mlt/Cargo.toml
+++ b/rust/mlt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt"
 description = "MapLibre Tile Tools"
-version = "0.1.18"
+version = "0.1.19"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `mlt-core`: 0.11.1 -> 0.12.0 (⚠ API breaking changes)
* `mlt`: 0.1.18 -> 0.1.19
* `mlt-ffi`: 0.1.7 -> 0.1.8
* `mlt-py`: 0.1.20 -> 0.1.21
* `mlt-wasm`: 0.1.13 -> 0.1.14

### ⚠ `mlt-core` breaking changes

```text
--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field EncoderConfig.attempt_spatial_morton_sort in /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/encoder/model.rs:184
  field EncoderConfig.attempt_spatial_hilbert_sort in /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/encoder/model.rs:186
  field EncoderConfig.attempt_id_sort in /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/encoder/model.rs:188
  field TileLayer.property_kinds in /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/decoder/model.rs:212

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field id of struct FeatureRef, previously in file /tmp/.tmpQoTz07/mlt-core/src/decoder/iterators.rs:219
  field geometry of struct FeatureRef, previously in file /tmp/.tmpQoTz07/mlt-core/src/decoder/iterators.rs:221
  field cfg of struct Encoder, previously in file /tmp/.tmpQoTz07/mlt-core/src/encoder/writer.rs:81
  field hdr of struct Encoder, previously in file /tmp/.tmpQoTz07/mlt-core/src/encoder/writer.rs:92
  field meta of struct Encoder, previously in file /tmp/.tmpQoTz07/mlt-core/src/encoder/writer.rs:100
  field data of struct Encoder, previously in file /tmp/.tmpQoTz07/mlt-core/src/encoder/writer.rs:109
  field name of struct Layer01, previously in file /tmp/.tmpQoTz07/mlt-core/src/decoder/model.rs:110
  field extent of struct Layer01, previously in file /tmp/.tmpQoTz07/mlt-core/src/decoder/model.rs:111
  field tessellate of struct EncoderConfig, previously in file /tmp/.tmpQoTz07/mlt-core/src/encoder/model.rs:65
  field try_spatial_morton_sort of struct EncoderConfig, previously in file /tmp/.tmpQoTz07/mlt-core/src/encoder/model.rs:67
  field try_spatial_hilbert_sort of struct EncoderConfig, previously in file /tmp/.tmpQoTz07/mlt-core/src/encoder/model.rs:69
  field try_id_sort of struct EncoderConfig, previously in file /tmp/.tmpQoTz07/mlt-core/src/encoder/model.rs:71
  field allow_fsst of struct EncoderConfig, previously in file /tmp/.tmpQoTz07/mlt-core/src/encoder/model.rs:73
  field allow_fastpfor of struct EncoderConfig, previously in file /tmp/.tmpQoTz07/mlt-core/src/encoder/model.rs:75
  field allow_shared_dict of struct EncoderConfig, previously in file /tmp/.tmpQoTz07/mlt-core/src/encoder/model.rs:77
  field name of struct ColumnRef, previously in file /tmp/.tmpQoTz07/mlt-core/src/decoder/iterators.rs:208
  field value of struct ColumnRef, previously in file /tmp/.tmpQoTz07/mlt-core/src/decoder/iterators.rs:209
  field id of struct TileFeature, previously in file /tmp/.tmpQoTz07/mlt-core/src/decoder/model.rs:178
  field geometry of struct TileFeature, previously in file /tmp/.tmpQoTz07/mlt-core/src/decoder/model.rs:180
  field properties of struct TileFeature, previously in file /tmp/.tmpQoTz07/mlt-core/src/decoder/model.rs:183
  field name of struct TileLayer, previously in file /tmp/.tmpQoTz07/mlt-core/src/decoder/model.rs:168
  field extent of struct TileLayer, previously in file /tmp/.tmpQoTz07/mlt-core/src/decoder/model.rs:169
  field property_names of struct TileLayer, previously in file /tmp/.tmpQoTz07/mlt-core/src/decoder/model.rs:171
  field features of struct TileLayer, previously in file /tmp/.tmpQoTz07/mlt-core/src/decoder/model.rs:172

--- failure struct_pub_field_now_doc_hidden: pub struct field is now #[doc(hidden)] ---

Description:
A pub field of a pub struct is now marked #[doc(hidden)] and is no longer part of the public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_now_doc_hidden.ron

Failed in:
  field FeatureRef.id in file /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/decoder/iterators.rs:229
  field FeatureRef.geometry in file /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/decoder/iterators.rs:229
  field Encoder.cfg in file /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/encoder/writer.rs:73
  field Encoder.hdr in file /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/encoder/writer.rs:73
  field Encoder.meta in file /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/encoder/writer.rs:73
  field Encoder.data in file /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/encoder/writer.rs:73
  field Layer01.name in file /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/decoder/model.rs:136
  field Layer01.extent in file /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/decoder/model.rs:136
  field EncoderConfig.tessellate in file /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/encoder/model.rs:180
  field EncoderConfig.allow_fsst in file /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/encoder/model.rs:180
  field EncoderConfig.allow_fastpfor in file /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/encoder/model.rs:180
  field EncoderConfig.allow_shared_dict in file /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/encoder/model.rs:180
  field ColumnRef.name in file /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/decoder/iterators.rs:207
  field ColumnRef.value in file /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/decoder/iterators.rs:207
  field TileFeature.id in file /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/decoder/model.rs:218
  field TileFeature.geometry in file /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/decoder/model.rs:218
  field TileFeature.properties in file /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/decoder/model.rs:218
  field TileLayer.name in file /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/decoder/model.rs:206
  field TileLayer.extent in file /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/decoder/model.rs:206
  field TileLayer.property_names in file /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/decoder/model.rs:206
  field TileLayer.features in file /tmp/.tmpmPmNd4/maplibre-tile-spec/rust/mlt-core/src/decoder/model.rs:206
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `mlt-core`

<blockquote>

## [0.12.0](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-core-v0.11.1...rust-mlt-core-v0.12.0) - 2026-06-19

### Other

- *(rust)* rm pub fields, builder pattern ([#1428](https://github.com/maplibre/maplibre-tile-spec/pull/1428))
</blockquote>

## `mlt`

<blockquote>

## [0.1.19](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.18...rust-mlt-v0.1.19) - 2026-06-19

### Other

- *(rust)* rm pub fields, builder pattern ([#1428](https://github.com/maplibre/maplibre-tile-spec/pull/1428))
</blockquote>

## `mlt-ffi`

<blockquote>

## [0.1.8](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-ffi-v0.1.7...rust-mlt-ffi-v0.1.8) - 2026-06-19

### Other

- *(rust)* rm pub fields, builder pattern ([#1428](https://github.com/maplibre/maplibre-tile-spec/pull/1428))
</blockquote>

## `mlt-py`

<blockquote>

## [0.1.21](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.20...python-mlt-v0.1.21) - 2026-06-19

### Other

- *(rust)* rm pub fields, builder pattern ([#1428](https://github.com/maplibre/maplibre-tile-spec/pull/1428))
</blockquote>

## `mlt-wasm`

<blockquote>

## [0.1.14](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-wasm-v0.1.13...rust-mlt-wasm-v0.1.14) - 2026-06-19

### Other

- *(rust)* rm pub fields, builder pattern ([#1428](https://github.com/maplibre/maplibre-tile-spec/pull/1428))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).