### PR TITLE
chore(rust): simplify `decode_(i32|i64|u32|u64)` to `decode_ints::<T>`

### DIFF
--- a/rust/mlt-core/src/codecs/fsst.rs
+++ b/rust/mlt-core/src/codecs/fsst.rs
@@ -25,7 +25,7 @@ pub fn decode_fsst(raw: RawFsstData<'_>, dec: &mut Decoder) -> MltResult<(String
         corpus,
     } = raw;
 
-    let sym_lens = symbol_lengths.decode_u32s(dec)?;
+    let sym_lens = symbol_lengths.decode_ints::<u32>(dec)?;
     let symbols = symbol_table.data;
     let compressed = corpus.data;
 
@@ -51,7 +51,7 @@ pub fn decode_fsst(raw: RawFsstData<'_>, dec: &mut Decoder) -> MltResult<(String
     }
 
     dec.consume_items::<u8>(output.len())?;
-    Ok((String::from_utf8(output)?, lengths.decode_u32s(dec)?))
+    Ok((String::from_utf8(output)?, lengths.decode_ints::<u32>(dec)?))
 }
 
 /// Raw output from FSST compression (unencoded byte buffers).

--- a/rust/mlt-core/src/decoder/geometry/decode.rs
+++ b/rust/mlt-core/src/decoder/geometry/decode.rs
@@ -30,7 +30,7 @@ pub fn decode_geometry_types(
     dec: &mut Decoder,
 ) -> MltResult<Vec<GeometryType>> {
     // TODO: simplify this, e.g. use u8 or even GeometryType directly rather than going via Vec<u32>
-    let vector_types: Vec<u32> = meta.decode_u32s(dec)?;
+    let vector_types: Vec<u32> = meta.decode_ints::<u32>(dec)?;
     let vector_types: Vec<GeometryType> = vector_types
         .into_iter()
         .map::<MltResult<GeometryType>, _>(|v| Ok(u8::try_from(v)?.try_into()?))
@@ -267,7 +267,7 @@ impl Decode<GeometryValues> for RawGeometry<'_> {
                 StreamType::Present => {}
                 StreamType::Data(v) => match v {
                     DictionaryType::Vertex | DictionaryType::Morton => {
-                        vertices.set_once(stream.decode_i32s(dec)?)?;
+                        vertices.set_once(stream.decode_ints::<i32>(dec)?)?;
                     }
                     _ => Err(MltError::UnexpectedStreamType(stream.meta.stream_type))?,
                 },
@@ -277,7 +277,7 @@ impl Decode<GeometryValues> for RawGeometry<'_> {
                         OffsetType::Index => &mut index_buffer,
                         _ => Err(MltError::UnexpectedStreamType(stream.meta.stream_type))?,
                     };
-                    target.set_once(stream.decode_u32s(dec)?)?;
+                    target.set_once(stream.decode_ints::<u32>(dec)?)?;
                 }
                 StreamType::Length(v) => {
                     let target = match v {
@@ -287,7 +287,7 @@ impl Decode<GeometryValues> for RawGeometry<'_> {
                         LengthType::Triangles => &mut triangles,
                         _ => Err(MltError::UnexpectedStreamType(stream.meta.stream_type))?,
                     };
-                    target.set_once(stream.decode_u32s(dec)?)?;
+                    target.set_once(stream.decode_ints::<u32>(dec)?)?;
                 }
             }
         }

--- a/rust/mlt-core/src/decoder/id/decode.rs
+++ b/rust/mlt-core/src/decoder/id/decode.rs
@@ -10,11 +10,11 @@ impl<'a> Decode<ParsedId<'a>> for RawId<'a> {
         let values: Vec<u64> = match value {
             RawIdValue::Id32(stream) => {
                 // FIXME: ParsedId should be an enum of u32 or u64 to avoid extra allocation
-                let ids = stream.decode_u32s(dec)?;
+                let ids = stream.decode_ints::<u32>(dec)?;
                 dec.consume_items::<u64>(ids.len())?;
                 ids.into_iter().map(u64::from).collect()
             }
-            RawIdValue::Id64(stream) => stream.decode_u64s(dec)?,
+            RawIdValue::Id64(stream) => stream.decode_ints::<u64>(dec)?,
         };
 
         Ok(ParsedId(decode_presence(presence, values, dec)?))

