### PR TITLE
fix(java): Fix handling of geometrycollection and empty geometries

### DIFF
--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/MltConverter.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/MltConverter.java
@@ -622,7 +622,7 @@ public class MltConverter {
         throw new RuntimeException("Missing Metadata");
       }
 
-      final var sourceFeatures = sourceLayer.features();
+      final var sourceFeatures = sourceLayer.features().stream().filter(GeometryEncoder::hasGeometry).toList();
       if (sourceFeatures.isEmpty()) {
         continue;
       }

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/MltConverter.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/MltConverter.java
@@ -622,7 +622,8 @@ public class MltConverter {
         throw new RuntimeException("Missing Metadata");
       }
 
-      final var sourceFeatures = sourceLayer.features().stream().filter(GeometryEncoder::hasGeometry).toList();
+      final var sourceFeatures =
+          sourceLayer.features().stream().filter(GeometryEncoder::hasGeometry).toList();
       if (sourceFeatures.isEmpty()) {
         continue;
       }

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/GeometryEncoder.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/GeometryEncoder.java
@@ -23,6 +23,7 @@ import java.util.stream.StreamSupport;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.LinearRing;
@@ -39,6 +40,7 @@ import org.maplibre.mlt.converter.geometry.SpaceFillingCurve;
 import org.maplibre.mlt.converter.geometry.Vertex;
 import org.maplibre.mlt.converter.geometry.ZOrderCurve;
 import org.maplibre.mlt.converter.tessellation.TessellationUtils;
+import org.maplibre.mlt.data.Feature;
 import org.maplibre.mlt.metadata.stream.DictionaryType;
 import org.maplibre.mlt.metadata.stream.LengthType;
 import org.maplibre.mlt.metadata.stream.LogicalLevelTechnique;
@@ -364,6 +366,21 @@ public class GeometryEncoder {
             vertexBuffer.add(new Vertex((int) point.getX(), (int) point.getY()));
           }
         }
+        case GeometryCollection geometryCollection -> {
+            final var nestedGeometries = IntStream.range(0, geometryCollection.getNumGeometries())
+                            .mapToObj(geometryCollection::getGeometryN)
+                                    .toList();
+            prepareGeometry(
+                nestedGeometries,
+                numGeometries,
+                geometryTypes,
+                vertexBuffer,
+                numParts,
+                numRings,
+                numTriangles,
+                indexBuffer,
+                tessellateSource);
+        }
         default ->
             throw new IllegalArgumentException(
                 "Specified geometry type is not (yet) supported: " + geometry.getGeometryType());
