### PR TITLE
fix(ts): Add defensive guards on geometry decode paths

### DIFF
--- a/ts/src/decoding/geometryDecoder.spec.ts
+++ b/ts/src/decoding/geometryDecoder.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import IntWrapper from "./intWrapper";
+import { decodeGeometryColumn } from "./geometryDecoder";
+import { createStream, concatenateBuffers } from "./decodingTestUtils";
+import { encodeVarintInt32 } from "../encoding/integerEncodingUtils";
+import { PhysicalStreamType } from "../metadata/tile/physicalStreamType";
+import { PhysicalLevelTechnique } from "../metadata/tile/physicalLevelTechnique";
+import { DictionaryType } from "../metadata/tile/dictionaryType";
+import { OffsetType } from "../metadata/tile/offsetType";
+
+// A single-value geometry-type stream decodes to VectorType.CONST, a multi-value one to FLAT.
+const constGeometryType = createStream(PhysicalStreamType.DATA, encodeVarintInt32(new Uint32Array([3])), {
+    technique: PhysicalLevelTechnique.VARINT,
+    count: 1,
+});
+const flatGeometryType = createStream(PhysicalStreamType.DATA, encodeVarintInt32(new Uint32Array([1, 1])), {
+    technique: PhysicalLevelTechnique.VARINT,
+    count: 2,
+});
+const vertexStream = createStream(PhysicalStreamType.DATA, encodeVarintInt32(new Uint32Array([0, 0])), {
+    logical: { dictionaryType: DictionaryType.VERTEX },
+    technique: PhysicalLevelTechnique.VARINT,
+    count: 2,
+});
+const indexStream = createStream(PhysicalStreamType.OFFSET, encodeVarintInt32(new Uint32Array([0, 1])), {
+    logical: { offsetType: OffsetType.INDEX },
+    technique: PhysicalLevelTechnique.VARINT,
+    count: 2,
+});
+
+describe("decodeGeometryColumn invariants", () => {
+    it("throws when a single-geometry-type column is missing its vertex buffer", () => {
+        expect(() => decodeGeometryColumn(constGeometryType, 1, new IntWrapper(0), 1)).toThrow(
+            "Geometry column is missing its vertex buffer.",
+        );
+    });
+
+    it("throws when a mixed-geometry-type column is missing its vertex buffer", () => {
+        expect(() => decodeGeometryColumn(flatGeometryType, 1, new IntWrapper(0), 2)).toThrow(
+            "Geometry column is missing its vertex buffer.",
+        );
+    });
+
+    it("throws when a single-geometry-type tessellated column is missing its triangle offsets", () => {
+        const column = concatenateBuffers(constGeometryType, vertexStream, indexStream);
+        expect(() => decodeGeometryColumn(column, 3, new IntWrapper(0), 1)).toThrow(
+            "Tessellated geometry is missing its triangle offsets.",
+        );
+    });
+
+    it("throws when a mixed-geometry-type tessellated column is missing its triangle offsets", () => {
+        const column = concatenateBuffers(flatGeometryType, vertexStream, indexStream);
+        expect(() => decodeGeometryColumn(column, 3, new IntWrapper(0), 2)).toThrow(
+            "Tessellated geometry is missing its triangle offsets.",
+        );
+    });
+});

--- a/ts/src/decoding/geometryDecoder.ts
+++ b/ts/src/decoding/geometryDecoder.ts
@@ -96,7 +96,14 @@ export function decodeGeometryColumn(
             }
         }
 
