### PR TITLE
feat(rust): narrow 64-bit property columns to 32-bit when values fit

### DIFF
--- a/rust/mlt-core/src/encoder/optimizer.rs
+++ b/rust/mlt-core/src/encoder/optimizer.rs
@@ -232,6 +232,18 @@ impl PropertyTypedStats {
         }
     }
 
+    /// Returns `true` if every value fits in an `i32`.
+    ///
+    /// Unlike [`Self::values_fit_u32`] this admits negative values.
+    #[must_use]
+    pub fn values_fit_i32(&self) -> bool {
+        match self {
+            Self::None | Self::Bool | Self::F32 | Self::F64 | Self::String { .. } => false,
+            Self::Signed { min, max } => i32::try_from(*min).is_ok() && i32::try_from(*max).is_ok(),
+            Self::Unsigned { max, .. } => i32::try_from(*max).is_ok(),
+        }
+    }
+
     #[must_use]
     pub fn shared_dict(&self) -> SharedDictRole {
         match self {

--- a/rust/mlt-core/src/encoder/property/tests.rs
+++ b/rust/mlt-core/src/encoder/property/tests.rs
@@ -779,6 +779,86 @@ fn staging_uses_id_presence_analysis() {
     assert!(matches!(staged.id(), StagedId::None));
 }
 
+fn stage_single_prop(name: &str, values: Vec<PropValue>) -> StagedProperty {
+    let tile = tile_from_cols(&[(name, values)]);
+    let analysis = tile.analyze(false).unwrap();
+    let curve_params = tile.curve_params();
+    let mut staged = StagedLayer::from_tile(tile, Unsorted, &analysis, false, curve_params)
+        .properties()
+        .to_vec();
+    assert_eq!(staged.len(), 1, "expected exactly one staged property");
+    staged.pop().unwrap()
+}
+
+fn staged_kind(p: &StagedProperty) -> &'static str {
+    match p {
+        StagedProperty::U32(_) => "U32",
+        StagedProperty::OptU32(_) => "OptU32",
+        StagedProperty::I32(_) => "I32",
+        StagedProperty::OptI32(_) => "OptI32",
+        StagedProperty::U64(_) => "U64",
+        StagedProperty::OptU64(_) => "OptU64",
+        StagedProperty::I64(_) => "I64",
+        StagedProperty::OptI64(_) => "OptI64",
+        _ => panic!("unexpected staged kind"),
+    }
+}
+
+#[rstest]
+#[case(vec![PropValue::I64(Some(1_782_397_800)), PropValue::I64(Some(0))], "U32")]
+#[case(vec![PropValue::U64(Some(0)), PropValue::U64(Some(u64::from(u32::MAX)))], "U32")]
+#[case(vec![PropValue::I64(Some(-5)), PropValue::I64(Some(2))], "I32")]
+#[case(vec![PropValue::I64(None), PropValue::I64(Some(1_782_397_800))], "OptU32")]
+#[case(vec![PropValue::I64(None), PropValue::I64(Some(-5))], "OptI32")]
+#[case(vec![PropValue::U64(Some(0)), PropValue::U64(Some(u64::from(u32::MAX) + 1))], "U64")]
+#[case(vec![PropValue::I64(Some(i64::from(i32::MIN) - 1)), PropValue::I64(Some(0))], "I64")]
+#[case(vec![PropValue::I64(Some(i64::from(u32::MAX) + 1)), PropValue::I64(Some(0))], "I64")]
+fn staging_narrows_64bit_columns_to_smallest_fitting_type(
+    #[case] values: Vec<PropValue>,
+    #[case] expected: &str,
+) {
+    assert_eq!(staged_kind(&stage_single_prop("c", values)), expected);
+}
+
+#[test]
+fn narrowed_property_column_round_trips_values() {
+    let ts = 1_782_397_800_i64;
+    let tile = tile_from_cols(&[(
+        "ts",
+        vec![
+            PropValue::I64(Some(ts)),
+            PropValue::I64(Some(ts + 60)),
+            PropValue::I64(Some(0)),
+        ],
+    )]);
+    let bytes = tile.encode(EncoderConfig::default()).unwrap();
+
+    let (_, layer) = Layer::from_bytes(&bytes, &mut parser()).expect("layer parse failed");
+    let Layer::Tag01(layer01) = layer else {
+        panic!("expected Tag01 layer")
+    };
+    let mut d = dec();
+    let decoded = layer01
+        .decode_all(&mut d)
+        .expect("decode failed")
+        .into_tile(&mut d)
+        .expect("into_tile failed");
+
+    assert_eq!(decoded.property_names(), &["ts"]);
+    assert_eq!(
+        decoded.features()[0].properties()[0],
+        PropValue::U32(Some(u32::try_from(ts).unwrap()))
+    );
+    assert_eq!(
+        decoded.features()[1].properties()[0],
+        PropValue::U32(Some(u32::try_from(ts + 60).unwrap()))
+    );
+    assert_eq!(
+        decoded.features()[2].properties()[0],
+        PropValue::U32(Some(0))
+    );
+}
+
 #[test]
 fn analyze_layer_classifies_id_and_property_presence() {
     let tile = tile_from_cols_with_ids(

--- a/rust/mlt-core/src/encoder/tile.rs
+++ b/rust/mlt-core/src/encoder/tile.rs
@@ -11,7 +11,7 @@
 
 use crate::decoder::{GeometryValues, PropValue, TileFeature, TileLayer};
 use crate::encoder::model::{CurveParams, StagedLayer};
-use crate::encoder::optimizer::{LayerStats, Presence, SharedDictRole};
+use crate::encoder::optimizer::{LayerStats, Presence, PropertyTypedStats, SharedDictRole};
 use crate::encoder::{SortStrategy, StagedId, StagedProperty, StagedSharedDict};
 
 impl StagedLayer {
@@ -84,6 +84,7 @@ impl StagedLayer {
                         std::mem::take(&mut property_names[col_idx]),
                         col_idx,
                         prop_analysis.presence,
+                        &prop_analysis.stats,
                         &mut features,
                     ) {
                         properties.push(prop);
@@ -118,6 +119,7 @@ fn build_scalar_column(
     name: String,
     col: usize,
     presence: Presence,
+    stats: &PropertyTypedStats,
     features: &mut [TileFeature],
 ) -> Option<StagedProperty> {
     if presence == Presence::AllNull {
@@ -157,13 +159,48 @@ fn build_scalar_column(
         }};
     }
 
+    // Narrows a 64-bit source column to a 32-bit destination, so the
+    // `FastPFOR` codec (32-bit only) becomes eligible.
+    macro_rules! narrow_col {
+        ($opt_ctor:ident, $non_opt_ctor:ident, $dst:ty, $sv:ident) => {{
+            Some(match presence {
+                Presence::AllNull => unreachable!("handled before variant dispatch"),
+                Presence::AllPresent => StagedProperty::$non_opt_ctor(
+                    name,
+                    features
+                        .iter()
+                        .map(|f| match f.properties().get(col) {
+                            Some(PropValue::$sv(Some(v))) => <$dst>::try_from(*v)
+                                .expect("analyzed range guarantees value fits narrowed type"),
+                            _ => unreachable!("analysis guarantees present typed values"),
+                        })
+                        .collect(),
+                ),
+                Presence::Mixed | Presence::SameAsProp(_) => StagedProperty::$opt_ctor(
+                    name,
+                    features.iter().map(|f| match f.properties().get(col) {
+                        Some(PropValue::$sv(Some(v))) => Some(
+                            <$dst>::try_from(*v)
+                                .expect("analyzed range guarantees value fits narrowed type"),
+                        ),
+                        _ => None,
+                    }),
+                ),
+            })
+        }};
+    }
+
     match first_val {
         Some(PropValue::Bool(_)) => scalar_col!(opt_bool, bool, bool, Bool),
         Some(PropValue::I8(_)) => scalar_col!(opt_i8, i8, i8, I8),
         Some(PropValue::U8(_)) => scalar_col!(opt_u8, u8, u8, U8),
         Some(PropValue::I32(_)) => scalar_col!(opt_i32, i32, i32, I32),
         Some(PropValue::U32(_)) => scalar_col!(opt_u32, u32, u32, U32),
+        // `u32` is tried before `i32` since `values_fit_u32` requires `min >= 0`.
+        Some(PropValue::I64(_)) if stats.values_fit_u32() => narrow_col!(opt_u32, u32, u32, I64),
+        Some(PropValue::I64(_)) if stats.values_fit_i32() => narrow_col!(opt_i32, i32, i32, I64),
         Some(PropValue::I64(_)) => scalar_col!(opt_i64, i64, i64, I64),
+        Some(PropValue::U64(_)) if stats.values_fit_u32() => narrow_col!(opt_u32, u32, u32, U64),
         Some(PropValue::U64(_)) => scalar_col!(opt_u64, u64, u64, U64),
         Some(PropValue::F32(_)) => scalar_col!(opt_f32, f32, f32, F32),
         Some(PropValue::F64(_)) => scalar_col!(opt_f64, f64, f64, F64),


### PR DESCRIPTION
Currently when converting MVT-> MLT we don't auto-narrow.
This is problematic because it is quite easy to add and because on the web 64-bit numbers are a problem.