### PR TITLE
chore(ci): add github token to avoid CI download failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       java: ${{ steps.filter.outputs.java }}
@@ -19,6 +22,7 @@ jobs:
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           filters: |
             rust:
               - 'justfile'

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -57,7 +57,6 @@ jobs:
           args: --release --zig --out dist --find-interpreter --locked --compatibility pypi --future-incompat-report --manifest-path rust/mlt-py/Cargo.toml
           sccache: false
           manylinux: auto
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -161,7 +160,6 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --zig --out dist --find-interpreter --locked --compatibility pypi --future-incompat-report --manifest-path rust/mlt-py/Cargo.toml
           sccache: false
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -177,7 +175,6 @@ jobs:
         with:
           command: sdist
           args: --out dist --manifest-path rust/mlt-py/Cargo.toml
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload sdist
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with: { name: 'wheels-sdist', path: 'dist' }

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -57,6 +57,7 @@ jobs:
           args: --release --zig --out dist --find-interpreter --locked --compatibility pypi --future-incompat-report --manifest-path rust/mlt-py/Cargo.toml
           sccache: false
           manylinux: auto
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -160,6 +161,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --zig --out dist --find-interpreter --locked --compatibility pypi --future-incompat-report --manifest-path rust/mlt-py/Cargo.toml
           sccache: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -175,6 +177,7 @@ jobs:
         with:
           command: sdist
           args: --out dist --manifest-path rust/mlt-py/Cargo.toml
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload sdist
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with: { name: 'wheels-sdist', path: 'dist' }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Python release workflow to improve authentication for Linux, macOS, and source distribution builds.
  * Updated the CI paths-check workflow to explicitly set permissions for repository access and provide an authentication token to the paths filter step.
  * No changes to application functionality or release triggers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->