+        if (vertexBuffer === undefined) {
+            throw new Error("Geometry column is missing its vertex buffer.");
+        }
+
         if (indexBuffer) {
+            if (triangleOffsets === undefined) {
+                throw new Error("Tessellated geometry is missing its triangle offsets.");
+            }
             if (geometryOffsets !== undefined || partOffsets !== undefined) {
                 /* Case when the indices of a Polygon outline are encoded in the tile */
                 const topologyVector = { geometryOffsets, partOffsets, ringOffsets };
@@ -208,13 +215,19 @@ export function decodeGeometryColumn(
         partOffsets = decodeRootLengthStream(geometryTypeVector, partLengths, 0);
     }
 
-    if (indexBuffer && !partOffsets) {
-        /* Case when the indices of a Polygon outline are not encoded in the data so no
-         *  topology data are present in the tile */
-        return createFlatGpuVector(geometryTypeVector, triangleOffsets, indexBuffer, vertexBuffer);
+    if (vertexBuffer === undefined) {
+        throw new Error("Geometry column is missing its vertex buffer.");
     }
 
     if (indexBuffer) {
+        if (triangleOffsets === undefined) {
+            throw new Error("Tessellated geometry is missing its triangle offsets.");
+        }
+        if (!partOffsets) {
+            /* Case when the indices of a Polygon outline are not encoded in the data so no
+             *  topology data are present in the tile */
+            return createFlatGpuVector(geometryTypeVector, triangleOffsets, indexBuffer, vertexBuffer);
+        }
         /* Case when the indices of a Polygon outline are encoded in the tile */
         return createFlatGpuVector(geometryTypeVector, triangleOffsets, indexBuffer, vertexBuffer, {
             geometryOffsets,

--- a/ts/src/mltDecoder.spec.ts
+++ b/ts/src/mltDecoder.spec.ts
@@ -8,6 +8,10 @@ import Pbf from "pbf";
 import { type FeatureTable, type Feature, decodeTile } from ".";
 import path from "node:path";
 import fs from "node:fs";
+import IntWrapper from "./decoding/intWrapper";
+import { concatenateBuffers } from "./decoding/decodingTestUtils";
+import { encodeFieldName } from "./encoding/embeddedTilesetMetadataEncoder";
+import { encodeVarintInt32Value } from "./encoding/integerEncodingUtils";
 
 const ITERATOR_TILE = path.resolve(__dirname, "../../test/expected/tag0x01/simple/multiline-boolean.mlt");
 
@@ -55,6 +59,29 @@ describe("FeatureTable", () => {
             featureCount++;
         }
         assert.equal(featureCount, table.numFeatures);
+    });
+});
+
+describe("decodeTile invariants", () => {
+    function varint(value: number): Uint8Array {
+        const buffer = new Uint8Array(5);
+        const offset = new IntWrapper(0);
+        encodeVarintInt32Value(value, buffer, offset);
+        return buffer.slice(0, offset.get());
+    }
+
+    it("throws when a feature table has no geometry column", () => {
+        // A Tag 0x01 block whose embedded metadata describes a feature table with zero
+        // columns, so neither an id nor a geometry column is decoded.
+        const metadata = concatenateBuffers(
+            encodeFieldName("layer"), // feature table name (length-prefixed)
+            varint(4096), // extent
+            varint(0), // column count
+        );
+        const block = concatenateBuffers(varint(1), metadata); // tag 0x01 + metadata
+        const tile = concatenateBuffers(varint(block.length), block); // length-prefixed block
+
+        assert.throws(() => decodeTile(tile), /Feature table "layer" is missing its geometry column\./);
     });
 });
 

--- a/ts/src/mltDecoder.ts
+++ b/ts/src/mltDecoder.ts
@@ -149,6 +149,10 @@ export default function decodeTile(
             }
         }
 
+        if (geometryVector === null) {
+            throw new Error(`Feature table "${featureTableMetadata.name}" is missing its geometry column.`);
+        }
+
         const featureTable = new FeatureTable(
             featureTableMetadata.name,
             geometryVector,

--- a/ts/src/vector/geometry/geometryVector.ts
+++ b/ts/src/vector/geometry/geometryVector.ts
@@ -30,6 +30,11 @@ export abstract class GeometryVector {
         return this._vertexBufferType;
     }
 
+    /**
+     * The topology arrays are present only for the geometry types that need them.
+     * Multi-geometries carry geometryOffsets, polygons carry part/ring offsets.
+     * Consumers must guard which arrays they index based on the geometry type.
+     */
     get topologyVector(): TopologyVector {
         return this._topologyVector;
     }

--- a/ts/src/vector/geometry/geometryVectorConverter.spec.ts
+++ b/ts/src/vector/geometry/geometryVectorConverter.spec.ts
@@ -5,6 +5,7 @@ import { GEOMETRY_TYPE } from "./geometryType";
 import { VertexBufferType } from "./vertexBufferType";
 import { encodeZOrderCurve } from "../../encoding/zOrderCurveEncoder";
 import type { GeometryVector, MortonSettings } from "./geometryVector";
+import type { TopologyVector } from "./topologyVector";
 import {
     encodeLineStringGeometryVector,
     encodeLineStringGeometryVectorWithMortonEncoding,
@@ -72,7 +73,7 @@ describe("POINT – Morton dictionary encoded", () => {
     it("decodes a point with a non-zero coordinateShift", () => {
         const x = 50;
         const y = 80;
-        const settings: MortonSettings = { numBits: 16, coordinateShift: 100 } as MortonSettings;
+        const settings: MortonSettings = { numBits: 16, coordinateShift: 100 };
         const code = encodeZOrderCurve(x, y, settings.numBits, settings.coordinateShift);
 
         const gv = new ConstGeometryVector(
@@ -614,7 +615,9 @@ describe("Error handling", () => {
             containsPolygonGeometry: () => false,
         } as unknown as GeometryVector;
 
-        expect(() => convertGeometryVector(gv)).toThrowError("The specified geometry type is currently not supported.");
+        expect(() => convertGeometryVector(gv)).toThrow(
+            "The specified geometry type (999) is currently not supported.",
+        );
     });
 });
 
@@ -644,5 +647,107 @@ describe("Edge cases", () => {
 
         const result = convertGeometryVector(gv);
         expect(result[0]).toEqual([[new Point(3, 9)]]);
+    });
+});
+
+describe("missing topology offsets and morton settings throw", () => {
+    // Build a minimal GeometryVector stand-in so we can omit individual topology
+    // arrays / morton settings and exercise the invariant guards in convertGeometryVector.
+    function fakeVector(opts: {
+        geometryType: number;
+        containsPolygon?: boolean;
+        topologyVector?: TopologyVector;
+        vertexBufferType?: VertexBufferType;
+        vertexOffsets?: Uint32Array;
+        vertexBuffer?: Int32Array;
+        mortonSettings?: MortonSettings;
+    }): GeometryVector {
+        return {
+            numGeometries: 1,
+            topologyVector: opts.topologyVector ?? {},
+            vertexBufferType: opts.vertexBufferType ?? VertexBufferType.VEC_2,
+            vertexOffsets: opts.vertexOffsets,
+            vertexBuffer: opts.vertexBuffer ?? new Int32Array([0, 0]),
+            mortonSettings: opts.mortonSettings,
+            geometryType: () => opts.geometryType,
+            containsPolygonGeometry: () => opts.containsPolygon ?? false,
+        } as unknown as GeometryVector;
+    }
+
+    it("throws for a Morton-encoded Point without morton settings", () => {
+        const gv = fakeVector({
+            geometryType: GEOMETRY_TYPE.POINT,
+            vertexBufferType: VertexBufferType.MORTON,
+            vertexOffsets: new Uint32Array([0]),
+            vertexBuffer: new Int32Array([0]),
+        });
+        expect(() => convertGeometryVector(gv)).toThrow("Morton-encoded geometry vector is missing morton settings.");
+    });
+
+    it("throws for a MultiPoint without geometry offsets", () => {
+        const gv = fakeVector({ geometryType: GEOMETRY_TYPE.MULTIPOINT });
+        expect(() => convertGeometryVector(gv)).toThrow("MultiPoint geometry is missing its geometry offsets.");
+    });
+
+    it("throws for a polygon-outline LineString without ring offsets", () => {
+        const gv = fakeVector({
+            geometryType: GEOMETRY_TYPE.LINESTRING,
+            containsPolygon: true,
+            topologyVector: { partOffsets: new Uint32Array([0, 2]) },
+        });
+        expect(() => convertGeometryVector(gv)).toThrow("LineString geometry is missing its ring offsets.");
+    });
+
+    it("throws for a LineString without part offsets", () => {
+        const gv = fakeVector({ geometryType: GEOMETRY_TYPE.LINESTRING });
+        expect(() => convertGeometryVector(gv)).toThrow("LineString geometry is missing its part offsets.");
+    });
+
+    it("throws for a Polygon without part or ring offsets", () => {
+        const gv = fakeVector({
+            geometryType: GEOMETRY_TYPE.POLYGON,
+            topologyVector: { ringOffsets: new Uint32Array([0, 4]) },
+        });
+        expect(() => convertGeometryVector(gv)).toThrow("Polygon geometry is missing its part or ring offsets.");
+    });
+
+    it("throws for a MultiLineString without geometry offsets", () => {
+        const gv = fakeVector({ geometryType: GEOMETRY_TYPE.MULTILINESTRING });
+        expect(() => convertGeometryVector(gv)).toThrow("MultiLineString geometry is missing its geometry offsets.");
+    });
+
+    it("throws for a polygon-outline MultiLineString without ring offsets", () => {
+        const gv = fakeVector({
+            geometryType: GEOMETRY_TYPE.MULTILINESTRING,
+            containsPolygon: true,
+            topologyVector: { geometryOffsets: new Uint32Array([0, 1]) },
+        });
+        expect(() => convertGeometryVector(gv)).toThrow("MultiLineString geometry is missing its ring offsets.");
+    });
+
+    it("throws for a MultiLineString without part offsets", () => {
+        const gv = fakeVector({
+            geometryType: GEOMETRY_TYPE.MULTILINESTRING,
+            topologyVector: { geometryOffsets: new Uint32Array([0, 1]) },
+        });
+        expect(() => convertGeometryVector(gv)).toThrow("MultiLineString geometry is missing its part offsets.");
+    });
+
+    it("throws for a MultiPolygon without geometry, part, or ring offsets", () => {
+        const gv = fakeVector({ geometryType: GEOMETRY_TYPE.MULTIPOLYGON });
+        expect(() => convertGeometryVector(gv)).toThrow(
+            "MultiPolygon geometry is missing its geometry, part, or ring offsets.",
+        );
+    });
+
+    it("throws for a Morton dictionary-encoded LineString without morton settings", () => {
+        const gv = fakeVector({
+            geometryType: GEOMETRY_TYPE.LINESTRING,
+            vertexBufferType: VertexBufferType.MORTON,
+            topologyVector: { partOffsets: new Uint32Array([0, 1]) },
+            vertexOffsets: new Uint32Array([0]),
+            vertexBuffer: new Int32Array([0]),
+        });
+        expect(() => convertGeometryVector(gv)).toThrow("Morton-encoded geometry vector is missing morton settings.");
     });
 });

--- a/ts/src/vector/geometry/geometryVectorConverter.ts
+++ b/ts/src/vector/geometry/geometryVectorConverter.ts
@@ -15,9 +15,9 @@ export function convertGeometryVector(geometryVector: GeometryVector): Coordinat
 
     const mortonSettings = geometryVector.mortonSettings;
     const topologyVector = geometryVector.topologyVector;
-    const geometryOffsets = topologyVector.geometryOffsets;
-    const partOffsets = topologyVector.partOffsets;
-    const ringOffsets = topologyVector.ringOffsets;
+    // These topology arrays are present only for the geometry types that need them (e.g. multi-geometries
+    // carry geometryOffsets, polygons carry part/ring offsets); each branch below guards what it indexes.
+    const { geometryOffsets, partOffsets, ringOffsets } = topologyVector;
     const vertexOffsets = geometryVector.vertexOffsets;
     const nonOffset = !vertexOffsets || vertexOffsets.length === 0;
 
@@ -37,6 +37,9 @@ export function convertGeometryVector(geometryVector: GeometryVector): Coordinat
                     } else if (geometryVector.vertexBufferType === VertexBufferType.MORTON) {
                         const offset = vertexOffsets[vertexOffsetsOffset++];
                         const mortonCode = vertexBuffer[offset];
+                        if (!mortonSettings) {
+                            throw new Error("Morton-encoded geometry vector is missing morton settings.");
+                        }
                         const vertex = decodeZOrderCurve(
                             mortonCode,
                             mortonSettings.numBits,
@@ -57,6 +60,9 @@ export function convertGeometryVector(geometryVector: GeometryVector): Coordinat
                 break;
             case GEOMETRY_TYPE.MULTIPOINT:
                 {
+                    if (!geometryOffsets) {
+                        throw new Error("MultiPoint geometry is missing its geometry offsets.");
+                    }
                     const numPoints =
                         geometryOffsets[geometryOffsetsCounter] - geometryOffsets[geometryOffsetsCounter - 1];
                     geometryOffsetsCounter++;
@@ -85,9 +91,15 @@ export function convertGeometryVector(geometryVector: GeometryVector): Coordinat
                 {
                     let numVertices: number;
                     if (containsPolygon) {
+                        if (!ringOffsets) {
+                            throw new Error("LineString geometry is missing its ring offsets.");
+                        }
                         numVertices = ringOffsets[ringOffsetsCounter] - ringOffsets[ringOffsetsCounter - 1];
                         ringOffsetsCounter++;
                     } else {
+                        if (!partOffsets) {
+                            throw new Error("LineString geometry is missing its part offsets.");
+                        }
                         numVertices = partOffsets[partOffsetCounter] - partOffsets[partOffsetCounter - 1];
                     }
                     partOffsetCounter++;
@@ -116,6 +128,9 @@ export function convertGeometryVector(geometryVector: GeometryVector): Coordinat
                 break;
             case GEOMETRY_TYPE.POLYGON:
                 {
+                    if (!partOffsets || !ringOffsets) {
+                        throw new Error("Polygon geometry is missing its part or ring offsets.");
+                    }
                     const numRings = partOffsets[partOffsetCounter] - partOffsets[partOffsetCounter - 1];
                     partOffsetCounter++;
                     const rings: CoordinatesArray = new Array(numRings - 1);
@@ -164,6 +179,9 @@ export function convertGeometryVector(geometryVector: GeometryVector): Coordinat
                 break;
             case GEOMETRY_TYPE.MULTILINESTRING:
                 {
+                    if (!geometryOffsets) {
+                        throw new Error("MultiLineString geometry is missing its geometry offsets.");
+                    }
                     const numLineStrings =
                         geometryOffsets[geometryOffsetsCounter] - geometryOffsets[geometryOffsetsCounter - 1];
                     geometryOffsetsCounter++;
@@ -171,9 +189,15 @@ export function convertGeometryVector(geometryVector: GeometryVector): Coordinat
                     for (let j = 0; j < numLineStrings; j++) {
                         let numVertices: number;
                         if (containsPolygon) {
+                            if (!ringOffsets) {
+                                throw new Error("MultiLineString geometry is missing its ring offsets.");
+                            }
                             numVertices = ringOffsets[ringOffsetsCounter] - ringOffsets[ringOffsetsCounter - 1];
                             ringOffsetsCounter++;
                         } else {
+                            if (!partOffsets) {
+                                throw new Error("MultiLineString geometry is missing its part offsets.");
+                            }
                             numVertices = partOffsets[partOffsetCounter] - partOffsets[partOffsetCounter - 1];
                         }
                         partOffsetCounter++;
@@ -199,6 +223,9 @@ export function convertGeometryVector(geometryVector: GeometryVector): Coordinat
                 break;
             case GEOMETRY_TYPE.MULTIPOLYGON:
                 {
+                    if (!geometryOffsets || !partOffsets || !ringOffsets) {
+                        throw new Error("MultiPolygon geometry is missing its geometry, part, or ring offsets.");
+                    }
                     const numPolygons =
                         geometryOffsets[geometryOffsetsCounter] - geometryOffsets[geometryOffsetsCounter - 1];
                     geometryOffsetsCounter++;
@@ -251,7 +278,7 @@ export function convertGeometryVector(geometryVector: GeometryVector): Coordinat
                 }
                 break;
             default:
-                throw new Error("The specified geometry type is currently not supported.");
+                throw new Error(`The specified geometry type (${geometryType}) is currently not supported.`);
         }
     }
 
@@ -265,9 +292,12 @@ function decodeDictionaryEncodedLineStringOrRing(
     vertexOffset: number,
     numVertices: number,
     closeLineString: boolean,
-    mortonSettings: MortonSettings,
+    mortonSettings: MortonSettings | undefined,
 ): Point[] {
     if (vertexBufferType === VertexBufferType.MORTON) {
+        if (!mortonSettings) {
+            throw new Error("Morton-encoded geometry vector is missing morton settings.");
+        }
         return decodeMortonDictionaryEncodedLineString(
             vertexBuffer,
             vertexOffsets,

--- a/ts/src/vector/geometry/geometryVectorConverter.ts
+++ b/ts/src/vector/geometry/geometryVectorConverter.ts
@@ -15,8 +15,6 @@ export function convertGeometryVector(geometryVector: GeometryVector): Coordinat
 
     const mortonSettings = geometryVector.mortonSettings;
     const topologyVector = geometryVector.topologyVector;
-    // These topology arrays are present only for the geometry types that need them (e.g. multi-geometries
-    // carry geometryOffsets, polygons carry part/ring offsets); each branch below guards what it indexes.
     const { geometryOffsets, partOffsets, ringOffsets } = topologyVector;
     const vertexOffsets = geometryVector.vertexOffsets;
     const nonOffset = !vertexOffsets || vertexOffsets.length === 0;

--- a/ts/src/vector/geometry/gpuVector.spec.ts
+++ b/ts/src/vector/geometry/gpuVector.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { ConstGpuVector } from "./constGpuVector";
+import { GEOMETRY_TYPE } from "./geometryType";
+import type { TopologyVector } from "./topologyVector";
+
+function gpuVector(geometryType: number, topologyVector?: TopologyVector): ConstGpuVector {
+    return new ConstGpuVector(
+        1,
+        geometryType,
+        new Uint32Array([0]), // triangleOffsets
+        new Uint32Array([0]), // indexBuffer
+        new Int32Array([0, 0]), // vertexBuffer
+        topologyVector,
+    );
+}
+
+describe("GpuVector.getGeometries invariants", () => {
+    it("throws without topology information", () => {
+        expect(() => gpuVector(GEOMETRY_TYPE.POLYGON).getGeometries()).toThrow(
+            "Cannot convert GpuVector to coordinates without topology information",
+        );
+    });
+
+    it("throws when part or ring offsets are missing", () => {
+        expect(() => gpuVector(GEOMETRY_TYPE.POLYGON, {}).getGeometries()).toThrow(
+            "Cannot convert GpuVector to coordinates without part and ring offsets",
+        );
+    });
+
+    it("throws for a MultiPolygon without geometry offsets", () => {
+        const topology: TopologyVector = {
+            partOffsets: new Uint32Array([0, 1]),
+            ringOffsets: new Uint32Array([0, 1]),
+        };
+        expect(() => gpuVector(GEOMETRY_TYPE.MULTIPOLYGON, topology).getGeometries()).toThrow(
+            "Cannot convert MultiPolygon GpuVector to coordinates without geometry offsets",
+        );
+    });
+});
+
+describe("GpuVector accessors", () => {
+    it("exposes the buffers and topology passed to the constructor", () => {
+        const triangleOffsets = new Uint32Array([0, 1]);
+        const indexBuffer = new Uint32Array([2, 3]);
+        const vertexBuffer = new Int32Array([4, 5]);
+        const topology: TopologyVector = { partOffsets: new Uint32Array([0, 1]) };
+        const vector = new ConstGpuVector(
+            1,
+            GEOMETRY_TYPE.POLYGON,
+            triangleOffsets,
+            indexBuffer,
+            vertexBuffer,
+            topology,
+        );
+
+        expect(vector.triangleOffsets).toBe(triangleOffsets);
+        expect(vector.indexBuffer).toBe(indexBuffer);
+        expect(vector.vertexBuffer).toBe(vertexBuffer);
+        expect(vector.topologyVector).toBe(topology);
+    });
+});
+
+describe("GpuVector iterator", () => {
+    it("throws because it is not implemented yet", () => {
+        expect(() => [...gpuVector(GEOMETRY_TYPE.POLYGON)]).toThrow("Iterator on a GpuVector is not implemented yet.");
+    });
+});

--- a/ts/src/vector/geometry/gpuVector.spec.ts
+++ b/ts/src/vector/geometry/gpuVector.spec.ts
@@ -59,9 +59,3 @@ describe("GpuVector accessors", () => {
         expect(vector.topologyVector).toBe(topology);
     });
 });
-
-describe("GpuVector iterator", () => {
-    it("throws because it is not implemented yet", () => {
-        expect(() => [...gpuVector(GEOMETRY_TYPE.POLYGON)]).toThrow("Iterator on a GpuVector is not implemented yet.");
-    });
-});

--- a/ts/src/vector/geometry/gpuVector.ts
+++ b/ts/src/vector/geometry/gpuVector.ts
@@ -132,18 +132,4 @@ export abstract class GpuVector implements Iterable<CoordinatesArray> {
         }
         return geometries;
     }
-
-    [Symbol.iterator](): Iterator<CoordinatesArray> {
-        /*for(let i = 1; i < this.triangleOffsets.length; i++) {
-           const numTriangles = this.triangleOffsets[i] - this.triangleOffsets[i-1];
-           const startIndex = this.triangleOffsets[i-1] * 3;
-           const endIndex = this.triangleOffsets[i] * 3;
-       }
-
-        while (index < this.numGeometries) {
-            yield geometries[index++];
-        }*/
-
-        throw new Error("Iterator on a GpuVector is not implemented yet.");
-    }
 }

--- a/ts/src/vector/geometry/gpuVector.ts
+++ b/ts/src/vector/geometry/gpuVector.ts
@@ -43,10 +43,10 @@ export abstract class GpuVector implements Iterable<CoordinatesArray> {
         }
 
         const geometries: CoordinatesArray[] = new Array(this.numGeometries);
-        const topology = this._topologyVector;
-        const partOffsets = topology.partOffsets;
-        const ringOffsets = topology.ringOffsets;
-        const geometryOffsets = topology.geometryOffsets;
+        const { partOffsets, ringOffsets, geometryOffsets } = this._topologyVector;
+        if (!partOffsets || !ringOffsets) {
+            throw new Error("Cannot convert GpuVector to coordinates without part and ring offsets");
+        }
 
         // Use counters to track position in offset arrays (like Java implementation)
         let vertexBufferOffset = 0;
@@ -89,6 +89,11 @@ export abstract class GpuVector implements Iterable<CoordinatesArray> {
                     break;
                 case GEOMETRY_TYPE.MULTIPOLYGON:
                     {
+                        if (!geometryOffsets) {
+                            throw new Error(
+                                "Cannot convert MultiPolygon GpuVector to coordinates without geometry offsets",
+                            );
+                        }
                         // Get number of polygons in this multipolygon
                         const numPolygons =
                             geometryOffsets[geometryOffsetsCounter] - geometryOffsets[geometryOffsetsCounter - 1];
@@ -139,7 +144,6 @@ export abstract class GpuVector implements Iterable<CoordinatesArray> {
             yield geometries[index++];
         }*/
 
-        //throw new Error("Iterator on a GpuVector is not implemented yet.");
-        return null;
+        throw new Error("Iterator on a GpuVector is not implemented yet.");
     }
 }

--- a/ts/src/vector/geometry/gpuVector.ts
+++ b/ts/src/vector/geometry/gpuVector.ts
@@ -3,7 +3,7 @@ import { GEOMETRY_TYPE } from "./geometryType";
 import type { CoordinatesArray } from "./geometryVector";
 import type { TopologyVector } from "./topologyVector";
 
-export abstract class GpuVector implements Iterable<CoordinatesArray> {
+export abstract class GpuVector {
     protected constructor(
         private readonly _triangleOffsets: Uint32Array,
         private readonly _indexBuffer: Uint32Array,


### PR DESCRIPTION
Split out from #1462

Adds named-error guards on the geometry decode paths.
Missing vertex/triangle/offset buffers/ morton settings fail with a clear message instead of a later errors.