### PR TITLE
fix(rust): preserve PMTiles geographic header

### DIFF
--- a/rust/mlt/src/convert/common.rs
+++ b/rust/mlt/src/convert/common.rs
@@ -6,11 +6,42 @@ use indicatif::{ProgressBar, ProgressStyle};
 use martin_tile_utils::Encoding;
 use mlt_core::encoder::EncoderConfig;
 use moka::sync::Cache;
-use pmtiles::TileCoord;
+use pmtiles::{PmTilesWriter, TileCoord};
 use size_format::SizeFormatterSI;
 use xxhash_rust::xxh3::Xxh3Builder;
 
 use super::{encode_one, whole_rate_per_sec};
+
+/// Geographic fields that can be carried into a new `PMTiles` archive.
+///
+/// Optional fields support metadata sources such as `MBTiles`, where individual
+/// values may be absent. Unspecified values retain the writer's defaults.
+#[derive(Debug, Default, PartialEq)]
+pub struct PmTilesGeography {
+    pub min_zoom: Option<u8>,
+    pub max_zoom: Option<u8>,
+    pub bounds: Option<(f64, f64, f64, f64)>,
+    pub center: Option<(f64, f64, u8)>,
+}
+
+impl PmTilesGeography {
+    #[must_use]
+    pub fn apply(self, mut writer: PmTilesWriter) -> PmTilesWriter {
+        if let Some(min_zoom) = self.min_zoom {
+            writer = writer.min_zoom(min_zoom);
+        }
+        if let Some(max_zoom) = self.max_zoom {
+            writer = writer.max_zoom(max_zoom);
+        }
+        if let Some((min_lon, min_lat, max_lon, max_lat)) = self.bounds {
+            writer = writer.bounds(min_lon, min_lat, max_lon, max_lat);
+        }
+        if let Some((longitude, latitude, zoom)) = self.center {
+            writer = writer.center_zoom(zoom).center(longitude, latitude);
+        }
+        writer
+    }
+}
 
 /// Cap on the encoding cache (which encoded `Bytes` to keep around).
 pub const ENCODE_CACHE_BYTES: u64 = 512 * 1024 * 1024;

--- a/rust/mlt/src/convert/from_mbtiles.rs
+++ b/rust/mlt/src/convert/from_mbtiles.rs
@@ -14,10 +14,20 @@ use size_format::SizeFormatterSI;
 use usize_cast::FromUsize as _;
 
 use super::common::{
-    ENCODE_CACHE_BYTES, EncodedTile, MAX_TILE_CACHE_TRACK_SIZE_BYTES, TileStats, encode_tile,
-    make_encode_cache, make_progress_bar,
+    ENCODE_CACHE_BYTES, EncodedTile, MAX_TILE_CACHE_TRACK_SIZE_BYTES, PmTilesGeography, TileStats,
+    encode_tile, make_encode_cache, make_progress_bar,
 };
 use super::{ContainerFormat, MbtFormat, encode_one};
