### PR TITLE
Draft: add on-demand geometry decoding #224

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "bench:fsst": "vitest bench --run src/decoding/fsstDecoder.bench.ts",
     "test": "vitest run --coverage --coverage.reportOnFailure",
     "lint": "eslint",
     "format": "biome format --write ./src",

--- a/ts/src/decoding/fsstDecoder.bench.ts
+++ b/ts/src/decoding/fsstDecoder.bench.ts
@@ -15,7 +15,7 @@ const phrases = [
 const { symbols, symbolLengths } = createSymbolTable(phrases);
 const original = textEncoder.encode(phrases.join("").repeat(25_000));
 const compressed = encodeFsst(symbols, symbolLengths, original);
-let checksum = 0;
+let _checksum = 0;
 
 function referenceDecodeFsst(): Uint8Array {
     const decoded: number[] = [];
@@ -42,7 +42,7 @@ describe(`FSST ${compressed.length} compressed bytes to ${original.length} decod
     bench(
         "reference whole dictionary",
         () => {
-            checksum += referenceDecodeFsst().length;
+            _checksum += referenceDecodeFsst().length;
         },
         options,
     );
@@ -50,7 +50,7 @@ describe(`FSST ${compressed.length} compressed bytes to ${original.length} decod
     bench(
         "optimized whole dictionary",
         () => {
-            checksum += decodeFsst(symbols, symbolLengths, compressed).length;
+            _checksum += decodeFsst(symbols, symbolLengths, compressed).length;
         },
         options,
     );
@@ -59,7 +59,7 @@ describe(`FSST ${compressed.length} compressed bytes to ${original.length} decod
         "one sparse range",
         () => {
             const decoder = new FsstDecoder(symbols, symbolLengths, compressed);
-            checksum += decoder.decodeRange(original.length / 2, original.length / 2 + 32).length;
+            _checksum += decoder.decodeRange(original.length / 2, original.length / 2 + 32).length;
         },
         options,
     );
@@ -70,7 +70,7 @@ describe(`FSST ${compressed.length} compressed bytes to ${original.length} decod
             const decoder = new FsstDecoder(symbols, symbolLengths, compressed);
             for (let i = 1; i <= 10; i++) {
                 const start = Math.floor((original.length * i) / 11);
-                checksum += decoder.decodeRange(start, start + 32).length;
+                _checksum += decoder.decodeRange(start, start + 32).length;
             }
         },
         options,

--- a/ts/src/decoding/fsstDecoder.bench.ts
+++ b/ts/src/decoding/fsstDecoder.bench.ts
@@ -1,0 +1,78 @@
+import { bench, describe } from "vitest";
+import { createSymbolTable, encodeFsst } from "../encoding/fsstEncoder";
+import { decodeFsst, FsstDecoder } from "./fsstDecoder";
+
+const textEncoder = new TextEncoder();
+const phrases = [
+    "international hiking network;",
+    "regional hiking route;",
+    "OpenStreetMap contributors;",
+    "relation_id_tokens;",
+    "Zürich;",
+    "Paris;",
+    "network;nwn;rwn;lwn;iwn;",
+];
+const { symbols, symbolLengths } = createSymbolTable(phrases);
+const original = textEncoder.encode(phrases.join("").repeat(25_000));
+const compressed = encodeFsst(symbols, symbolLengths, original);
+let checksum = 0;
+
+function referenceDecodeFsst(): Uint8Array {
+    const decoded: number[] = [];
+    const symbolOffsets = new Array<number>(symbolLengths.length).fill(0);
+    for (let i = 1; i < symbolLengths.length; i++) {
+        symbolOffsets[i] = symbolOffsets[i - 1] + symbolLengths[i - 1];
+    }
+    for (let i = 0; i < compressed.length; i++) {
+        const symbolIndex = compressed[i];
+        if (symbolIndex === 255) {
+            decoded.push(compressed[++i]);
+        } else {
+            const length = symbolLengths[symbolIndex];
+            const offset = symbolOffsets[symbolIndex];
+            for (let j = 0; j < length; j++) decoded.push(symbols[offset + j]);
+        }
+    }
+    return new Uint8Array(decoded);
+}
+
+const options = { warmupTime: 500, time: 2_000 } as const;
+
+describe(`FSST ${compressed.length} compressed bytes to ${original.length} decoded bytes`, () => {
+    bench(
+        "reference whole dictionary",
+        () => {
+            checksum += referenceDecodeFsst().length;
+        },
+        options,
+    );
+
+    bench(
+        "optimized whole dictionary",
+        () => {
+            checksum += decodeFsst(symbols, symbolLengths, compressed).length;
+        },
+        options,
+    );
+
+    bench(
+        "one sparse range",
+        () => {
+            const decoder = new FsstDecoder(symbols, symbolLengths, compressed);
+            checksum += decoder.decodeRange(original.length / 2, original.length / 2 + 32).length;
+        },
+        options,
+    );
+
+    bench(
+        "ten sparse ranges",
+        () => {
+            const decoder = new FsstDecoder(symbols, symbolLengths, compressed);
+            for (let i = 1; i <= 10; i++) {
+                const start = Math.floor((original.length * i) / 11);
+                checksum += decoder.decodeRange(start, start + 32).length;
+            }
+        },
+        options,
+    );
+});

--- a/ts/src/decoding/fsstDecoder.spec.ts
+++ b/ts/src/decoding/fsstDecoder.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { decodeFsst } from "./fsstDecoder";
+import { decodeFsst, FsstDecoder } from "./fsstDecoder";
 import { encodeFsst, createSymbolTable } from "../encoding/fsstEncoder";
 
 const textEncoder = new TextEncoder();
@@ -42,6 +42,14 @@ describe("decodeFsst", () => {
             expect(new TextDecoder().decode(decoded)).toBe(inputString);
         });
 
+        it("should handle consecutive escaped bytes", () => {
+            const symbols = new Uint8Array([65]);
+            const symbolLengths = new Uint32Array([1]);
+            const encoded = new Uint8Array([255, 1, 255, 2, 0, 255, 3]);
+
+            expect(decodeFsst(symbols, symbolLengths, encoded)).toEqual(new Uint8Array([1, 2, 65, 3]));
+        });
+
         it("should handle string with all matching symbols", () => {
             const inputString = "AAAA";
             const originalBytes = textEncoder.encode(inputString);
@@ -68,5 +76,60 @@ describe("decodeFsst", () => {
             expect(new TextDecoder().decode(decoded)).toBe(inputString);
             expect(encoded.length).toBeLessThan(originalBytes.length);
         });
+    });
+
+    it("decodes individual byte ranges", () => {
+        const originalBytes = textEncoder.encode("HelloWorld escaped: \u0001");
+        const { symbols, symbolLengths } = createSymbolTable(["Hello", "World", " escaped: "]);
+        const encoded = encodeFsst(symbols, symbolLengths, originalBytes);
+        const decoder = new FsstDecoder(symbols, symbolLengths, encoded);
+
+        for (let start = 0; start < originalBytes.length; start++) {
+            for (let end = start; end <= originalBytes.length; end++) {
+                expect(decoder.decodeRange(start, end)).toEqual(originalBytes.subarray(start, end));
+            }
+        }
+        expect(decoder.decode()).toEqual(originalBytes);
+    });
+
+    it("decodes ranges across lazily built checkpoints", () => {
+        const originalBytes = textEncoder.encode("abcdefgh escaped:\u0001 multilingual:Zürich;".repeat(5_000));
+        const { symbols, symbolLengths } = createSymbolTable(["abcdefgh", " escaped:", " multilingual:", "Zürich;"]);
+        const encoded = encodeFsst(symbols, symbolLengths, originalBytes);
+        const expected = decodeFsst(symbols, symbolLengths, encoded);
+        const decoder = new FsstDecoder(symbols, symbolLengths, encoded);
+        const ranges = [
+            [16_380, 16_405],
+            [65_530, 65_550],
+            [131_068, 131_100],
+            [2, 19],
+            [originalBytes.length - 31, originalBytes.length],
+        ];
+
+        let random = 0x12345678;
+        for (let i = 0; i < 100; i++) {
+            random = (Math.imul(random, 1_664_525) + 1_013_904_223) >>> 0;
+            const start = random % (originalBytes.length - 64);
+            ranges.push([start, start + 64]);
+        }
+
+        for (const [start, end] of ranges) {
+            expect(decoder.decodeRange(start, end)).toEqual(expected.subarray(start, end));
+        }
+        expect(decoder.decodeRange(0, 1).buffer.byteLength).toBe(expected.length);
+    });
+
+    it("clamps sparse and full ranges to the decoded length", () => {
+        const originalBytes = textEncoder.encode("HelloWorld");
+        const { symbols, symbolLengths } = createSymbolTable(["Hello", "World"]);
+        const encoded = encodeFsst(symbols, symbolLengths, originalBytes);
+        const sparseDecoder = new FsstDecoder(symbols, symbolLengths, encoded);
+        const fullDecoder = new FsstDecoder(symbols, symbolLengths, encoded);
+        fullDecoder.decode();
+
+        expect(sparseDecoder.decodeRange(8, 20)).toEqual(originalBytes.subarray(8, 20));
+        expect(fullDecoder.decodeRange(8, 20)).toEqual(originalBytes.subarray(8, 20));
+        expect(sparseDecoder.decodeRange(20, 30)).toEqual(new Uint8Array());
+        expect(fullDecoder.decodeRange(20, 30)).toEqual(new Uint8Array());
     });
 });

--- a/ts/src/decoding/fsstDecoder.ts
+++ b/ts/src/decoding/fsstDecoder.ts
@@ -6,26 +6,144 @@
  * @param compressedData    FSST Compressed data, where each entry is an index to the symbols array
  * @returns                 Decoded data as Uint8Array
  */
-//TODO: improve -> quick and dirty implementation
 export function decodeFsst(symbols: Uint8Array, symbolLengths: Uint32Array, compressedData: Uint8Array): Uint8Array {
-    //TODO: use typed array directly
-    const decodedData: number[] = [];
-    const symbolOffsets: number[] = new Array(symbolLengths.length).fill(0);
+    const symbolOffsets = new Uint32Array(symbolLengths.length);
 
     for (let i = 1; i < symbolLengths.length; i++) {
         symbolOffsets[i] = symbolOffsets[i - 1] + symbolLengths[i - 1];
     }
 
+    let decodedLength = 0;
     for (let i = 0; i < compressedData.length; i++) {
-        if (compressedData[i] === 255) {
-            decodedData.push(compressedData[++i]);
+        const symbolIndex = compressedData[i];
+        if (symbolIndex === 255) {
+            decodedLength++;
+            i++;
         } else {
-            const symbolLength = symbolLengths[compressedData[i]];
-            const symbolOffset = symbolOffsets[compressedData[i]];
-            for (let j = 0; j < symbolLength; j++) {
-                decodedData.push(symbols[symbolOffset + j]);
+            decodedLength += symbolLengths[symbolIndex];
+        }
+    }
+
+    const decodedData = new Uint8Array(decodedLength);
+    let decodedOffset = 0;
+    for (let i = 0; i < compressedData.length; i++) {
+        const symbolIndex = compressedData[i];
+        if (symbolIndex === 255) {
+            decodedData[decodedOffset++] = compressedData[++i];
+        } else {
+            let symbolLength = symbolLengths[symbolIndex];
+            let symbolOffset = symbolOffsets[symbolIndex];
+            while (symbolLength-- > 0) {
+                decodedData[decodedOffset++] = symbols[symbolOffset++];
             }
         }
     }
-    return new Uint8Array(decodedData);
+
+    return decodedData;
+}
+
+const CHECKPOINT_INTERVAL = 1 << 14;
+// Sparse reads avoid expanding the dictionary. Dense consumers switch to the
+// two-pass sequential decoder once sparse scans have examined the compressed
+// input twice, making the decision proportional to the dictionary size.
+const FULL_DECODE_SCAN_MULTIPLIER = 2;
+
+export class FsstDecoder {
+    private readonly symbolOffsets: Uint32Array;
+    private readonly compressedCheckpoints: number[] = [0];
+    private readonly decodedCheckpoints: number[] = [0];
+    private indexedCompressedOffset = 0;
+    private indexedDecodedOffset = 0;
+    private nextCheckpoint = CHECKPOINT_INTERVAL;
+    private sparseBytesScanned = 0;
+    private decodedData?: Uint8Array;
+
+    constructor(
+        private readonly symbols: Uint8Array,
+        private readonly symbolLengths: Uint32Array,
+        private readonly compressedData: Uint8Array,
+    ) {
+        this.symbolOffsets = new Uint32Array(symbolLengths.length);
+        for (let i = 1; i < symbolLengths.length; i++) {
+            this.symbolOffsets[i] = this.symbolOffsets[i - 1] + symbolLengths[i - 1];
+        }
+    }
+
+    decodeRange(start: number, end: number): Uint8Array {
+        if (this.decodedData) return this.decodedData.subarray(start, end);
+        if (this.sparseBytesScanned >= this.compressedData.length * FULL_DECODE_SCAN_MULTIPLIER) {
+            return this.decode().subarray(start, end);
+        }
+        this.sparseBytesScanned += this.indexThrough(start);
+
+        let low = 0;
+        let high = this.decodedCheckpoints.length;
+        while (low + 1 < high) {
+            const middle = (low + high) >> 1;
+            if (this.decodedCheckpoints[middle] <= start) low = middle;
+            else high = middle;
+        }
+
+        const decodedData = new Uint8Array(end - start);
+        let compressedOffset = this.compressedCheckpoints[low];
+        const rangeStart = compressedOffset;
+        let decodedOffset = this.decodedCheckpoints[low];
+        let outputOffset = 0;
+        while (compressedOffset < this.compressedData.length && decodedOffset < end) {
+            const symbolIndex = this.compressedData[compressedOffset++];
+            if (symbolIndex === 255) {
+                const value = this.compressedData[compressedOffset++];
+                if (decodedOffset >= start) decodedData[outputOffset++] = value;
+                decodedOffset++;
+            } else {
+                const symbolLength = this.symbolLengths[symbolIndex];
+                const symbolOffset = this.symbolOffsets[symbolIndex];
+                const copyStart = Math.max(start - decodedOffset, 0);
+                const copyEnd = Math.min(end - decodedOffset, symbolLength);
+                for (let i = copyStart; i < copyEnd; i++) {
+                    decodedData[outputOffset++] = this.symbols[symbolOffset + i];
+                }
+                decodedOffset += symbolLength;
+            }
+        }
+        this.sparseBytesScanned += compressedOffset - rangeStart;
+
+        return outputOffset === decodedData.length ? decodedData : decodedData.subarray(0, outputOffset);
+    }
+
+    decode(): Uint8Array {
+        return (this.decodedData ??= decodeFsst(this.symbols, this.symbolLengths, this.compressedData));
+    }
+
+    private indexThrough(targetDecodedOffset: number): number {
+        const initialCompressedOffset = this.indexedCompressedOffset;
+        let compressedOffset = this.indexedCompressedOffset;
+        let decodedOffset = this.indexedDecodedOffset;
+        let nextCheckpoint = this.nextCheckpoint;
+        const compressedData = this.compressedData;
+        const symbolLengths = this.symbolLengths;
+        const compressedCheckpoints = this.compressedCheckpoints;
+        const decodedCheckpoints = this.decodedCheckpoints;
+
+        while (compressedOffset < compressedData.length && decodedOffset < targetDecodedOffset) {
+            const symbolIndex = compressedData[compressedOffset++];
+            if (symbolIndex === 255) {
+                decodedOffset++;
+                compressedOffset++;
+            } else {
+                decodedOffset += symbolLengths[symbolIndex];
+            }
+
+            if (decodedOffset >= nextCheckpoint) {
+                compressedCheckpoints.push(compressedOffset);
+                decodedCheckpoints.push(decodedOffset);
+                nextCheckpoint = decodedOffset + CHECKPOINT_INTERVAL;
+            }
+        }
+
+        this.indexedCompressedOffset = compressedOffset;
+        this.indexedDecodedOffset = decodedOffset;
+        this.nextCheckpoint = nextCheckpoint;
+        return compressedOffset - initialCompressedOffset;
+    }
 }

--- a/ts/src/mltDecoder.spec.ts
+++ b/ts/src/mltDecoder.spec.ts
@@ -94,6 +94,7 @@ function comparePlainGeometryEncodedTile(mlt: FeatureTable[], mvt: VectorTile) {
 
         // Use getFeatures() instead of iterator (like C++ and Java implementations)
         const mltFeatures = featureTable.getFeatures();
+        const mltGeometries = featureTable.geometryVector.getGeometries();
 
         assert.equal(mltFeatures.length, layer.length);
 
@@ -103,9 +104,10 @@ function comparePlainGeometryEncodedTile(mlt: FeatureTable[], mvt: VectorTile) {
 
             compareId(mltFeature, mvtFeature, true);
 
-            const mltGeometry = mltFeature.geometry?.coordinates;
+            const mltGeometry = featureTable.geometryVector.getGeometry(j);
             const mvtGeometry = mvtFeature.loadGeometry();
             assert.deepEqual(mltGeometry, mvtGeometry);
+            assert.deepEqual(mltGeometries[j], mvtGeometry);
 
             const mltProperties = mltFeature.properties;
             const mvtProperties = mvtFeature.properties;

--- a/ts/src/vector/fsst-dictionary/stringFsstDictionaryVector.spec.ts
+++ b/ts/src/vector/fsst-dictionary/stringFsstDictionaryVector.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import BitVector from "../flat/bitVector";
 import { StringFsstDictionaryVector } from "./stringFsstDictionaryVector";
+import { createSymbolTable, encodeFsst } from "../../encoding/fsstEncoder";
 
 describe("StringFsstDictionaryVector", () => {
     let indexBuffer: Uint32Array;
@@ -34,5 +35,62 @@ describe("StringFsstDictionaryVector", () => {
             nullabilityBuffer,
         );
         expect(vector).toBeInstanceOf(StringFsstDictionaryVector);
+    });
+
+    it("shares decoders only when all FSST buffers match and caches values sparsely", () => {
+        const original = new TextEncoder().encode("alphabeta");
+        const { symbols, symbolLengths } = createSymbolTable(["alpha", "beta"]);
+        const compressed = encodeFsst(symbols, symbolLengths, original);
+        const symbolOffsets = new Uint32Array(symbolLengths.length + 1);
+        for (let i = 0; i < symbolLengths.length; i++) symbolOffsets[i + 1] = symbolOffsets[i] + symbolLengths[i];
+        const offsets = new Uint32Array([0, 5, 9]);
+        const indices = new Uint32Array([0, 1]);
+        const presence = new BitVector(new Uint8Array([0b00000011]), 2);
+        const createVector = (fsstOffsets: Uint32Array) =>
+            new StringFsstDictionaryVector("test", indices, offsets, compressed, fsstOffsets, symbols, presence);
+
+        const first = createVector(symbolOffsets);
+        const second = createVector(symbolOffsets);
+        const equivalentOffsets = new Uint32Array(symbolOffsets);
+        const third = createVector(equivalentOffsets);
+        const internals = (vector: StringFsstDictionaryVector) =>
+            vector as unknown as {
+                decodedValues?: Map<number, string> | Array<string | undefined>;
+                dictionaryDecoder: object;
+                symbolLengthBuffer?: Uint32Array;
+            };
+
+        expect(internals(first).decodedValues).toBeUndefined();
+        expect(first.getValue(0)).toBe("alpha");
+        expect(second.getValue(1)).toBe("beta");
+        expect(third.getValue(0)).toBe("alpha");
+        expect(internals(first).decodedValues).toBeInstanceOf(Map);
+        expect(internals(first).dictionaryDecoder).toBe(internals(second).dictionaryDecoder);
+        expect(internals(third).dictionaryDecoder).not.toBe(internals(first).dictionaryDecoder);
+        expect(internals(first).symbolLengthBuffer).toBeInstanceOf(Uint32Array);
+        expect(internals(second).symbolLengthBuffer).toBeUndefined();
+    });
+
+    it("promotes the value cache when access becomes dense", () => {
+        const values = Array.from({ length: 256 }, (_, index) => `value-${index.toString().padStart(3, "0")}`);
+        const original = new TextEncoder().encode(values.join(""));
+        const { symbols, symbolLengths } = createSymbolTable(["value-"]);
+        const compressed = encodeFsst(symbols, symbolLengths, original);
+        const symbolOffsets = new Uint32Array(symbolLengths.length + 1);
+        for (let i = 0; i < symbolLengths.length; i++) symbolOffsets[i + 1] = symbolOffsets[i] + symbolLengths[i];
+        const offsets = new Uint32Array(values.length + 1);
+        for (let i = 0; i < values.length; i++) offsets[i + 1] = offsets[i] + values[i].length;
+        const vector = new StringFsstDictionaryVector(
+            "test",
+            new Uint32Array(values.map((_, index) => index)),
+            offsets,
+            compressed,
+            symbolOffsets,
+            symbols,
+            new BitVector(new Uint8Array(values.length / 8).fill(0xff), values.length),
+        );
+
+        expect(values.map((_, index) => vector.getValue(index))).toEqual(values);
+        expect((vector as unknown as { decodedValues: unknown }).decodedValues).toBeInstanceOf(Array);
     });
 });

--- a/ts/src/vector/fsst-dictionary/stringFsstDictionaryVector.ts
+++ b/ts/src/vector/fsst-dictionary/stringFsstDictionaryVector.ts
@@ -1,12 +1,18 @@
 import { VariableSizeVector } from "../variableSizeVector";
 import type BitVector from "../flat/bitVector";
-import { decodeFsst } from "../../decoding/fsstDecoder";
+import { FsstDecoder } from "../../decoding/fsstDecoder";
 import { decodeString } from "../../decoding/decodingUtils";
+
+const dictionaryDecoders = new WeakMap<Uint8Array, WeakMap<Uint8Array, WeakMap<Uint32Array, FsstDecoder>>>();
+const MIN_DENSE_VALUE_CACHE_SIZE = 256;
+const DENSE_VALUE_CACHE_RATIO = 4;
+type DecodedValueCache = Map<number, string> | Array<string | undefined>;
 
 export class StringFsstDictionaryVector extends VariableSizeVector<Uint8Array, string> {
     // TODO: extend from StringVector
     private symbolLengthBuffer: Uint32Array;
-    private decodedDictionary: Uint8Array;
+    private dictionaryDecoder: FsstDecoder;
+    private decodedValues?: DecodedValueCache;
 
     constructor(
         name: string,
@@ -21,19 +27,64 @@ export class StringFsstDictionaryVector extends VariableSizeVector<Uint8Array, s
     }
 
     protected getValueFromBuffer(index: number): string {
-        if (this.decodedDictionary == null) {
-            if (this.symbolLengthBuffer == null) {
+        if (this.dictionaryDecoder == null) {
+            const decodersForData = dictionaryDecoders.get(this.dataBuffer);
+            const decodersForSymbols = decodersForData?.get(this.symbolTableBuffer);
+            const cachedDecoder = decodersForSymbols?.get(this.symbolOffsetBuffer);
+            if (cachedDecoder) {
+                this.dictionaryDecoder = cachedDecoder;
+            } else {
                 // TODO: change FsstEncoder to take offsets instead of length to get rid of this conversion
                 this.symbolLengthBuffer = this.offsetToLengthBuffer(this.symbolOffsetBuffer);
+                this.dictionaryDecoder = new FsstDecoder(
+                    this.symbolTableBuffer,
+                    this.symbolLengthBuffer,
+                    this.dataBuffer,
+                );
+                const symbolDecoders = decodersForSymbols ?? new WeakMap<Uint32Array, FsstDecoder>();
+                symbolDecoders.set(this.symbolOffsetBuffer, this.dictionaryDecoder);
+                if (!decodersForSymbols) {
+                    const dataDecoders =
+                        decodersForData ?? new WeakMap<Uint8Array, WeakMap<Uint32Array, FsstDecoder>>();
+                    dataDecoders.set(this.symbolTableBuffer, symbolDecoders);
+                    if (!decodersForData) dictionaryDecoders.set(this.dataBuffer, dataDecoders);
+                }
             }
-
-            this.decodedDictionary = decodeFsst(this.symbolTableBuffer, this.symbolLengthBuffer, this.dataBuffer);
         }
 
         const offset = this.indexBuffer[index];
+        const cached =
+            this.decodedValues instanceof Map ? this.decodedValues.get(offset) : this.decodedValues?.[offset];
+        if (cached !== undefined) return cached;
         const start = this.offsetBuffer[offset];
         const end = this.offsetBuffer[offset + 1];
-        return decodeString(this.decodedDictionary, start, end);
+        const decodedString = this.dictionaryDecoder.decodeRange(start, end);
+        const value = decodeString(decodedString, 0, decodedString.length);
+        this.cacheDecodedValue(offset, value);
+        return value;
+    }
+
+    private cacheDecodedValue(index: number, value: string): void {
+        let decodedValues = this.decodedValues;
+        if (Array.isArray(decodedValues)) {
+            decodedValues[index] = value;
+            return;
+        }
+
+        if (!decodedValues) {
+            decodedValues = new Map<number, string>();
+            this.decodedValues = decodedValues;
+        }
+        decodedValues.set(index, value);
+        const denseCacheThreshold = Math.max(
+            MIN_DENSE_VALUE_CACHE_SIZE,
+            Math.ceil((this.offsetBuffer.length - 1) / DENSE_VALUE_CACHE_RATIO),
+        );
+        if (decodedValues.size >= denseCacheThreshold) {
+            const denseValues = new Array<string | undefined>(this.offsetBuffer.length - 1);
+            for (const [cachedIndex, cachedValue] of decodedValues) denseValues[cachedIndex] = cachedValue;
+            this.decodedValues = denseValues;
+        }
     }
 
     // TODO: get rid of that conversion

--- a/ts/src/vector/geometry/geometryVector.ts
+++ b/ts/src/vector/geometry/geometryVector.ts
@@ -4,6 +4,7 @@ import type Point from "@mapbox/point-geometry";
 import type { GEOMETRY_TYPE } from "./geometryType";
 import type { VertexBufferType } from "./vertexBufferType";
 import type { TopologyVector } from "../../vector/geometry/topologyVector";
+import { PerFeatureGeometryReader } from "./perFeatureGeometryReader";
 
 export type CoordinatesArray = Array<Array<Point>>;
 
@@ -18,6 +19,8 @@ export interface MortonSettings {
 }
 
 export abstract class GeometryVector {
+    private geometryReader?: PerFeatureGeometryReader;
+
     protected constructor(
         private readonly _vertexBufferType: VertexBufferType,
         private readonly _topologyVector: TopologyVector,
@@ -45,7 +48,7 @@ export abstract class GeometryVector {
     /* Allows faster access to the vertices since morton encoding is currently not used in the POC. Morton encoding
        will be used after adapting the shader to decode the morton codes on the GPU. */
     getSimpleEncodedVertex(index: number): [number, number] {
-        const offset = this.vertexOffsets ? this.vertexOffsets[index] * 2 : index * 2;
+        const offset = this.vertexOffsets?.length ? this.vertexOffsets[index] * 2 : index * 2;
         const x = this.vertexBuffer[offset];
         const y = this.vertexBuffer[offset + 1];
         return [x, y];
@@ -53,7 +56,7 @@ export abstract class GeometryVector {
 
     //TODO: add scaling information to the constructor
     getVertex(index: number): [number, number] {
-        if (this.vertexOffsets && this.mortonSettings) {
+        if (this.vertexOffsets?.length && this.mortonSettings) {
             //TODO: move decoding of the morton codes on the GPU in the vertex shader
             const vertexOffset = this.vertexOffsets[index];
             const mortonEncodedVertex = this.vertexBuffer[vertexOffset];
@@ -66,7 +69,7 @@ export abstract class GeometryVector {
             return [vertex.x, vertex.y];
         }
 
-        const offset = this.vertexOffsets ? this.vertexOffsets[index] * 2 : index * 2;
+        const offset = this.vertexOffsets?.length ? this.vertexOffsets[index] * 2 : index * 2;
         const x = this.vertexBuffer[offset];
         const y = this.vertexBuffer[offset + 1];
         return [x, y];
@@ -74,6 +77,17 @@ export abstract class GeometryVector {
 
     getGeometries(): CoordinatesArray[] {
         return convertGeometryVector(this);
+    }
+
+    getGeometry(index: number): CoordinatesArray {
+        this.geometryReader ??= new PerFeatureGeometryReader({
+            numGeometries: this.numGeometries,
+            topologyVector: this.topologyVector,
+            containsPolygonGeometry: this.containsPolygonGeometry(),
+            geometryType: (geometryIndex) => this.geometryType(geometryIndex),
+            getVertex: (vertexIndex) => this.getVertex(vertexIndex),
+        });
+        return this.geometryReader.getGeometry(index);
     }
 
     get mortonSettings(): MortonSettings | undefined {

--- a/ts/src/vector/geometry/gpuVector.ts
+++ b/ts/src/vector/geometry/gpuVector.ts
@@ -1,9 +1,12 @@
 import Point from "@mapbox/point-geometry";
-import { GEOMETRY_TYPE } from "./geometryType";
 import type { CoordinatesArray } from "./geometryVector";
+import { GEOMETRY_TYPE } from "./geometryType";
 import type { TopologyVector } from "./topologyVector";
+import { PerFeatureGeometryReader } from "./perFeatureGeometryReader";
 
 export abstract class GpuVector implements Iterable<CoordinatesArray> {
+    private geometryReader?: PerFeatureGeometryReader;
+
     protected constructor(
         private readonly _triangleOffsets: Uint32Array,
         private readonly _indexBuffer: Uint32Array,
@@ -33,97 +36,70 @@ export abstract class GpuVector implements Iterable<CoordinatesArray> {
         return this._topologyVector;
     }
 
+    getGeometry(index: number): CoordinatesArray {
+        if (!this.topologyVector) {
+            throw new Error("Cannot access GpuVector geometry without topology information");
+        }
+        this.geometryReader ??= new PerFeatureGeometryReader({
+            numGeometries: this.numGeometries,
+            topologyVector: this.topologyVector,
+            containsPolygonGeometry: true,
+            geometryType: (geometryIndex) => this.geometryType(geometryIndex),
+            getVertex: (vertexIndex) => {
+                const offset = vertexIndex * 2;
+                return [this.vertexBuffer[offset], this.vertexBuffer[offset + 1]];
+            },
+        });
+        return this.geometryReader.getGeometry(index);
+    }
+
     /**
      * Returns geometries as coordinate arrays by extracting polygon outlines from topology.
      * The vertexBuffer contains the outline vertices, separate from the tessellated triangles.
      */
     getGeometries(): CoordinatesArray[] {
-        if (!this._topologyVector) {
+        if (!this.topologyVector) {
             throw new Error("Cannot convert GpuVector to coordinates without topology information");
         }
 
-        const geometries: CoordinatesArray[] = new Array(this.numGeometries);
-        const topology = this._topologyVector;
-        const partOffsets = topology.partOffsets;
-        const ringOffsets = topology.ringOffsets;
-        const geometryOffsets = topology.geometryOffsets;
+        const { geometryOffsets, partOffsets, ringOffsets } = this.topologyVector;
+        const geometries = new Array<CoordinatesArray>(this.numGeometries);
+        let vertex = 0;
+        let geometry = 1;
+        let part = 1;
+        let ring = 1;
 
-        // Use counters to track position in offset arrays (like Java implementation)
-        let vertexBufferOffset = 0;
-        let partOffsetCounter = 1;
-        let ringOffsetsCounter = 1;
-        let geometryOffsetsCounter = 1;
+        const readRing = (): Point[] => {
+            const count = gpuOffsetLength(ringOffsets, ring++);
+            const points = new Array<Point>(count + (count > 0 ? 1 : 0));
+            for (let i = 0; i < count; i++) {
+                points[i] = new Point(this.vertexBuffer[vertex++], this.vertexBuffer[vertex++]);
+            }
+            if (count > 0) points[count] = points[0];
+            return points;
+        };
 
         for (let i = 0; i < this.numGeometries; i++) {
-            const geometryType = this.geometryType(i);
-
-            switch (geometryType) {
-                case GEOMETRY_TYPE.POLYGON:
-                    {
-                        // Get number of rings for this polygon
-                        const numRings = partOffsets[partOffsetCounter] - partOffsets[partOffsetCounter - 1];
-                        partOffsetCounter++;
-                        const rings: Point[][] = [];
-
-                        for (let j = 0; j < numRings; j++) {
-                            // Get number of vertices in this ring
-                            const numVertices = ringOffsets[ringOffsetsCounter] - ringOffsets[ringOffsetsCounter - 1];
-                            ringOffsetsCounter++;
-                            const ring: Point[] = [];
-
-                            for (let k = 0; k < numVertices; k++) {
-                                const x = this._vertexBuffer[vertexBufferOffset++];
-                                const y = this._vertexBuffer[vertexBufferOffset++];
-                                ring.push(new Point(x, y));
-                            }
-                            // Close the ring by duplicating the first vertex (MVT format requirement)
-                            if (ring.length > 0) {
-                                ring.push(ring[0]);
-                            }
-                            rings.push(ring);
-                        }
-
-                        geometries[i] = rings;
-                        if (geometryOffsets) geometryOffsetsCounter++;
+            const result: CoordinatesArray = [];
+            switch (this.geometryType(i)) {
+                case GEOMETRY_TYPE.POLYGON: {
+                    const ringCount = gpuOffsetLength(partOffsets, part++);
+                    for (let j = 0; j < ringCount; j++) result.push(readRing());
+                    if (geometryOffsets) geometry++;
+                    break;
+                }
+                case GEOMETRY_TYPE.MULTIPOLYGON: {
+                    const polygonCount = gpuOffsetLength(geometryOffsets, geometry++);
+                    for (let j = 0; j < polygonCount; j++) {
+                        const ringCount = gpuOffsetLength(partOffsets, part++);
+                        for (let k = 0; k < ringCount; k++) result.push(readRing());
                     }
                     break;
-                case GEOMETRY_TYPE.MULTIPOLYGON:
-                    {
-                        // Get number of polygons in this multipolygon
-                        const numPolygons =
-                            geometryOffsets[geometryOffsetsCounter] - geometryOffsets[geometryOffsetsCounter - 1];
-                        geometryOffsetsCounter++;
-                        const allRings: Point[][] = [];
-
-                        for (let p = 0; p < numPolygons; p++) {
-                            // Get number of rings in this polygon
-                            const numRings = partOffsets[partOffsetCounter] - partOffsets[partOffsetCounter - 1];
-                            partOffsetCounter++;
-
-                            for (let j = 0; j < numRings; j++) {
-                                // Get number of vertices in this ring
-                                const numVertices =
-                                    ringOffsets[ringOffsetsCounter] - ringOffsets[ringOffsetsCounter - 1];
-                                ringOffsetsCounter++;
-                                const ring: Point[] = [];
-
-                                for (let k = 0; k < numVertices; k++) {
-                                    const x = this._vertexBuffer[vertexBufferOffset++];
-                                    const y = this._vertexBuffer[vertexBufferOffset++];
-                                    ring.push(new Point(x, y));
-                                }
-                                // Close the ring by duplicating the first vertex (MVT format requirement)
-                                if (ring.length > 0) {
-                                    ring.push(ring[0]);
-                                }
-                                allRings.push(ring);
-                            }
-                        }
-
-                        geometries[i] = allRings;
-                    }
-                    break;
+                }
+                default:
+                    throw new Error(`GPU geometry type ${this.geometryType(i)} is not supported`);
             }
+            geometries[i] = result;
         }
         return geometries;
     }
@@ -142,4 +118,9 @@ export abstract class GpuVector implements Iterable<CoordinatesArray> {
         //throw new Error("Iterator on a GpuVector is not implemented yet.");
         return null;
     }
+}
+
+function gpuOffsetLength(offsets: Uint32Array | undefined, index: number): number {
+    if (!offsets) throw new Error("Invalid GPU geometry topology");
+    return offsets[index] - offsets[index - 1];
 }

--- a/ts/src/vector/geometry/perFeatureGeometryReader.spec.ts
+++ b/ts/src/vector/geometry/perFeatureGeometryReader.spec.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import {
+    encodeLineStringGeometryVector,
+    encodeLineStringGeometryVectorWithMortonEncoding,
+    encodeMultiLineStringGeometryVector,
+    encodeMultiLineStringGeometryVectorWithMortonOffsets,
+    encodeMultiLineStringGeometryVectorWithOffsets,
+    encodeMultiPointGeometryVector,
+    encodeMultiPolygonGeometryVector,
+    encodeMultiPolygonGeometryVectorWithMortonOffsets,
+    encodeMultiPolygonGeometryVectorWithOffsets,
+    encodePointGeometryVector,
+    encodePointGeometryVectorWithMortonEncoding,
+    encodePointGeometryVectorWithOffset,
+    encodePointsGeometryVector,
+    encodePolygonGeometryVector,
+    encodePolygonGeometryVectorWithMortonOffsets,
+    encodePolygonGeometryVectorWithOffsets,
+} from "../../encoding/constGeometryVectorEncoder";
+import { GEOMETRY_TYPE } from "./geometryType";
+import { ConstGpuVector } from "./constGpuVector";
+import { ConstGeometryVector } from "./constGeometryVector";
+import type { GeometryVector } from "./geometryVector";
+import { convertGeometryVector } from "./geometryVectorConverter";
+import { VertexBufferType } from "./vertexBufferType";
+
+const line: [number, number][] = [
+    [1, 2],
+    [3, 4],
+    [5, 6],
+];
+const polygon: [number, number][][] = [
+    [
+        [0, 0],
+        [10, 0],
+        [10, 10],
+    ],
+    [
+        [2, 2],
+        [3, 2],
+        [3, 3],
+    ],
+];
+const multiLine: [number, number][][] = [
+    line,
+    [
+        [7, 8],
+        [9, 10],
+    ],
+];
+const multiPolygon: [number, number][][][] = [
+    polygon,
+    [
+        [
+            [20, 20],
+            [30, 20],
+            [30, 30],
+        ],
+    ],
+];
+
+describe("GeometryVector.getGeometry", () => {
+    const vectors: Array<[string, () => GeometryVector]> = [
+        ["point", () => encodePointGeometryVector(1, 2)],
+        ["dictionary point", () => encodePointGeometryVectorWithOffset(1, 2)],
+        ["Morton point", () => encodePointGeometryVectorWithMortonEncoding(1, 2)],
+        ["multipoint", () => encodeMultiPointGeometryVector(line)],
+        ["line", () => encodeLineStringGeometryVector(line)],
+        ["Morton line", () => encodeLineStringGeometryVectorWithMortonEncoding(line)],
+        ["polygon", () => encodePolygonGeometryVector(polygon)],
+        ["dictionary polygon", () => encodePolygonGeometryVectorWithOffsets(polygon)],
+        ["Morton polygon", () => encodePolygonGeometryVectorWithMortonOffsets(polygon)],
+        ["multiline", () => encodeMultiLineStringGeometryVector(multiLine)],
+        ["dictionary multiline", () => encodeMultiLineStringGeometryVectorWithOffsets(multiLine)],
+        ["Morton multiline", () => encodeMultiLineStringGeometryVectorWithMortonOffsets(multiLine)],
+        ["multipolygon", () => encodeMultiPolygonGeometryVector(multiPolygon)],
+        ["dictionary multipolygon", () => encodeMultiPolygonGeometryVectorWithOffsets(multiPolygon)],
+        ["Morton multipolygon", () => encodeMultiPolygonGeometryVectorWithMortonOffsets(multiPolygon)],
+    ];
+
+    it.each(vectors)("matches whole-vector conversion for %s", (_name, createVector) => {
+        const vector = createVector();
+        const expected = convertGeometryVector(vector);
+        for (let i = vector.numGeometries - 1; i >= 0; i--) {
+            expect(vector.getGeometry(i)).toEqual(expected[i]);
+        }
+    });
+
+    it("supports random access to vectors containing multiple geometries", () => {
+        const vector = encodePointsGeometryVector([1, 2, 3, 4, 5, 6]);
+        const expected = convertGeometryVector(vector);
+        expect(vector.getGeometry(2)).toEqual(expected[2]);
+        expect(vector.getGeometry(0)).toEqual(expected[0]);
+        expect(vector.getGeometry(1)).toEqual(expected[1]);
+    });
+
+    it("returns independently mutable coordinates", () => {
+        const vector = encodePolygonGeometryVector(polygon);
+        const first = vector.getGeometry(0);
+        first[0][0].x = 999;
+        first[0].push(first[0][0]);
+        expect(vector.getGeometry(0)).toEqual(convertGeometryVector(vector)[0]);
+    });
+
+    it("rejects invalid indexes", () => {
+        const vector = encodePointGeometryVector(1, 2);
+        expect(() => vector.getGeometry(-1)).toThrow(RangeError);
+        expect(() => vector.getGeometry(1)).toThrow(RangeError);
+        expect(() => vector.getGeometry(0.5)).toThrow(RangeError);
+    });
+
+    it("treats an empty vertex-offset vector as sequential encoding", () => {
+        const vector = new ConstGeometryVector(
+            1,
+            GEOMETRY_TYPE.LINESTRING,
+            VertexBufferType.VEC_2,
+            { partOffsets: new Uint32Array([0, 2]) },
+            new Uint32Array(),
+            new Int32Array([1, 2, 3, 4]),
+        );
+        expect(vector.getGeometry(0)).toEqual(convertGeometryVector(vector)[0]);
+    });
+});
+
+describe("GpuVector.getGeometry", () => {
+    it("supports polygon random access", () => {
+        const vector = new ConstGpuVector(
+            2,
+            GEOMETRY_TYPE.POLYGON,
+            new Uint32Array(),
+            new Uint32Array(),
+            new Int32Array([0, 0, 10, 0, 10, 10, 20, 20, 30, 20, 30, 30]),
+            {
+                partOffsets: new Uint32Array([0, 1, 2]),
+                ringOffsets: new Uint32Array([0, 3, 6]),
+            },
+        );
+
+        expect(vector.getGeometry(1)).toEqual(vector.getGeometries()[1]);
+        expect(vector.getGeometry(0)).toEqual(vector.getGeometries()[0]);
+    });
+
+    it("requires topology information", () => {
+        const vector = new ConstGpuVector(
+            1,
+            GEOMETRY_TYPE.POLYGON,
+            new Uint32Array(),
+            new Uint32Array(),
+            new Int32Array(),
+        );
+        expect(() => vector.getGeometry(0)).toThrow("without topology information");
+    });
+});

--- a/ts/src/vector/geometry/perFeatureGeometryReader.ts
+++ b/ts/src/vector/geometry/perFeatureGeometryReader.ts
@@ -1,0 +1,180 @@
+import Point from "@mapbox/point-geometry";
+import { GEOMETRY_TYPE } from "./geometryType";
+import type { CoordinatesArray } from "./geometryVector";
+import type { TopologyVector } from "./topologyVector";
+
+export type RandomAccessGeometryVector = {
+    readonly numGeometries: number;
+    readonly topologyVector: TopologyVector;
+    readonly containsPolygonGeometry: boolean;
+    geometryType(index: number): number;
+    getVertex(index: number): [number, number];
+};
+
+type GeometryCursor = {
+    vertex: number;
+    geometry: number;
+    part: number;
+    ring: number;
+};
+
+const CHECKPOINT_INTERVAL = 64;
+
+export class PerFeatureGeometryReader {
+    private readonly checkpoints: GeometryCursor[] = [{ vertex: 0, geometry: 1, part: 1, ring: 1 }];
+    private sequentialCursor?: { index: number; cursor: GeometryCursor };
+
+    constructor(private readonly geometryVector: RandomAccessGeometryVector) {}
+
+    private advanceCursor(cursor: GeometryCursor, index: number): GeometryCursor {
+        const { geometryOffsets, partOffsets, ringOffsets } = this.geometryVector.topologyVector;
+        const next = cursor;
+
+        switch (this.geometryVector.geometryType(index)) {
+            case GEOMETRY_TYPE.POINT:
+                next.vertex++;
+                if (geometryOffsets) next.geometry++;
+                if (partOffsets) next.part++;
+                if (ringOffsets) next.ring++;
+                break;
+            case GEOMETRY_TYPE.MULTIPOINT: {
+                const count = offsetLength(geometryOffsets, next.geometry++);
+                next.vertex += count;
+                next.part += count;
+                next.ring += count;
+                break;
+            }
+            case GEOMETRY_TYPE.LINESTRING:
+                next.vertex += this.geometryVector.containsPolygonGeometry
+                    ? offsetLength(ringOffsets, next.ring++)
+                    : offsetLength(partOffsets, next.part);
+                next.part++;
+                if (geometryOffsets) next.geometry++;
+                break;
+            case GEOMETRY_TYPE.POLYGON: {
+                const ringCount = offsetLength(partOffsets, next.part++);
+                for (let j = 0; j < ringCount; j++) next.vertex += offsetLength(ringOffsets, next.ring++);
+                if (geometryOffsets) next.geometry++;
+                break;
+            }
+            case GEOMETRY_TYPE.MULTILINESTRING: {
+                const partCount = offsetLength(geometryOffsets, next.geometry++);
+                for (let j = 0; j < partCount; j++) {
+                    next.vertex += this.geometryVector.containsPolygonGeometry
+                        ? offsetLength(ringOffsets, next.ring++)
+                        : offsetLength(partOffsets, next.part);
+                    next.part++;
+                }
+                break;
+            }
+            case GEOMETRY_TYPE.MULTIPOLYGON: {
+                const polygonCount = offsetLength(geometryOffsets, next.geometry++);
+                for (let j = 0; j < polygonCount; j++) {
+                    const ringCount = offsetLength(partOffsets, next.part++);
+                    for (let k = 0; k < ringCount; k++) next.vertex += offsetLength(ringOffsets, next.ring++);
+                }
+                break;
+            }
+            default:
+                throw new Error(
+                    `The specified geometry type (${this.geometryVector.geometryType(index)}) is currently not supported.`,
+                );
+        }
+        return next;
+    }
+
+    private getCursor(index: number): GeometryCursor {
+        if (this.sequentialCursor?.index === index) return { ...this.sequentialCursor.cursor };
+
+        const checkpointIndex = Math.floor(index / CHECKPOINT_INTERVAL);
+        while (this.checkpoints.length <= checkpointIndex) {
+            let cursor = { ...this.checkpoints[this.checkpoints.length - 1] };
+            const start = (this.checkpoints.length - 1) * CHECKPOINT_INTERVAL;
+            const end = Math.min(start + CHECKPOINT_INTERVAL, this.geometryVector.numGeometries);
+            for (let i = start; i < end; i++) cursor = this.advanceCursor(cursor, i);
+            this.checkpoints.push(cursor);
+        }
+
+        let cursor = { ...this.checkpoints[checkpointIndex] };
+        for (let i = checkpointIndex * CHECKPOINT_INTERVAL; i < index; i++) {
+            cursor = this.advanceCursor(cursor, i);
+        }
+        return cursor;
+    }
+
+    getGeometry(index: number): CoordinatesArray {
+        if (!Number.isInteger(index) || index < 0 || index >= this.geometryVector.numGeometries) {
+            throw new RangeError(`Geometry index ${index} is out of bounds`);
+        }
+
+        const geometryType = this.geometryVector.geometryType(index);
+        const { geometryOffsets, partOffsets, ringOffsets } = this.geometryVector.topologyVector;
+        const cursor = this.getCursor(index);
+        let { vertex, part, ring } = cursor;
+        const { geometry } = cursor;
+        const result: CoordinatesArray = [];
+
+        const addVertices = (count: number, closeRing: boolean) => {
+            const points = new Array<Point>(count + (closeRing ? 1 : 0));
+            for (let i = 0; i < count; i++) {
+                const [x, y] = this.geometryVector.getVertex(vertex++);
+                points[i] = new Point(x, y);
+            }
+            if (closeRing && count > 0) points[count] = new Point(points[0].x, points[0].y);
+            result.push(points);
+        };
+
+        switch (geometryType) {
+            case GEOMETRY_TYPE.POINT:
+                addVertices(1, false);
+                break;
+            case GEOMETRY_TYPE.MULTIPOINT: {
+                const count = offsetLength(geometryOffsets, geometry);
+                for (let i = 0; i < count; i++) addVertices(1, false);
+                break;
+            }
+            case GEOMETRY_TYPE.LINESTRING:
+                addVertices(
+                    this.geometryVector.containsPolygonGeometry
+                        ? offsetLength(ringOffsets, ring)
+                        : offsetLength(partOffsets, part),
+                    false,
+                );
+                break;
+            case GEOMETRY_TYPE.POLYGON: {
+                const ringCount = offsetLength(partOffsets, part);
+                for (let i = 0; i < ringCount; i++) addVertices(offsetLength(ringOffsets, ring++), true);
+                break;
+            }
+            case GEOMETRY_TYPE.MULTILINESTRING: {
+                const partCount = offsetLength(geometryOffsets, geometry);
+                for (let i = 0; i < partCount; i++) {
+                    const count = this.geometryVector.containsPolygonGeometry
+                        ? offsetLength(ringOffsets, ring++)
+                        : offsetLength(partOffsets, part);
+                    part++;
+                    addVertices(count, false);
+                }
+                break;
+            }
+            case GEOMETRY_TYPE.MULTIPOLYGON: {
+                const polygonCount = offsetLength(geometryOffsets, geometry);
+                for (let i = 0; i < polygonCount; i++) {
+                    const ringCount = offsetLength(partOffsets, part++);
+                    for (let j = 0; j < ringCount; j++) addVertices(offsetLength(ringOffsets, ring++), true);
+                }
+                break;
+            }
+            default:
+                throw new Error(`The specified geometry type (${geometryType}) is currently not supported.`);
+        }
+
+        this.sequentialCursor = { index: index + 1, cursor: this.advanceCursor(cursor, index) };
+        return result;
+    }
+}
+
+function offsetLength(offsets: Uint32Array | undefined, index: number): number {
+    if (!offsets) throw new Error("Invalid MLT geometry topology");
+    return offsets[index] - offsets[index - 1];
+}

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -23,5 +23,6 @@
   "exclude": [
     "node_modules",
     "**/*.spec.ts",
+    "**/*.bench.ts"
   ]
 }


### PR DESCRIPTION
This PR is based on #1499 to avoid conflicts. If #1499 should not land, I can rebase this PR on main.

Add getGeometry(index) to GeometryVector and GpuVector so callers can materialize only requested features. Use lazy sparse topology checkpoints plus a sequential cursor to avoid whole-layer indexing for sparse and ordered access.

Keep optimized sequential implementations for getGeometries(), including a dedicated GPU path, and use the original geometry converter as an independent regression oracle.

Cover every geometry type, dictionary and Morton vertex encoding, GPU polygons, random access, bounds checking, empty offset vectors, and mutation independence. The decoder corpus exercises per-feature access against paired MVT fixtures.

This enables MapLibre GL JS to avoid whole-layer geometry allocation.
This can lead to some huge performance improvements. I'll create a PR in MapLibre GL JS to use that new interface later

Closes #224

## AI assistance
This PR was developed with assistance from OpenAI Codex. The implementation was reviewed, benchmarked, and tested by me.