@@ -633,5 +650,24 @@ public class GeometryEncoder {
 
     result.add(encodedValues);
     return result;
+  }
+
+  public static boolean hasGeometry(@Nullable Feature feature) {
+    return (feature != null) && hasGeometry(feature.getGeometry());
+  }
+  public static boolean hasGeometry(@Nullable Geometry geometry) {
+    return switch (geometry) {
+      case Point ignored -> true;
+      case LineString lineString -> !lineString.isEmpty();
+      case Polygon polygon -> !polygon.isEmpty();
+      case MultiLineString multiLineString -> !multiLineString.isEmpty();
+      case MultiPolygon multiPolygon -> !multiPolygon.isEmpty();
+      case MultiPoint multiPoint -> !multiPoint.isEmpty();
+      case GeometryCollection geometryCollection ->
+        IntStream.range(0, geometryCollection.getNumGeometries())
+                .mapToObj(geometryCollection::getGeometryN)
+                .anyMatch(GeometryEncoder::hasGeometry);
+        case null, default -> false;
+    };
   }
 }

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/GeometryEncoder.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/GeometryEncoder.java
@@ -367,19 +367,20 @@ public class GeometryEncoder {
           }
         }
         case GeometryCollection geometryCollection -> {
-            final var nestedGeometries = IntStream.range(0, geometryCollection.getNumGeometries())
-                            .mapToObj(geometryCollection::getGeometryN)
-                                    .toList();
-            prepareGeometry(
-                nestedGeometries,
-                numGeometries,
-                geometryTypes,
-                vertexBuffer,
-                numParts,
-                numRings,
-                numTriangles,
-                indexBuffer,
-                tessellateSource);
+          final var nestedGeometries =
+              IntStream.range(0, geometryCollection.getNumGeometries())
+                  .mapToObj(geometryCollection::getGeometryN)
+                  .toList();
+          prepareGeometry(
+              nestedGeometries,
+              numGeometries,
+              geometryTypes,
+              vertexBuffer,
+              numParts,
+              numRings,
+              numTriangles,
+              indexBuffer,
+              tessellateSource);
         }
         default ->
             throw new IllegalArgumentException(
@@ -655,6 +656,7 @@ public class GeometryEncoder {
   public static boolean hasGeometry(@Nullable Feature feature) {
     return (feature != null) && hasGeometry(feature.getGeometry());
   }
+
   public static boolean hasGeometry(@Nullable Geometry geometry) {
     return switch (geometry) {
       case Point ignored -> true;
@@ -664,10 +666,10 @@ public class GeometryEncoder {
       case MultiPolygon multiPolygon -> !multiPolygon.isEmpty();
       case MultiPoint multiPoint -> !multiPoint.isEmpty();
       case GeometryCollection geometryCollection ->
-        IntStream.range(0, geometryCollection.getNumGeometries())
-                .mapToObj(geometryCollection::getGeometryN)
-                .anyMatch(GeometryEncoder::hasGeometry);
-        case null, default -> false;
+          IntStream.range(0, geometryCollection.getNumGeometries())
+              .mapToObj(geometryCollection::getGeometryN)
+              .anyMatch(GeometryEncoder::hasGeometry);
+      case null, default -> false;
     };
   }
 }

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/GeometryEncoder.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/GeometryEncoder.java
@@ -370,6 +370,7 @@ public class GeometryEncoder {
           final var nestedGeometries =
               IntStream.range(0, geometryCollection.getNumGeometries())
                   .mapToObj(geometryCollection::getGeometryN)
+                  .filter(GeometryEncoder::hasGeometry)
                   .toList();
           prepareGeometry(
               nestedGeometries,
@@ -659,7 +660,7 @@ public class GeometryEncoder {
 
   public static boolean hasGeometry(@Nullable Geometry geometry) {
     return switch (geometry) {
-      case Point ignored -> true;
+      case Point point -> !point.isEmpty();
       case LineString lineString -> !lineString.isEmpty();
       case Polygon polygon -> !polygon.isEmpty();
       case MultiLineString multiLineString -> !multiLineString.isEmpty();

--- a/java/mlt-core/src/test/java/org/maplibre/mlt/converter/encodings/GeometryEncoderTest.java
+++ b/java/mlt-core/src/test/java/org/maplibre/mlt/converter/encodings/GeometryEncoderTest.java
@@ -1,0 +1,261 @@
+package org.maplibre.mlt.converter.encodings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+import org.maplibre.mlt.converter.geometry.GeometryType;
+import org.maplibre.mlt.converter.geometry.Vertex;
+import org.maplibre.mlt.data.Feature;
+
+class GeometryEncoderTest {
+  @Test
+  void nullGeom() {
+    assertHasGeometry(null, false);
+  }
+
+  @Test
+  void nullFeature() {
+    assertFalse(GeometryEncoder.hasGeometry((Feature) null));
+  }
+
+  @ParameterizedTest
+  @EnumSource(GeometryType.class)
+  void validGeometries_return_true(final GeometryType type) {
+    assertTrue(GeometryEncoder.hasGeometry(makeGeometry(type)), type.name());
+  }
+
+  @ParameterizedTest
+  @EnumSource(GeometryType.class)
+  void emptyGeometries_return_false(final GeometryType type) {
+    assertFalse(GeometryEncoder.hasGeometry(makeEmptyGeometry(type)), type.name());
+  }
+
+  private Geometry makeGeometry(final GeometryType type) {
+    return switch (type) {
+      case POINT -> GF.createPoint(coord(0, 0));
+      case LINESTRING -> GF.createLineString(new Coordinate[] {coord(0, 0), coord(1, 1)});
+      case POLYGON -> makePolygon(SAMPLE_SQUARE);
+      case MULTIPOINT -> {
+        final var p1 = GF.createPoint(coord(0, 0));
+        final var p2 = GF.createPoint(coord(1, 1));
+        yield GF.createMultiPoint(new Point[] {p1, p2});
+      }
+      case MULTILINESTRING -> {
+        final var l1 = GF.createLineString(new Coordinate[] {coord(0, 0), coord(1, 1)});
+        final var l2 = GF.createLineString(new Coordinate[] {coord(2, 2), coord(3, 3)});
+        yield GF.createMultiLineString(new LineString[] {l1, l2});
+      }
+      case MULTIPOLYGON -> GF.createMultiPolygon(new Polygon[] {makePolygon(SAMPLE_SQUARE)});
+    };
+  }
+
+  private Geometry makeEmptyGeometry(final GeometryType type) {
+    return switch (type) {
+      case POINT -> emptyGeom();
+      case LINESTRING -> GF.createLineString(new Coordinate[] {});
+      case POLYGON -> GF.createPolygon(new Coordinate[] {});
+      case MULTIPOINT -> emptyGeom();
+      case MULTILINESTRING -> GF.createMultiLineString(new LineString[] {});
+      case MULTIPOLYGON -> GF.createMultiPolygon(new Polygon[] {});
+    };
+  }
+
+  @Test
+  void pointCollection() {
+    final var collection =
+        GF.createGeometryCollection(new Geometry[] {GF.createPoint(coord(0, 0))});
+    assertHasGeometry(collection, true);
+  }
+
+  @Test
+  void lineStringCollection() {
+    final var collection =
+        GF.createGeometryCollection(
+            new Geometry[] {GF.createLineString(new Coordinate[] {coord(0, 0), coord(1, 1)})});
+    assertHasGeometry(collection, true);
+  }
+
+  @Test
+  void polygonCollection() {
+    final var collection = GF.createGeometryCollection(new Geometry[] {makePolygon(SAMPLE_SQUARE)});
+    assertHasGeometry(collection, true);
+  }
+
+  @Test
+  void collectionEmpty() {
+    assertHasGeometry(GF.createGeometryCollection(new Geometry[] {}), false);
+  }
+
+  @Test
+  void emptyGeomCollection() {
+    final var collection = GF.createGeometryCollection(new Geometry[] {emptyGeom()});
+    assertHasGeometry(collection, false);
+  }
+
+  @Test
+  void collectionAnyNotEmpty() {
+    final var collection =
+        GF.createGeometryCollection(new Geometry[] {emptyGeom(), GF.createPoint(coord(0, 0))});
+    assertHasGeometry(collection, true);
+  }
+
+  @Test
+  void collectionAllEmpty() {
+    final var collection =
+        GF.createGeometryCollection(
+            new Geometry[] {emptyGeom(), GF.createLineString(new Coordinate[] {})});
+    assertHasGeometry(collection, false);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void nestedCollection(final boolean hasContent) {
+    final var inner =
+        hasContent
+            ? GF.createGeometryCollection(new Geometry[] {GF.createPoint(coord(0, 0))})
+            : GF.createGeometryCollection(new Geometry[] {emptyGeom()});
+    final var outer = GF.createGeometryCollection(new Geometry[] {inner});
+    assertHasGeometry(outer, hasContent);
+  }
+
+  @Test
+  void collectionLineString() throws Exception {
+    final var point = GF.createPoint(coord(10, 20));
+    final var lineString = GF.createLineString(new Coordinate[] {coord(30, 40), coord(50, 60)});
+    final var geometryCollection = GF.createGeometryCollection(new Geometry[] {point, lineString});
+
+    assertFlattenedEquals(
+        runPrepareGeometry(List.of(geometryCollection)),
+        runPrepareGeometry(List.of(point, lineString)));
+  }
+
+  @Test
+  void collectionNested() throws Exception {
+    final var point = GF.createPoint(coord(5, 10));
+    final var innerCollection = GF.createGeometryCollection(new Geometry[] {point});
+    final var outerCollection = GF.createGeometryCollection(new Geometry[] {innerCollection});
+
+    assertEquals(
+        runPrepareGeometry(List.of(outerCollection)).geometryTypes,
+        runPrepareGeometry(List.of(point)).geometryTypes);
+    assertEquals(
+        runPrepareGeometry(List.of(outerCollection)).numGeometries,
+        runPrepareGeometry(List.of(point)).numGeometries);
+    assertEquals(
+        runPrepareGeometry(List.of(outerCollection)).vertexBuffer,
+        runPrepareGeometry(List.of(point)).vertexBuffer);
+  }
+
+  @Test
+  void collectionMultiPolygon() throws Exception {
+    final var multiPolygon =
+        GF.createMultiPolygon(
+            new Polygon[] {makePolygon(SAMPLE_SQUARE), makePolygon(SAMPLE_SQUARE_2)});
+    final var geometryCollection = GF.createGeometryCollection(new Geometry[] {multiPolygon});
+
+    assertFlattenedEquals(
+        runPrepareGeometry(List.of(geometryCollection)), runPrepareGeometry(List.of(multiPolygon)));
+  }
+
+  @Test
+  void collectionPolygon() throws Exception {
+    final var geometryCollection =
+        GF.createGeometryCollection(
+            new Geometry[] {makePolygon(SAMPLE_SQUARE), makePolygon(SAMPLE_SQUARE_2)});
+
+    assertFlattenedEquals(
+        runPrepareGeometry(List.of(geometryCollection)),
+        runPrepareGeometry(List.of(makePolygon(SAMPLE_SQUARE), makePolygon(SAMPLE_SQUARE_2))));
+  }
+
+  private static final GeometryFactory GF = new GeometryFactory();
+  private static final Coordinate[] SAMPLE_SQUARE = {
+    coord(0, 0), coord(1, 0), coord(1, 1), coord(0, 1), coord(0, 0)
+  };
+  private static final Coordinate[] SAMPLE_SQUARE_2 = {
+    coord(2, 2), coord(3, 2), coord(3, 3), coord(2, 3), coord(2, 2)
+  };
+
+  private static Coordinate coord(final double x, final double y) {
+    return new Coordinate(x, y);
+  }
+
+  private static Polygon makePolygon(final Coordinate[] coords) {
+    return GF.createPolygon(coords);
+  }
+
+  private static Geometry emptyGeom() {
+    return GF.createEmpty(2);
+  }
+
+  private static void assertHasGeometry(final Geometry geom, final boolean expected) {
+    assertEquals(expected, GeometryEncoder.hasGeometry(geom));
+  }
+
+  private static void assertFlattenedEquals(final PrepareResult a, final PrepareResult b) {
+    assertEquals(a.geometryTypes, b.geometryTypes);
+    assertEquals(a.numGeometries, b.numGeometries);
+    assertEquals(a.vertexBuffer, b.vertexBuffer);
+    assertEquals(a.numParts, b.numParts);
+    assertEquals(a.numRings, b.numRings);
+  }
+
+  private record PrepareResult(
+      List<Integer> geometryTypes,
+      List<Integer> numGeometries,
+      List<Vertex> vertexBuffer,
+      List<Integer> numParts,
+      List<Integer> numRings) {}
+
+  private PrepareResult runPrepareGeometry(final List<Geometry> geometries) throws Exception {
+    final var method =
+        GeometryEncoder.class.getDeclaredMethod(
+            "prepareGeometry",
+            List.class,
+            ArrayList.class,
+            ArrayList.class,
+            ArrayList.class,
+            ArrayList.class,
+            ArrayList.class,
+            ArrayList.class,
+            ArrayList.class,
+            URI.class);
+    method.setAccessible(true);
+
+    final var numGeometries = new ArrayList<Integer>();
+    final var geometryTypes = new ArrayList<Integer>();
+    final var vertexBuffer = new ArrayList<Vertex>();
+    final var numParts = new ArrayList<Integer>();
+    final var numRings = new ArrayList<Integer>();
+    final var numTriangles = new ArrayList<Integer>();
+    final var indexBuffer = new ArrayList<Integer>();
+
+    method.invoke(
+        null,
+        geometries,
+        numGeometries,
+        geometryTypes,
+        vertexBuffer,
+        numParts,
+        numRings,
+        numTriangles,
+        indexBuffer,
+        (URI) null);
+
+    return new PrepareResult(geometryTypes, numGeometries, vertexBuffer, numParts, numRings);
+  }
+}

--- a/java/mlt-core/src/test/java/org/maplibre/mlt/converter/encodings/GeometryEncoderTest.java
+++ b/java/mlt-core/src/test/java/org/maplibre/mlt/converter/encodings/GeometryEncoderTest.java
@@ -44,34 +44,9 @@ class GeometryEncoderTest {
     assertFalse(GeometryEncoder.hasGeometry(makeEmptyGeometry(type)), type.name());
   }
 
-  private Geometry makeGeometry(final GeometryType type) {
-    return switch (type) {
-      case POINT -> GF.createPoint(coord(0, 0));
-      case LINESTRING -> GF.createLineString(new Coordinate[] {coord(0, 0), coord(1, 1)});
-      case POLYGON -> makePolygon(SAMPLE_SQUARE);
-      case MULTIPOINT -> {
-        final var p1 = GF.createPoint(coord(0, 0));
-        final var p2 = GF.createPoint(coord(1, 1));
-        yield GF.createMultiPoint(new Point[] {p1, p2});
-      }
-      case MULTILINESTRING -> {
-        final var l1 = GF.createLineString(new Coordinate[] {coord(0, 0), coord(1, 1)});
-        final var l2 = GF.createLineString(new Coordinate[] {coord(2, 2), coord(3, 3)});
-        yield GF.createMultiLineString(new LineString[] {l1, l2});
-      }
-      case MULTIPOLYGON -> GF.createMultiPolygon(new Polygon[] {makePolygon(SAMPLE_SQUARE)});
-    };
-  }
-
-  private Geometry makeEmptyGeometry(final GeometryType type) {
-    return switch (type) {
-      case POINT -> emptyGeom();
-      case LINESTRING -> GF.createLineString(new Coordinate[] {});
-      case POLYGON -> GF.createPolygon(new Coordinate[] {});
-      case MULTIPOINT -> emptyGeom();
-      case MULTILINESTRING -> GF.createMultiLineString(new LineString[] {});
-      case MULTIPOLYGON -> GF.createMultiPolygon(new Polygon[] {});
-    };
+  @Test
+  void emptyPoint() {
+    assertFalse(GeometryEncoder.hasGeometry(GF.createPoint((Coordinate) null)));
   }
 
   @Test
@@ -102,14 +77,15 @@ class GeometryEncoderTest {
 
   @Test
   void emptyGeomCollection() {
-    final var collection = GF.createGeometryCollection(new Geometry[] {emptyGeom()});
+    final var collection = GF.createGeometryCollection(new Geometry[] {GF.createEmpty(2)});
     assertHasGeometry(collection, false);
   }
 
   @Test
   void collectionAnyNotEmpty() {
     final var collection =
-        GF.createGeometryCollection(new Geometry[] {emptyGeom(), GF.createPoint(coord(0, 0))});
+        GF.createGeometryCollection(
+            new Geometry[] {GF.createEmpty(2), GF.createPoint(coord(0, 0))});
     assertHasGeometry(collection, true);
   }
 
@@ -117,7 +93,7 @@ class GeometryEncoderTest {
   void collectionAllEmpty() {
     final var collection =
         GF.createGeometryCollection(
-            new Geometry[] {emptyGeom(), GF.createLineString(new Coordinate[] {})});
+            new Geometry[] {GF.createEmpty(2), GF.createLineString(new Coordinate[] {})});
     assertHasGeometry(collection, false);
   }
 
@@ -127,7 +103,7 @@ class GeometryEncoderTest {
     final var inner =
         hasContent
             ? GF.createGeometryCollection(new Geometry[] {GF.createPoint(coord(0, 0))})
-            : GF.createGeometryCollection(new Geometry[] {emptyGeom()});
+            : GF.createGeometryCollection(new Geometry[] {GF.createEmpty(2)});
     final var outer = GF.createGeometryCollection(new Geometry[] {inner});
     assertHasGeometry(outer, hasContent);
   }
@@ -182,6 +158,36 @@ class GeometryEncoderTest {
         runPrepareGeometry(List.of(makePolygon(SAMPLE_SQUARE), makePolygon(SAMPLE_SQUARE_2))));
   }
 
+  private Geometry makeGeometry(final GeometryType type) {
+    return switch (type) {
+      case POINT -> GF.createPoint(coord(0, 0));
+      case LINESTRING -> GF.createLineString(new Coordinate[] {coord(0, 0), coord(1, 1)});
+      case POLYGON -> makePolygon(SAMPLE_SQUARE);
+      case MULTIPOINT -> {
+        final var p1 = GF.createPoint(coord(0, 0));
+        final var p2 = GF.createPoint(coord(1, 1));
+        yield GF.createMultiPoint(new Point[] {p1, p2});
+      }
+      case MULTILINESTRING -> {
+        final var l1 = GF.createLineString(new Coordinate[] {coord(0, 0), coord(1, 1)});
+        final var l2 = GF.createLineString(new Coordinate[] {coord(2, 2), coord(3, 3)});
+        yield GF.createMultiLineString(new LineString[] {l1, l2});
+      }
+      case MULTIPOLYGON -> GF.createMultiPolygon(new Polygon[] {makePolygon(SAMPLE_SQUARE)});
+    };
+  }
+
+  private Geometry makeEmptyGeometry(final GeometryType type) {
+    return switch (type) {
+      case POINT -> GF.createPoint((Coordinate) null);
+      case LINESTRING -> GF.createLineString(new Coordinate[] {});
+      case POLYGON -> GF.createPolygon(new Coordinate[] {});
+      case MULTIPOINT -> GF.createMultiPoint(new Point[] {});
+      case MULTILINESTRING -> GF.createMultiLineString(new LineString[] {});
+      case MULTIPOLYGON -> GF.createMultiPolygon(new Polygon[] {});
+    };
+  }
+
   private static final GeometryFactory GF = new GeometryFactory();
   private static final Coordinate[] SAMPLE_SQUARE = {
     coord(0, 0), coord(1, 0), coord(1, 1), coord(0, 1), coord(0, 0)
@@ -196,10 +202,6 @@ class GeometryEncoderTest {
 
   private static Polygon makePolygon(final Coordinate[] coords) {
     return GF.createPolygon(coords);
-  }
-
-  private static Geometry emptyGeom() {
-    return GF.createEmpty(2);
   }
 
   private static void assertHasGeometry(final Geometry geom, final boolean expected) {


### PR DESCRIPTION
Features with empty geometry still got an ID assigned, leading to a mismatch on decoding.  The geometry collection type wasn't handled at all.