+
+fn geography_from_metadata(metadata: &Metadata) -> PmTilesGeography {
+    let tilejson = &metadata.tilejson;
+    PmTilesGeography {
+        min_zoom: tilejson.minzoom,
+        max_zoom: tilejson.maxzoom,
+        bounds: tilejson.bounds.map(|v| (v.left, v.bottom, v.right, v.top)),
+        center: tilejson.center.map(|v| (v.longitude, v.latitude, v.zoom)),
+    }
+}
 
 /// Re-encode an `.mbtiles` input (MVT) into the requested container.
 pub async fn convert(
@@ -154,13 +164,15 @@ async fn convert_mbtiles_to_pmtiles(
     let start = Instant::now();
     let bar = make_progress_bar(total);
 
+    let geography = geography_from_metadata(&metadata);
     metadata.tilejson.other.insert(
         "format".into(),
         serde_json::Value::String(Format::Mlt.metadata_format_value().into()),
     );
     let file = std::fs::File::create(output)?;
     let metadata_str = serde_json::to_string(&metadata.tilejson)?;
-    let mut stream_writer = PmTilesWriter::new(TileType::Mlt)
+    let mut stream_writer = geography
+        .apply(PmTilesWriter::new(TileType::Mlt))
         .metadata(&metadata_str)
         .create(file)?;
 
@@ -218,4 +230,38 @@ async fn convert_mbtiles_to_pmtiles(
     stats.print_summary(start);
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_pmtiles_geography_from_mbtiles_metadata() {
+        let metadata = Metadata {
+            id: "test".into(),
+            layer_type: None,
+            tilejson: serde_json::from_value(serde_json::json!({
+                "tilejson": "3.0.0",
+                "tiles": [],
+                "minzoom": 3,
+                "maxzoom": 12,
+                "bounds": [-12.345_678_9, -67.890_123_4, 98.765_432_1, 54.321_098_7],
+                "center": [11.223_344_5, -44.556_677_8, 8]
+            }))
+            .expect("parse TileJSON metadata"),
+            json: None,
+            agg_tiles_hash: None,
+        };
+
+        assert_eq!(
+            geography_from_metadata(&metadata),
+            PmTilesGeography {
+                min_zoom: Some(3),
+                max_zoom: Some(12),
+                bounds: Some((-12.345_678_9, -67.890_123_4, 98.765_432_1, 54.321_098_7)),
+                center: Some((11.223_344_5, -44.556_677_8, 8)),
+            }
+        );
+    }
 }

--- a/rust/mlt/src/convert/from_pmtiles.rs
+++ b/rust/mlt/src/convert/from_pmtiles.rs
@@ -10,13 +10,14 @@ use futures::TryStreamExt;
 use martin_tile_utils::{Encoding, Format};
 use mlt_core::encoder::EncoderConfig;
 use pmtiles::{
-    AsyncPmTilesReader, Compression, HashMapCache, MmapBackend, PmTilesWriter, TileCoord, TileId,
-    TileType,
+    AsyncPmTilesReader, Compression, HashMapCache, Header, MmapBackend, PmTilesWriter, TileCoord,
+    TileId, TileType,
 };
 
 use super::ContainerFormat;
 use super::common::{
-    EncodeCache, EncodedTile, TileStats, encode_tile, make_encode_cache, make_progress_bar,
+    EncodeCache, EncodedTile, PmTilesGeography, TileStats, encode_tile, make_encode_cache,
+    make_progress_bar,
 };
 
 /// Re-encode a `.pmtiles` input (MVT) into the requested container.
@@ -62,6 +63,24 @@ fn mlt_pmtiles_metadata(metadata: &str) -> AnyResult<String> {
         );
     }
     Ok(serde_json::to_string(&value)?)
+}
+
+fn geography_from_header(source: &Header) -> PmTilesGeography {
+    PmTilesGeography {
+        min_zoom: Some(source.min_zoom),
+        max_zoom: Some(source.max_zoom),
+        bounds: Some((
+            source.min_longitude,
+            source.min_latitude,
+            source.max_longitude,
+            source.max_latitude,
+        )),
+        center: Some((
+            source.center_longitude,
+            source.center_latitude,
+            source.center_zoom,
+        )),
+    }
 }
 
 /// Open a local `.pmtiles`, require MVT tiles, and report its tile [`Encoding`].
