### PR TITLE
Add ability to build mlt-cpp as object library and fix WASM build

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -22,12 +22,18 @@ if(PROJECT_IS_TOP_LEVEL AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     set(CMAKE_MODULE_LINKER_FLAGS_COVERAGE "--coverage")
 endif()
 
-add_library(mlt-cpp STATIC)
-add_library(mlt-cpp-encoder STATIC)
-
+option(MLT_AS_OBJECT_LIBRARY "Build mlt-cpp and mlt-cpp-encoder as object libraries" OFF)
 option(MLT_WITH_JSON "Include JSON support" ON)
 option(MLT_WITH_TESTS "Include Tests" ON)
 option(MLT_WITH_TOOLS "Include CLI tools" ON)
+
+if(MLT_AS_OBJECT_LIBRARY)
+    add_library(mlt-cpp OBJECT)
+    add_library(mlt-cpp-encoder OBJECT)
+else()
+    add_library(mlt-cpp STATIC)
+    add_library(mlt-cpp-encoder STATIC)
+endif()
 
 foreach(_target mlt-cpp mlt-cpp-encoder)
     set_target_properties(
@@ -94,6 +100,9 @@ add_cxx_compiler_flag(-wd4514) # MSVC: unreferenced inline function has been rem
 add_cxx_compiler_flag(-wd4710) # MSVC: function not inlined
 add_cxx_compiler_flag(-wd4711) # MSVC: function selected for inline expansion
 add_cxx_compiler_flag(-wd4820) # MSVC: padding added after data member
+if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+   add_cxx_compiler_flag(-pthread)
+endif()
 
 foreach(_target mlt-cpp mlt-cpp-encoder)
     target_include_directories(${_target}
@@ -202,4 +211,6 @@ if(MLT_WITH_TOOLS)
 endif(MLT_WITH_TOOLS)
 
 list(APPEND MLT_EXPORT_TARGETS mlt-cpp-encoder)
-export(TARGETS ${MLT_EXPORT_TARGETS} FILE MLTTargets.cmake)
+if(NOT MLT_AS_OBJECT_LIBRARY)
+    export(TARGETS ${MLT_EXPORT_TARGETS} FILE MLTTargets.cmake)
+endif()

--- a/cpp/vendor/fastpfor.cmake
+++ b/cpp/vendor/fastpfor.cmake
@@ -1,4 +1,10 @@
-add_library(fastpfor-lib STATIC
+if(MLT_AS_OBJECT_LIBRARY)
+    add_library(fastpfor-lib OBJECT)
+else()
+    add_library(fastpfor-lib STATIC)
+endif()
+
+target_sources(fastpfor-lib PRIVATE
     "${PROJECT_SOURCE_DIR}/vendor/fastpfor/fastpfor/bitpacking.cpp"
 )
 

--- a/cpp/vendor/fastpfor/fastpfor/util.h
+++ b/cpp/vendor/fastpfor/fastpfor/util.h
@@ -103,7 +103,7 @@ __attribute__((const)) inline uint32_t gccbits(const uint64_t v) {
         return static_cast<uint32_t>(index + 32 + 1);
     }
 #endif
-#elif defined(__arm__) || defined(__aarch64__)
+#elif defined(__arm__) || defined(__aarch64__) || defined(__wasm__)
     return 64 - __builtin_clzll(v);
 #else
     uint32_t answer;
@@ -158,7 +158,7 @@ inline void checkifdivisibleby(size_t a, uint32_t x) {
 __attribute__((const)) inline uint32_t asmbits(const uint32_t v) {
 #ifdef _MSC_VER
     return gccbits(v);
-#elif defined(__arm__) || defined(__aarch64__)
+#elif defined(__arm__) || defined(__aarch64__) || defined(__wasm__)
     return gccbits(v);
 #else
     if (v == 0) return 0;
@@ -171,7 +171,7 @@ __attribute__((const)) inline uint32_t asmbits(const uint32_t v) {
 __attribute__((const)) inline uint32_t asmbits(const uint64_t v) {
 #ifdef _MSC_VER
     return gccbits(v);
-#elif defined(__arm__) || defined(__aarch64__)
+#elif defined(__arm__) || defined(__aarch64__) || defined(__wasm__)
     return gccbits(v);
 #else
     if (v == 0) return 0;


### PR DESCRIPTION
Add ability to build mlt-cpp as object library and add threaded support for WASM. This is needed for an alternative way of amalgamation of static libraries where only the primary library is static, but the rest are object libraries.

I'm happy to split the MR if the WASM part is too unrelated.