### PR TITLE
spec: add missing extent field to FeatureTableMetadata schema

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -194,6 +194,7 @@ direction TB
 
     class FeatureTable {
       +String name
+      +VarInt extent
       +VarInt columnCount
       +Column[] columns
     }
@@ -210,6 +211,10 @@ direction TB
     TileMetadata --> FeatureTable : featureTables
     FeatureTable --> Column : columns
 ```
+
+The `extent` field defines the coordinate space size for the tile's geometry.
+Geometry coordinates in MapLibre Tiles are encoded as integers in the range `[0, extent)`.
+The default value is `4096`, matching the Mapbox Vector Tile convention.
 
 Strings are encoded as UTF-8 sequences of characters with a length header:
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -212,9 +212,11 @@ direction TB
     FeatureTable --> Column : columns
 ```
 
-The `extent` field defines the coordinate space size for the tile's geometry.
-Geometry coordinates in MapLibre Tiles are encoded as integers in the range `[0, extent)`.
-The default value is `4096`, matching the Mapbox Vector Tile convention.
+The required `extent` field defines the coordinate space size for the tile's geometry.
+Geometry coordinates in MapLibre Tiles are encoded as signed integers in vector-tile grid coordinates (typically near the `0..=extent` range, but not restricted to it).
+Values MAY be negative or exceed extent for geometry that crosses tile boundaries.
+Encoders MAY default to `4096` when a user does not specify the extent.
+Decoders MUST require it to diferente `extent` and `columnCount`.
 
 Strings are encoded as UTF-8 sequences of characters with a length header:
 


### PR DESCRIPTION
The FeatureTable binary format encodes an `extent varint` between the `name` string and the `columnCount` varint
[(see tileset.cpp)](https://raw.githubusercontent.com/maplibre/maplibre-tile-spec/refs/heads/main/cpp/src/mlt/metadata/tileset.cpp).

This field was absent from the FeatureTableSchema diagram and had no accompanying description, making any spec-only implementation produce an incorrect parser.

Add extent to the schema and document it's semantics: tile coordinate space size, default 4096.