### PR TITLE
fix: FSST shared dictionary encoded as DictionaryType::Single

### DIFF
--- a/rust/mlt-core/src/encoder/property/shared_dict.rs
+++ b/rust/mlt-core/src/encoder/property/shared_dict.rs
@@ -362,7 +362,7 @@ impl Codecs {
         // Write stream data: total count, corpus streams, then per-child streams.
         enc.write_varint(stream_len)?;
         if let Some(ref raw) = fsst_raw {
-            write_fsst_data(raw, DictionaryType::Single, &shared_dict.prefix, enc, self)?;
+            write_fsst_data(raw, DictionaryType::Shared, &shared_dict.prefix, enc, self)?;
         } else {
             let lengths = strings_to_lengths(&dict)?;
             let typ = StreamType::Length(LengthType::Dictionary);

--- a/rust/mlt-core/tests/mvt_round_trip.rs
+++ b/rust/mlt-core/tests/mvt_round_trip.rs
@@ -6,8 +6,15 @@
 use std::fs;
 use std::path::Path;
 
+use mlt_core::encoder::{
+    Codecs, Encoder, EncoderConfig, ExplicitEncoder, IntEncoder, Presence, StagedId, StagedLayer,
+    StagedProperty, StagedSharedDict, StrEncoding,
+};
+use mlt_core::geo_types::{Geometry, Point};
 use mlt_core::mvt::{mvt_to_tile_layers, tile_layers_to_mvt};
 use mlt_core::test_helpers::assert_mvt_equivalent_layers;
+use mlt_core::wire::{Analyze, DictionaryType, StreamType};
+use mlt_core::{Decoder, GeometryValues, Parser, PropValue, TileLayer};
 use test_each_file::test_each_path;
 
 test_each_path! { for ["mvt"] in "../test/fixtures" as mvt_round_trip => round_trip_fixture }
@@ -25,7 +32,93 @@ fn round_trip_fixture([path]: [&Path; 1]) {
     }
 }
 
-fn re_encode(layers: Vec<mlt_core::TileLayer>) -> Vec<mlt_core::TileLayer> {
+#[test]
+fn fsst_shared_dict_uses_shared_data_stream_type() {
+    let en = vec![
+        Some("Main Street".to_string()),
+        Some("Market Square".to_string()),
+        Some("River Road".to_string()),
+    ];
+    let de = vec![
+        Some("Hauptstrasse".to_string()),
+        Some("Marktplatz".to_string()),
+        Some("Flussweg".to_string()),
+    ];
+    let shared = StagedSharedDict::new(
+        "name:",
+        [
+            ("en", en.clone(), Presence::AllPresent),
+            ("de", de.clone(), Presence::AllPresent),
+        ],
+    )
+    .expect("shared dict");
+
+    let layer = StagedLayer::new(
+        "shared_fsst",
+        4096,
+        StagedId::None,
+        point_geometry(3),
+        vec![StagedProperty::SharedDict(shared)],
+    )
+    .expect("staged layer");
+    let mut codecs = Codecs::default();
+    let bytes = layer
+        .encode_into(
+            Encoder::with_explicit(
+                EncoderConfig::default(),
+                ExplicitEncoder::all_with_str(IntEncoder::varint(), StrEncoding::Fsst),
+            ),
+            &mut codecs,
+        )
+        .expect("encode layer")
+        .into_layer_bytes()
+        .expect("layer bytes");
+
+    let mut parser = Parser::default();
+    let raw = parser
+        .parse_layers(&bytes)
+        .expect("parse layer")
+        .remove(0)
+        .into_layer01()
+        .expect("tag 01 layer");
+    let mut stream_types = Vec::new();
+    raw.for_each_stream(&mut |meta| stream_types.push(meta.stream_type));
+
+    assert!(
+        stream_types.contains(&StreamType::Data(DictionaryType::Shared)),
+        "shared FSST corpus stream should be tagged Data(Shared): {stream_types:#?}"
+    );
+    assert!(
+        !stream_types.contains(&StreamType::Data(DictionaryType::Single)),
+        "shared FSST corpus stream must not be tagged Data(Single): {stream_types:#?}"
+    );
+
+    let mut decoder = Decoder::default();
+    let decoded = raw
+        .decode_all(&mut decoder)
+        .expect("decode layer")
+        .into_tile(&mut decoder)
+        .expect("tile layer");
+
+    assert_eq!(decoded.property_names(), &["name:en", "name:de"]);
+    for (i, feature) in decoded.features().iter().enumerate() {
+        assert_eq!(
+            feature.properties(),
+            &[PropValue::Str(en[i].clone()), PropValue::Str(de[i].clone()),],
+        );
+    }
+}
+
+fn point_geometry(n: usize) -> GeometryValues {
+    let mut geometry = GeometryValues::default();
+    for i in 0..n {
+        let point = Point::new(i as i32, i as i32);
+        geometry.push_geom(&Geometry::Point(point));
+    }
+    geometry
+}
+
+fn re_encode(layers: Vec<TileLayer>) -> Vec<TileLayer> {
     let bytes = tile_layers_to_mvt(layers).expect("encode mvt");
     mvt_to_tile_layers(bytes).expect("decode re-encoded mvt")
 }


### PR DESCRIPTION
## Summary

Tags the FSST shared-dictionary corpus stream with `DictionaryType::Shared` instead of `DictionaryType::Single` when encoding string properties. The stream metadata now matches how the data is actually laid out, so a shared FSST dictionary round-trips correctly.

## Why this matters

Issue #1085 reports that FSST shared dictionaries are encoded with the wrong `DictionaryType`. The encoder emitted `Single` for the corpus stream even though the values reference a shared dictionary, so the stream header disagreed with the payload. A decoder trusting the header would mis-read a shared FSST dictionary.

The fix sets the corpus stream's dictionary type to `Shared` in the FSST shared-dictionary path. It is a one-line correction to the stream metadata; the encoded bytes for the dictionary itself are unchanged.

## Testing

`cargo test -p mlt-core --features __private --test mvt_round_trip` — 135 passed. Added a focused round-trip regression that encodes a shared FSST dictionary and asserts the corpus stream is tagged `Shared` and decodes back to the original strings.

Fixes #1085