@@ -280,7 +299,8 @@ async fn convert_pmtiles_to_pmtiles(
 
     let metadata_str = mlt_pmtiles_metadata(&reader.get_metadata().await?)?;
     let file = std::fs::File::create(output)?;
-    let mut writer = PmTilesWriter::new(TileType::Mlt)
+    let mut writer = geography_from_header(reader.get_header())
+        .apply(PmTilesWriter::new(TileType::Mlt))
         .metadata(&metadata_str)
         .create(file)?;
 
@@ -312,4 +332,63 @@ async fn convert_pmtiles_to_pmtiles(
     stats.print_summary(start);
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+
+    const HEADER_SIZE: usize = 127;
+
+    fn write_header(writer: PmTilesWriter) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        writer
+            .create(Cursor::new(&mut bytes))
+            .expect("create PMTiles writer")
+            .finalize()
+            .expect("finalize PMTiles writer");
+        bytes
+    }
+
+    fn parse_header(bytes: &[u8]) -> Header {
+        Header::try_from_bytes(Bytes::copy_from_slice(&bytes[..HEADER_SIZE]))
+            .expect("parse PMTiles header")
+    }
+
+    #[test]
+    #[expect(
+        clippy::float_cmp,
+        reason = "header floats round-trip losslessly through the writer"
+    )]
+    fn copies_geographic_header_without_copying_content_encoding() {
+        let source = write_header(
+            PmTilesWriter::new(TileType::Mvt)
+                .min_zoom(3)
+                .max_zoom(12)
+                .bounds(-12.345_678_9, -67.890_123_4, 98.765_432_1, 54.321_098_7)
+                .center_zoom(8)
+                .center(11.223_344_5, -44.556_677_8),
+        );
+        let source = parse_header(&source);
+
+        let output =
+            write_header(geography_from_header(&source).apply(PmTilesWriter::new(TileType::Mlt)));
+        let output = parse_header(&output);
+
+        assert_eq!(output.min_zoom, source.min_zoom);
+        assert_eq!(output.max_zoom, source.max_zoom);
+        assert_eq!(output.min_longitude, source.min_longitude);
+        assert_eq!(output.min_latitude, source.min_latitude);
+        assert_eq!(output.max_longitude, source.max_longitude);
+        assert_eq!(output.max_latitude, source.max_latitude);
+        assert_eq!(output.center_zoom, source.center_zoom);
+        assert_eq!(output.center_longitude, source.center_longitude);
+        assert_eq!(output.center_latitude, source.center_latitude);
+
+        assert_eq!(source.tile_compression, Compression::Gzip);
+        assert_eq!(output.tile_compression, Compression::None);
+        assert_eq!(output.tile_type, TileType::Mlt);
+    }
 }


### PR DESCRIPTION




## What does this change?

Preserve geographic PMTiles header fields when converting MVT tiles to MLT.

For PMTiles inputs, the converter now copies:

- Minimum and maximum zoom
- Bounds
- Center coordinates and zoom

For MBTiles inputs, the converter populates those fields from the corresponding TileJSON metadata when present. Missing MBTiles metadata continues to use the PMTiles writer defaults.

Output-specific and content-derived fields—including tile type, compression, clustering, and tile counts—remain controlled by the output writer. MLT PMTiles output therefore remains uncompressed.

## Why?

The converter previously initialized the output with default PMTiles header values. This could produce an incorrect zoom range, bounds, and center even when the source contained accurate values.

For example, an input with zoom range `0..12` was written with the default output range `0..22`.

### main
```
$ pmtiles show source.pmtiles | grep -e zoom -e center
min zoom: 0
max zoom: 12
center: (long: 2.329102, lat: 48.835789)
center zoom: 12
$ convert source.pmtiles target.pmtiles

$ pmtiles show target.pmtiles | grep -e zoom -e center
min zoom: 0
max zoom: 22
center: (long: 0.000000, lat: 0.000000)
center zoom: 0
```


### with this PR:
```
$ pmtiles show source.pmtiles | grep -e zoom -e center
min zoom: 0
max zoom: 12
center: (long: 2.329102, lat: 48.835789)
center zoom: 12
$ convert source.pmtiles target.pmtiles

$ pmtiles show target.pmtiles | grep -e zoom -e center
min zoom: 0
max zoom: 12
center: (long: 2.329102, lat: 48.835789)
center zoom: 12
```


## AI notice

This change was developed with assistance from OpenAI Codex. The implementation and generated tests were reviewed and validated me