--- a/rust/mlt-core/src/decoder/property/decode.rs
+++ b/rust/mlt-core/src/decoder/property/decode.rs
@@ -52,9 +52,9 @@ impl<'a> Decode<ParsedProperty<'a>> for RawProperty<'a> {
     /// charged *after* decoding based on actual allocation sizes.
     fn decode(self, dec: &mut Decoder) -> MltResult<ParsedProperty<'a>> {
         /// Decode the dense value stream and wrap it with the presence bitmap.
-        /// `$decode_method` is the typed `RawStream` method for element type `$ty`.
+        /// `$decode_method` is the typed `RawStream` method.
         macro_rules! scalar_decode {
-            ($variant:ident, $ty:ty, $decode_method:ident, $v:expr, $dec:expr) => {{
+            ($variant:ident, $decode_method:ident, $v:expr, $dec:expr) => {{
                 ParsedProperty::$variant(ParsedScalar::from_parts(
                     $v.name,
                     $v.presence,
@@ -64,16 +64,27 @@ impl<'a> Decode<ParsedProperty<'a>> for RawProperty<'a> {
             }};
         }
 
+        macro_rules! scalar_decode_int {
+            ($variant:ident, $ty:ty, $v:expr, $dec:expr) => {{
+                ParsedProperty::$variant(ParsedScalar::from_parts(
+                    $v.name,
+                    $v.presence,
+                    $v.data.decode_ints::<$ty>($dec)?,
+                    $dec,
+                )?)
+            }};
+        }
+
         Ok(match self {
-            Self::Bool(v) => scalar_decode!(Bool, bool, decode_bools, v, dec),
-            Self::I8(v) => scalar_decode!(I8, i8, decode_i8s, v, dec),
-            Self::U8(v) => scalar_decode!(U8, u8, decode_u8s, v, dec),
-            Self::I32(v) => scalar_decode!(I32, i32, decode_i32s, v, dec),
-            Self::U32(v) => scalar_decode!(U32, u32, decode_u32s, v, dec),
-            Self::I64(v) => scalar_decode!(I64, i64, decode_i64s, v, dec),
-            Self::U64(v) => scalar_decode!(U64, u64, decode_u64s, v, dec),
-            Self::F32(v) => scalar_decode!(F32, f32, decode_f32s, v, dec),
-            Self::F64(v) => scalar_decode!(F64, f64, decode_f64s, v, dec),
+            Self::Bool(v) => scalar_decode!(Bool, decode_bools, v, dec),
+            Self::I8(v) => scalar_decode!(I8, decode_i8s, v, dec),
+            Self::U8(v) => scalar_decode!(U8, decode_u8s, v, dec),
+            Self::I32(v) => scalar_decode_int!(I32, i32, v, dec),
+            Self::U32(v) => scalar_decode_int!(U32, u32, v, dec),
+            Self::I64(v) => scalar_decode_int!(I64, i64, v, dec),
+            Self::U64(v) => scalar_decode_int!(U64, u64, v, dec),
+            Self::F32(v) => scalar_decode!(F32, decode_f32s, v, dec),
+            Self::F64(v) => scalar_decode!(F64, decode_f64s, v, dec),
             Self::Str(v) => ParsedProperty::Str(v.decode(dec)?),
             Self::SharedDict(v) => ParsedProperty::SharedDict(v.decode(dec)?),
         })

--- a/rust/mlt-core/src/decoder/property/strings.rs
+++ b/rust/mlt-core/src/decoder/property/strings.rs
@@ -196,7 +196,7 @@ impl<'a> RawPlainData<'a> {
     pub fn decode(self, dec: &mut Decoder) -> MltResult<(&'a str, Vec<u32>)> {
         Ok((
             str::from_utf8(self.data.data)?,
-            self.lengths.decode_u32s(dec)?,
+            self.lengths.decode_ints(dec)?,
         ))
     }
 }
@@ -296,7 +296,7 @@ impl<'a> RawStrings<'a> {
                 offsets,
             } => {
                 let (data, lengths) = plain_data.decode(dec)?;
-                let offsets: Vec<u32> = offsets.decode_u32s(dec)?;
+                let offsets: Vec<u32> = offsets.decode_ints(dec)?;
                 decode_dictionary_strings(name, &lengths, &offsets, presence.as_deref(), data, dec)?
             }
             RawStringsEncoding::FsstPlain(fsst_data) => {
@@ -309,7 +309,7 @@ impl<'a> RawStrings<'a> {
             }
             RawStringsEncoding::FsstDictionary { fsst_data, offsets } => {
                 let (data, lengths) = fsst_data.decode(dec)?;
-                let offsets: Vec<u32> = offsets.decode_u32s(dec)?;
+                let offsets: Vec<u32> = offsets.decode_ints(dec)?;
                 decode_dictionary_strings(
                     name,
                     &lengths,
@@ -444,7 +444,7 @@ impl<'a> RawSharedDict<'a> {
         };
         let mut items = Vec::with_capacity(self.children.len());
         for child in self.children {
-            let offsets: Vec<u32> = child.data.decode_u32s(dec)?;
+            let offsets: Vec<u32> = child.data.decode_ints(dec)?;
             let presence = child.presence.decode_bools(dec)?;
             let ranges = resolve_dict_spans(&offsets, presence.as_deref(), &dict_spans, dec)?
                 .into_iter()

--- a/rust/mlt-core/src/decoder/stream/decode.rs
+++ b/rust/mlt-core/src/decoder/stream/decode.rs
@@ -51,7 +51,7 @@ impl<'a> RawStream<'a> {
     }
 
     pub fn decode_i8s(self, dec: &mut Decoder) -> MltResult<Vec<i8>> {
-        self.decode_i32s(dec)?
+        self.decode_ints::<i32>(dec)?
             .into_iter()
             .map(i8::try_from)
             .collect::<Result<Vec<_>, _>>()
@@ -59,68 +59,33 @@ impl<'a> RawStream<'a> {
     }
 
     pub fn decode_u8s(self, dec: &mut Decoder) -> MltResult<Vec<u8>> {
-        self.decode_u32s(dec)?
+        self.decode_ints::<u32>(dec)?
             .into_iter()
             .map(u8::try_from)
             .collect::<Result<Vec<u8>, _>>()
             .map_err(Into::into)
     }
 
-    pub fn decode_i32s(self, dec: &mut Decoder) -> MltResult<Vec<i32>> {
+    /// Decode an integer stream into `Vec<T>`, applying the logical transform.
+    ///
+    /// Fast path: when there is no logical transform and `T` is unsigned, the
+    /// physical words *are* the output and are decoded straight into a fresh
+    /// `Vec`, skipping the scratch-buffer round-trip. Otherwise the physical
+    /// decode uses the decoder's reusable scratch buffer and the logical
+    /// transform (zigzag / delta / RLE / Morton / …) produces the output. Signed
+    /// types always take the transform path (zigzag is required even for `None`).
+    pub fn decode_ints<T: DecodeInt>(self, dec: &mut Decoder) -> MltResult<Vec<T>> {
         let meta = self.meta;
-        // i32 always needs a logical transform (zigzag at minimum) — use scratch buffer.
-        let mut buf = mem::take(&mut dec.buffer_u32);
-        self.decode_bits::<u32>(&mut buf, dec)?;
-        let result = LogicalValue::new(meta).decode_i32(&buf, dec);
-        dec.buffer_u32 = buf;
-        dec.buffer_u32.clear();
-        result
-    }
-
-    pub fn decode_u32s(self, dec: &mut Decoder) -> MltResult<Vec<u32>> {
-        let meta = self.meta;
-        if meta.encoding.logical == LogicalEncoding::None {
-            // No logical transform: physical words are the output — decode into a fresh Vec.
-            let mut out = Vec::new();
-            self.decode_bits::<u32>(&mut out, dec)?;
-            Ok(out)
-        } else {
-            // Logical transform needed — use the reusable scratch buffer.
-            let mut buf = mem::take(&mut dec.buffer_u32);
-            self.decode_bits::<u32>(&mut buf, dec)?;
-            let result = LogicalValue::new(meta).decode_u32(&buf, dec);
-            dec.buffer_u32 = buf;
-            dec.buffer_u32.clear();
-            result
+        if meta.encoding.logical == LogicalEncoding::None
+            && let Some(out) = T::decode_none_passthrough(&self, dec)?
+        {
+            return Ok(out);
         }
-    }
-
-    pub fn decode_u64s(self, dec: &mut Decoder) -> MltResult<Vec<u64>> {
-        let meta = self.meta;
-        if meta.encoding.logical == LogicalEncoding::None {
-            // No logical transform: physical words are the output — decode into a fresh Vec.
-            let mut out = Vec::new();
-            self.decode_bits::<u64>(&mut out, dec)?;
-            Ok(out)
-        } else {
-            // Logical transform needed — use the reusable scratch buffer.
-            let mut buf = mem::take(&mut dec.buffer_u64);
-            self.decode_bits::<u64>(&mut buf, dec)?;
-            let result = LogicalValue::new(meta).decode_u64(&buf, dec);
-            dec.buffer_u64 = buf;
-            dec.buffer_u64.clear();
-            result
-        }
-    }
-
-    pub fn decode_i64s(self, dec: &mut Decoder) -> MltResult<Vec<i64>> {
-        let meta = self.meta;
-        // i64 always needs a logical transform (zigzag at minimum) — use scratch buffer.
-        let mut buf = mem::take(&mut dec.buffer_u64);
-        self.decode_bits::<u64>(&mut buf, dec)?;
-        let result = LogicalValue::new(meta).decode_i64(&buf, dec);
-        dec.buffer_u64 = buf;
-        dec.buffer_u64.clear();
+        let mut buf = mem::take(T::scratch(dec));
+        self.decode_bits::<T::Physical>(&mut buf, dec)?;
+        let result = T::logical_decode(LogicalValue::new(meta), &buf, dec);
+        *T::scratch(dec) = buf;
+        T::scratch(dec).clear();
         result
     }
 
@@ -164,7 +129,7 @@ impl<'a> RawStream<'a> {
     ///
     /// `FastPFOR` is `u32`-only; decoding a `u64` `FastPFOR` stream returns an error.
     pub fn decode_bits<T: PhysicalWord>(
-        self,
+        &self,
         buf: &mut Vec<T>,
         dec: &mut Decoder,
     ) -> MltResult<()> {
@@ -183,5 +148,103 @@ impl<'a> RawStream<'a> {
             }
         }
         Ok(())
+    }
+}
+
+/// Logical output integer type of a decoded stream (`i32` / `u32` / `i64` / `u64`).
+///
+/// Maps the output type to the physical word width it decodes from, the decoder
+/// scratch buffer to reuse for that width, and the logical-decode entry point.
+/// Decoder-side mirror of the encoder's `LogicalIntStreamKind`.
+pub trait DecodeInt: Sized {
+    /// Physical word width the stream is decoded into before the logical transform.
+    type Physical: PhysicalWord;
+
+    /// The reusable scratch buffer the decoder holds for this physical width.
+    fn scratch(dec: &mut Decoder) -> &mut Vec<Self::Physical>;
+
+    /// Apply the logical transform (zigzag / delta / RLE / Morton / …) to the
+    /// physically decoded words, producing the output values.
+    fn logical_decode(
+        lv: LogicalValue,
+        data: &[Self::Physical],
+        dec: &mut Decoder,
+    ) -> MltResult<Vec<Self>>;
+
+    /// Fast path for [`LogicalEncoding::None`]: for unsigned types the physical
+    /// words are already the output, so decode straight into a fresh `Vec` and
+    /// skip the scratch round-trip. Signed types return `None` — a zigzag
+    /// transform is always required, so they fall through to the general path.
+    fn decode_none_passthrough(
+        _stream: &RawStream<'_>,
+        _dec: &mut Decoder,
+    ) -> MltResult<Option<Vec<Self>>> {
+        Ok(None)
+    }
+}
+
+impl DecodeInt for i32 {
+    type Physical = u32;
+
+    fn scratch(dec: &mut Decoder) -> &mut Vec<u32> {
+        &mut dec.buffer_u32
+    }
+
+    fn logical_decode(lv: LogicalValue, data: &[u32], dec: &mut Decoder) -> MltResult<Vec<Self>> {
+        lv.decode_i32(data, dec)
+    }
+}
+
+impl DecodeInt for u32 {
+    type Physical = Self;
+
+    fn scratch(dec: &mut Decoder) -> &mut Vec<Self> {
+        &mut dec.buffer_u32
+    }
+
+    fn logical_decode(lv: LogicalValue, data: &[Self], dec: &mut Decoder) -> MltResult<Vec<Self>> {
+        lv.decode_u32(data, dec)
+    }
+
+    fn decode_none_passthrough(
+        stream: &RawStream<'_>,
+        dec: &mut Decoder,
+    ) -> MltResult<Option<Vec<Self>>> {
+        let mut out = Vec::new();
+        stream.decode_bits::<Self>(&mut out, dec)?;
+        Ok(Some(out))
+    }
+}
+
+impl DecodeInt for i64 {
+    type Physical = u64;
+
+    fn scratch(dec: &mut Decoder) -> &mut Vec<u64> {
+        &mut dec.buffer_u64
+    }
+
+    fn logical_decode(lv: LogicalValue, data: &[u64], dec: &mut Decoder) -> MltResult<Vec<Self>> {
+        lv.decode_i64(data, dec)
+    }
+}
+
+impl DecodeInt for u64 {
+    type Physical = Self;
+
+    fn scratch(dec: &mut Decoder) -> &mut Vec<Self> {
+        &mut dec.buffer_u64
+    }
+
+    fn logical_decode(lv: LogicalValue, data: &[Self], dec: &mut Decoder) -> MltResult<Vec<Self>> {
+        lv.decode_u64(data, dec)
+    }
+
+    fn decode_none_passthrough(
+        stream: &RawStream<'_>,
+        dec: &mut Decoder,
+    ) -> MltResult<Option<Vec<Self>>> {
+        let mut out = Vec::new();
+        stream.decode_bits::<Self>(&mut out, dec)?;
+        Ok(Some(out))
     }
 }

--- a/rust/mlt-core/src/encoder/stream/logical.rs
+++ b/rust/mlt-core/src/encoder/stream/logical.rs
@@ -62,7 +62,7 @@ mod tests {
             let ctx = StreamCtx::prop_data("test");
             codecs.write_int_stream(&values, &ctx, &mut enc).unwrap();
             let parsed = assert_empty(RawStream::from_bytes(enc.data(), &mut parser()));
-            let decoded = parsed.decode_u32s(&mut dec()).unwrap();
+            let decoded = parsed.decode_ints::<u32>(&mut dec()).unwrap();
             prop_assert_eq!(decoded, values);
         }
 
@@ -79,7 +79,7 @@ mod tests {
             let ctx = StreamCtx::prop_data("test");
             codecs.write_int_stream(&values, &ctx, &mut enc).unwrap();
             let parsed = assert_empty(RawStream::from_bytes(enc.data(), &mut parser()));
-            let decoded = parsed.decode_i32s(&mut dec()).unwrap();
+            let decoded = parsed.decode_ints::<i32>(&mut dec()).unwrap();
             prop_assert_eq!(decoded, values);
         }
 
@@ -96,7 +96,7 @@ mod tests {
             let ctx = StreamCtx::prop_data("test");
             codecs.write_int_stream(&values, &ctx, &mut enc).unwrap();
             let parsed = assert_empty(RawStream::from_bytes(enc.data(), &mut parser()));
-            let decoded = parsed.decode_u64s(&mut dec()).unwrap();
+            let decoded = parsed.decode_ints::<u64>(&mut dec()).unwrap();
             prop_assert_eq!(decoded, values);
         }
 
@@ -113,7 +113,7 @@ mod tests {
             let ctx = StreamCtx::prop_data("test");
             codecs.write_int_stream(&values, &ctx, &mut enc).unwrap();
             let parsed = assert_empty(RawStream::from_bytes(enc.data(), &mut parser()));
-            let decoded = parsed.decode_i64s(&mut dec()).unwrap();
+            let decoded = parsed.decode_ints::<i64>(&mut dec()).unwrap();
             prop_assert_eq!(decoded, values);
         }
     }

--- a/rust/mlt-core/src/encoder/stream/tests.rs
+++ b/rust/mlt-core/src/encoder/stream/tests.rs
@@ -23,7 +23,7 @@ fn roundtrip_stream_u32s(wire: &[u8]) -> Vec<u32> {
     let parsed_stream = assert_empty(RawStream::from_bytes(wire, &mut parser()));
 
     let mut decoder = dec();
-    let values = parsed_stream.decode_u32s(&mut decoder).unwrap();
+    let values = parsed_stream.decode_ints::<u32>(&mut decoder).unwrap();
     if !values.is_empty() {
         assert!(
             decoder.consumed() > 0,
@@ -443,7 +443,7 @@ proptest! {
         let mut codecs = Codecs::default();
         codecs.write_int_stream(&values, &StreamCtx::prop_data("test"), &mut enc).unwrap();
         let parsed_stream = assert_empty(RawStream::from_bytes(enc.data(), &mut parser()));
-        let decoded_values = parsed_stream.decode_i32s(&mut dec()).unwrap();
+        let decoded_values = parsed_stream.decode_ints::<i32>(&mut dec()).unwrap();
 
         assert_eq!(decoded_values, values);
     }
@@ -457,7 +457,7 @@ proptest! {
         let mut codecs = Codecs::default();
         codecs.write_int_stream(&values, &StreamCtx::prop_data("test"), &mut enc).unwrap();
         let parsed_stream = assert_empty(RawStream::from_bytes(enc.data(), &mut parser()));
-        let decoded_values = parsed_stream.decode_u64s(&mut dec()).unwrap();
+        let decoded_values = parsed_stream.decode_ints::<u64>(&mut dec()).unwrap();
 
         assert_eq!(decoded_values, values);
     }
@@ -471,7 +471,7 @@ proptest! {
         let mut codecs = Codecs::default();
         codecs.write_int_stream(&values, &StreamCtx::prop_data("test"), &mut enc).unwrap();
         let parsed_stream = assert_empty(RawStream::from_bytes(enc.data(), &mut parser()));
-        let decoded_values = parsed_stream.decode_i64s(&mut dec()).unwrap();
+        let decoded_values = parsed_stream.decode_ints::<i64>(&mut dec()).unwrap();
 
         assert_eq!(decoded_values, values);
     }


### PR DESCRIPTION
based on #1516 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Streamlined integer and bit decoding through unified generic decoding APIs.
  * Improved support for multiple physical word sizes and encoding formats.
  * Preserved decoding behavior across geometry, IDs, properties, strings, and compressed data.

* **Bug Fixes**
  * Added clearer handling for insufficient input buffers and unsupported physical encodings.

* **Tests**
  * Updated round-trip and decoding coverage for signed and unsigned integer streams, empty inputs, partial consumption, and underflow conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->