### PR TITLE
fix(rust): Skip encoding competition for single-value int streams; pick smaller of VarInt/plain

### DIFF
--- a/rust/mlt-core/src/encoder/stream/codecs.rs
+++ b/rust/mlt-core/src/encoder/stream/codecs.rs
@@ -140,27 +140,30 @@ impl Codecs {
             return encoder::write_stream_payload(enc.data_mut(), meta, false, vals2);
         }
 
-        // One value has no deltas and no runs, and FastPFOR framing always
-        // costs more here. Only the physical layout varies: VarInt is shorter
-        // until the value needs all its bytes (>= 2^28 for u32, >= 2^56 for u64,
-        // post-zigzag for signed), where plain avoids VarInt's continuation
-        // byte. Pick the smaller; no competition needed.
-        if values.len() == 1 {
-            let Self { logical, physical } = self;
-            let vals1 = logical.none(values);
-            let plain: &[u8] = cast_slice(vals1);
-            let varint = physical.varint(vals1);
-            let (pe, payload) = if varint.len() <= plain.len() {
-                (PE::VarInt, varint)
+        // A single value has no deltas or runs, so Delta would only zigzag the
+        // lone value into something equal or larger, and FastPFOR never pays off
+        // for one value. Only the physical layout matters, so skip the
+        // competition. Matching the encoded stream binds the lone value with no
+        // indexing bounds check. VarInt is shorter until the value needs all its
+        // bytes (>= 2^28 for u32, >= 2^56 for u64, post-zigzag for signed),
+        // where fixed-width plain avoids VarInt's continuation byte.
+        let Self { logical, physical } = self;
+        if values.len() == 1
+            && let [value] = logical.none(values)
+        {
+            let n: u64 = (*value).into();
+            let varint_len = (u64::BITS - n.leading_zeros()).max(1).div_ceil(7) as usize;
+            let encoded = std::slice::from_ref(value);
+            let (pe, payload) = if varint_len <= size_of_val(encoded) {
+                (PE::VarInt, physical.varint(encoded))
             } else {
-                (PE::None, plain)
+                (PE::None, cast_slice(encoded))
             };
-            let meta = StreamMeta::new2(ctx.stream_type, LE::None, pe, vals1.len())?;
+            let meta = StreamMeta::new2(ctx.stream_type, LE::None, pe, 1)?;
             return encoder::write_stream_payload(enc.data_mut(), meta, false, payload);
         }
 
         let allow_fastpfor = enc.config().allow_fastpfor();
-        let Self { logical, physical } = self;
         let mut alt = enc.try_alternatives();
 
         let sample = logical.none(DataProfile::take_sample(values));

--- a/rust/mlt-core/src/encoder/stream/codecs.rs
+++ b/rust/mlt-core/src/encoder/stream/codecs.rs
@@ -140,6 +140,25 @@ impl Codecs {
             return encoder::write_stream_payload(enc.data_mut(), meta, false, vals2);
         }
 
+        // One value has no deltas and no runs, and FastPFOR framing always
+        // costs more here. Only the physical layout varies: VarInt is shorter
+        // until the value needs all its bytes (>= 2^28 for u32, >= 2^56 for u64,
+        // post-zigzag for signed), where plain avoids VarInt's continuation
+        // byte. Pick the smaller; no competition needed.
+        if values.len() == 1 {
+            let Self { logical, physical } = self;
+            let vals1 = logical.none(values);
+            let plain: &[u8] = cast_slice(vals1);
+            let varint = physical.varint(vals1);
+            let (pe, payload) = if varint.len() <= plain.len() {
+                (PE::VarInt, varint)
+            } else {
+                (PE::None, plain)
+            };
+            let meta = StreamMeta::new2(ctx.stream_type, LE::None, pe, vals1.len())?;
+            return encoder::write_stream_payload(enc.data_mut(), meta, false, payload);
+        }
+
         let allow_fastpfor = enc.config().allow_fastpfor();
         let Self { logical, physical } = self;
         let mut alt = enc.try_alternatives();

--- a/rust/mlt-core/src/encoder/stream/tests.rs
+++ b/rust/mlt-core/src/encoder/stream/tests.rs
@@ -175,6 +175,55 @@ fn auto_physical(values: &[u32], cfg: EncoderConfig) -> PhysicalEncoding {
     parsed.meta.encoding.physical
 }
 
+/// A single value picks logical `None` and the smaller physical layout:
+/// `VarInt` for small values, plain `None` once `VarInt` needs an extra
+/// continuation byte (>= 2^28 for u32).
+#[rstest]
+// u32: small values -> VarInt; >= 2^28 -> plain wins by one byte.
+#[case::u32_zero(0u32, PhysicalEncoding::VarInt)]
+#[case::u32_small(5u32, PhysicalEncoding::VarInt)]
+#[case::u32_two_bytes(1000u32, PhysicalEncoding::VarInt)]
+#[case::u32_boundary_lo((1u32 << 28) - 1, PhysicalEncoding::VarInt)]
+#[case::u32_boundary_hi(1u32 << 28, PhysicalEncoding::None)]
+#[case::u32_max(u32::MAX, PhysicalEncoding::None)]
+fn single_value_u32_picks_smaller_physical(
+    #[case] v: u32,
+    #[case] expected_physical: PhysicalEncoding,
+) {
+    let mut enc = Encoder::new(EncoderConfig::default());
+    let codecs = &mut Codecs::default();
+    let ctx = StreamCtx::prop_data("test");
+    codecs.write_int_stream(&[v], &ctx, &mut enc).unwrap();
+
+    let parsed = assert_empty(RawStream::from_bytes(enc.data(), &mut parser()));
+    assert_eq!(parsed.meta.encoding.logical, LogicalEncoding::None);
+    assert_eq!(parsed.meta.encoding.physical, expected_physical);
+    assert_eq!(parsed.meta.num_values, 1);
+    assert_eq!(roundtrip_stream_u32s(enc.data()), vec![v]);
+}
+
+/// Same for signed values, where `none()` zigzags first: large-magnitude values
+/// cross into the plain layout, small ones stay `VarInt`.
+#[rstest]
+#[case::i32_zero(0i32, PhysicalEncoding::VarInt)]
+#[case::i32_neg_one(-1i32, PhysicalEncoding::VarInt)]
+#[case::i32_small_neg(-1000i32, PhysicalEncoding::VarInt)]
+#[case::i32_large_pos(i32::MAX, PhysicalEncoding::None)]
+#[case::i32_large_neg(i32::MIN, PhysicalEncoding::None)]
+fn single_value_i32_picks_smaller_physical(
+    #[case] v: i32,
+    #[case] expected_physical: PhysicalEncoding,
+) {
+    let mut enc = Encoder::new(EncoderConfig::default());
+    let codecs = &mut Codecs::default();
+    let ctx = StreamCtx::prop_data("test");
+    codecs.write_int_stream(&[v], &ctx, &mut enc).unwrap();
+
+    let parsed = assert_empty(RawStream::from_bytes(enc.data(), &mut parser()));
+    assert_eq!(parsed.meta.encoding.logical, LogicalEncoding::None);
+    assert_eq!(parsed.meta.encoding.physical, expected_physical);
+}
+
 /// Regression: `EncoderConfig::allow_fastpfor` must actually gate `FastPFOR` selection in the auto path.
 /// Previously the flag was dead — `FastPFOR` was always tried.
 #[test]

--- a/rust/mlt-core/src/encoder/stream/tests.rs
+++ b/rust/mlt-core/src/encoder/stream/tests.rs
@@ -175,11 +175,7 @@ fn auto_physical(values: &[u32], cfg: EncoderConfig) -> PhysicalEncoding {
     parsed.meta.encoding.physical
 }
 
-/// A single value picks logical `None` and the smaller physical layout:
-/// `VarInt` for small values, plain `None` once `VarInt` needs an extra
-/// continuation byte (>= 2^28 for u32).
 #[rstest]
-// u32: small values -> VarInt; >= 2^28 -> plain wins by one byte.
 #[case::u32_zero(0u32, PhysicalEncoding::VarInt)]
 #[case::u32_small(5u32, PhysicalEncoding::VarInt)]
 #[case::u32_two_bytes(1000u32, PhysicalEncoding::VarInt)]
@@ -202,8 +198,6 @@ fn single_value_u32_picks_smaller_physical(
     assert_eq!(roundtrip_stream_u32s(enc.data()), vec![v]);
 }
 
-/// Same for signed values, where `none()` zigzags first: large-magnitude values
-/// cross into the plain layout, small ones stay `VarInt`.
 #[rstest]
 #[case::i32_zero(0i32, PhysicalEncoding::VarInt)]
 #[case::i32_neg_one(-1i32, PhysicalEncoding::VarInt)]


### PR DESCRIPTION
- non-optimal strat
- doing work is slower than skipping work
- not a "high value" issue though, given occurance