### PR TITLE
chore(rust): genericize some more fns

### DIFF
--- a/rust/mlt-core/src/decoder/property/decode.rs
+++ b/rust/mlt-core/src/decoder/property/decode.rs
@@ -51,42 +51,48 @@ impl<'a> Decode<ParsedProperty<'a>> for RawProperty<'a> {
     /// columns the exact decoded size depends on compression, so the budget is
     /// charged *after* decoding based on actual allocation sizes.
     fn decode(self, dec: &mut Decoder) -> MltResult<ParsedProperty<'a>> {
-        /// Decode the dense value stream and wrap it with the presence bitmap.
-        /// `$decode_method` is the typed `RawStream` method.
-        macro_rules! scalar_decode {
-            ($variant:ident, $decode_method:ident, $v:expr, $dec:expr) => {{
-                ParsedProperty::$variant(ParsedScalar::from_parts(
-                    $v.name,
-                    $v.presence,
-                    $v.data.$decode_method($dec)?,
-                    $dec,
-                )?)
-            }};
-        }
-
-        macro_rules! scalar_decode_int {
-            ($variant:ident, $ty:ty, $v:expr, $dec:expr) => {{
-                ParsedProperty::$variant(ParsedScalar::from_parts(
-                    $v.name,
-                    $v.presence,
-                    $v.data.decode_ints::<$ty>($dec)?,
-                    $dec,
-                )?)
-            }};
-        }
+        use ParsedProperty as P;
+        use ParsedScalar as S;
 
         Ok(match self {
-            Self::Bool(v) => scalar_decode!(Bool, decode_bools, v, dec),
-            Self::I8(v) => scalar_decode!(I8, decode_i8s, v, dec),
-            Self::U8(v) => scalar_decode!(U8, decode_u8s, v, dec),
-            Self::I32(v) => scalar_decode_int!(I32, i32, v, dec),
-            Self::U32(v) => scalar_decode_int!(U32, u32, v, dec),
-            Self::I64(v) => scalar_decode_int!(I64, i64, v, dec),
-            Self::U64(v) => scalar_decode_int!(U64, u64, v, dec),
-            Self::F32(v) => scalar_decode!(F32, decode_f32s, v, dec),
-            Self::F64(v) => scalar_decode!(F64, decode_f64s, v, dec),
-            Self::Str(v) => ParsedProperty::Str(v.decode(dec)?),
-            Self::SharedDict(v) => ParsedProperty::SharedDict(v.decode(dec)?),
+            Self::Bool(v) => {
+                let vals = v.data.decode_bools(dec)?;
+                P::Bool(S::from_parts(v.name, v.presence, vals, dec)?)
+            }
+            Self::I8(v) => {
+                let vals = v.data.decode_narrow::<i8, i32>(dec)?;
+                P::I8(S::from_parts(v.name, v.presence, vals, dec)?)
+            }
+            Self::U8(v) => {
+                let vals = v.data.decode_narrow::<u8, u32>(dec)?;
+                P::U8(S::from_parts(v.name, v.presence, vals, dec)?)
+            }
+            Self::I32(v) => {
+                let vals = v.data.decode_ints::<i32>(dec)?;
+                P::I32(S::from_parts(v.name, v.presence, vals, dec)?)
+            }
+            Self::U32(v) => {
+                let vals = v.data.decode_ints::<u32>(dec)?;
+                P::U32(S::from_parts(v.name, v.presence, vals, dec)?)
+            }
+            Self::I64(v) => {
+                let vals = v.data.decode_ints::<i64>(dec)?;
+                P::I64(S::from_parts(v.name, v.presence, vals, dec)?)
+            }
+            Self::U64(v) => {
+                let vals = v.data.decode_ints::<u64>(dec)?;
+                P::U64(S::from_parts(v.name, v.presence, vals, dec)?)
+            }
+            Self::F32(v) => {
+                let vals = v.data.decode_floats::<f32>(dec)?;
+                P::F32(S::from_parts(v.name, v.presence, vals, dec)?)
+            }
+            Self::F64(v) => {
+                let vals = v.data.decode_floats::<f64>(dec)?;
+                P::F64(S::from_parts(v.name, v.presence, vals, dec)?)
+            }
+            Self::Str(v) => P::Str(v.decode(dec)?),
+            Self::SharedDict(v) => P::SharedDict(v.decode(dec)?),
         })
     }
 }

--- a/rust/mlt-core/src/decoder/stream/decode.rs
+++ b/rust/mlt-core/src/decoder/stream/decode.rs
@@ -50,19 +50,18 @@ impl<'a> RawStream<'a> {
         decode_bytes_to_bools(&decoded, num_values, dec)
     }
 
-    pub fn decode_i8s(self, dec: &mut Decoder) -> MltResult<Vec<i8>> {
-        self.decode_ints::<i32>(dec)?
+    /// Decode an integer stream via its 32-bit physical type `W`, then narrow each
+    /// value to the 8-bit output `N`, erroring if any value is out of range.
+    pub fn decode_narrow<N, W>(self, dec: &mut Decoder) -> MltResult<Vec<N>>
+    where
+        W: DecodeInt,
+        N: TryFrom<W>,
+        MltError: From<<N as TryFrom<W>>::Error>,
+    {
+        self.decode_ints::<W>(dec)?
             .into_iter()
-            .map(i8::try_from)
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(Into::into)
-    }
-
-    pub fn decode_u8s(self, dec: &mut Decoder) -> MltResult<Vec<u8>> {
-        self.decode_ints::<u32>(dec)?
-            .into_iter()
-            .map(u8::try_from)
-            .collect::<Result<Vec<u8>, _>>()
+            .map(N::try_from)
+            .collect::<Result<Vec<N>, _>>()
             .map_err(Into::into)
     }
 
@@ -89,35 +88,32 @@ impl<'a> RawStream<'a> {
         result
     }
 
-    /// Decode a stream of f32 values from raw little-endian bytes, charging `dec`.
-    pub fn decode_f32s(self, dec: &mut Decoder) -> MltResult<Vec<f32>> {
+    /// Decode a stream of floating-point values (`f32` / `f64`) from raw little-endian
+    /// bytes, charging `dec`. Varint physical encoding is not supported for floats.
+    pub fn decode_floats<T>(self, dec: &mut Decoder) -> MltResult<Vec<T>>
+    where
+        T: num_traits::FromBytes,
+        for<'b> <T as num_traits::FromBytes>::Bytes: TryFrom<&'b [u8]>,
+    {
         if self.meta.encoding.physical == PhysicalEncoding::VarInt {
-            return Err(MltError::NotImplemented("varint f32 decoding"));
+            return Err(MltError::NotImplemented("varint float decoding"));
         }
         let num = self.meta.num_values.into_usize();
-        dec.consume_items::<f32>(num)?;
-        fail_if_invalid_stream_size(self.data.len(), num.checked_mul(4).or_overflow()?)?;
+        let width = size_of::<T>();
+        fail_if_invalid_stream_size(self.data.len(), num.checked_mul(width).or_overflow()?)?;
+        dec.consume_items::<T>(num)?;
 
         Ok(self
             .data
-            .chunks_exact(4)
-            .map(|chunk| f32::from_le_bytes(chunk.try_into().expect("infallible: chunks_exact(4)")))
-            .collect())
-    }
-
-    /// Decode a stream of f64 values from raw little-endian bytes, charging `dec`.
-    pub fn decode_f64s(self, dec: &mut Decoder) -> MltResult<Vec<f64>> {
-        if self.meta.encoding.physical == PhysicalEncoding::VarInt {
-            return Err(MltError::NotImplemented("varint f64 decoding"));
-        }
-        let num = self.meta.num_values.into_usize();
-        fail_if_invalid_stream_size(self.data.len(), num.checked_mul(8).or_overflow()?)?;
-
-        dec.consume_items::<f64>(num)?;
-        Ok(self
-            .data
-            .chunks_exact(8)
-            .map(|chunk| f64::from_le_bytes(chunk.try_into().expect("infallible: chunks_exact(8)")))
+            .chunks_exact(width)
+            .map(|chunk| {
+                T::from_le_bytes(
+                    &chunk
+                        .try_into()
+                        .ok()
+                        .expect("infallible: chunks_exact(width)"),
+                )
+            })
             .collect())
     }
 

--- a/rust/mlt-core/src/encoder/id/staged_id.rs
+++ b/rust/mlt-core/src/encoder/id/staged_id.rs
@@ -183,10 +183,10 @@ impl StagedId {
     pub fn write_to(self, enc: &mut Encoder, codecs: &mut Codecs) -> MltResult<()> {
         match &self {
             Self::None => Ok(()),
-            Self::U32(v) => codecs.write_u32_scalar_col(ColumnType::Id, None, v, enc),
-            Self::OptU32(v) => codecs.write_opt_u32_scalar_col(ColumnType::OptId, None, v, enc),
-            Self::U64(v) => codecs.write_u64_scalar_col(ColumnType::LongId, None, v, enc),
-            Self::OptU64(v) => codecs.write_opt_u64_scalar_col(ColumnType::OptLongId, None, v, enc),
+            Self::U32(v) => codecs.write_scalar_col(ColumnType::Id, None, v, enc),
+            Self::OptU32(v) => codecs.write_opt_scalar_col(ColumnType::OptId, None, v, enc),
+            Self::U64(v) => codecs.write_scalar_col(ColumnType::LongId, None, v, enc),
+            Self::OptU64(v) => codecs.write_opt_scalar_col(ColumnType::OptLongId, None, v, enc),
         }
     }
 }

--- a/rust/mlt-core/src/encoder/property/encode.rs
+++ b/rust/mlt-core/src/encoder/property/encode.rs
@@ -2,7 +2,10 @@ use super::model::{StagedOptScalar, StagedProperty};
 use crate::MltResult;
 use crate::decoder::{ColumnType, DictionaryType, StreamType};
 use crate::encoder::model::StreamCtx;
-use crate::encoder::{Codecs, Encoder, StagedScalar, StagedStrings};
+use crate::encoder::{
+    Codecs, Encoder, LogicalCodecs, LogicalIntCodec, LogicalIntStreamKind, StagedScalar,
+    StagedStrings,
+};
 
 /// Encode all property columns and write them to `enc`.
 #[hotpath::measure]
@@ -74,8 +77,8 @@ fn write_prop(prop: &StagedProperty, enc: &mut Encoder, codecs: &mut Codecs) -> 
             codecs.begin_opt_col(CT::OptI32, &v.name, &v.presence, enc)?;
             codecs.write_int_stream(&v.values, &StreamCtx::prop_data(&v.name), enc)
         }
-        D::U32(v) => codecs.write_u32_scalar_col(CT::U32, Some(&v.name), v, enc),
-        D::OptU32(v) => codecs.write_opt_u32_scalar_col(CT::OptU32, Some(&v.name), v, enc),
+        D::U32(v) => codecs.write_scalar_col(CT::U32, Some(&v.name), v, enc),
+        D::OptU32(v) => codecs.write_opt_scalar_col(CT::OptU32, Some(&v.name), v, enc),
         D::I64(v) => {
             enc.write_column_header(CT::I64, &v.name)?;
             codecs.write_int_stream(&v.values, &StreamCtx::prop_data(&v.name), enc)
@@ -84,8 +87,8 @@ fn write_prop(prop: &StagedProperty, enc: &mut Encoder, codecs: &mut Codecs) -> 
             codecs.begin_opt_col(CT::OptI64, &v.name, &v.presence, enc)?;
             codecs.write_int_stream(&v.values, &StreamCtx::prop_data(&v.name), enc)
         }
-        D::U64(v) => codecs.write_u64_scalar_col(CT::U64, Some(&v.name), v, enc),
-        D::OptU64(v) => codecs.write_opt_u64_scalar_col(CT::OptU64, Some(&v.name), v, enc),
+        D::U64(v) => codecs.write_scalar_col(CT::U64, Some(&v.name), v, enc),
+        D::OptU64(v) => codecs.write_opt_scalar_col(CT::OptU64, Some(&v.name), v, enc),
         D::Str(v) => {
             enc.write_column_header(ColumnType::Str, &v.name)?;
             codecs.write_str_col(v, None, enc)
@@ -115,50 +118,36 @@ impl Codecs {
         self.write_presence_stream(presence.iter().copied(), enc)
     }
 
-    pub(crate) fn write_u32_scalar_col(
+    pub(crate) fn write_scalar_col<T>(
         &mut self,
         ct: ColumnType,
         name: Option<&str>,
-        v: &StagedScalar<u32>,
+        v: &StagedScalar<T>,
         enc: &mut Encoder,
-    ) -> MltResult<()> {
+    ) -> MltResult<()>
+    where
+        T: Copy + PartialEq,
+        [T]: LogicalIntStreamKind<Input = T>,
+        LogicalCodecs: LogicalIntCodec<[T]>,
+    {
         begin_scalar_col(ct, name, enc)?;
         self.write_int_stream(&v.values, &scalar_ctx(name), enc)
     }
 
-    pub(crate) fn write_opt_u32_scalar_col(
+    pub(crate) fn write_opt_scalar_col<T>(
         &mut self,
         ct: ColumnType,
         name: Option<&str>,
-        v: &StagedOptScalar<u32>,
+        v: &StagedOptScalar<T>,
         enc: &mut Encoder,
-    ) -> MltResult<()> {
+    ) -> MltResult<()>
+    where
+        T: Copy + PartialEq,
+        [T]: LogicalIntStreamKind<Input = T>,
+        LogicalCodecs: LogicalIntCodec<[T]>,
+    {
         begin_scalar_col(ct, name, enc)?;
         self.write_presence_stream(v.presence.iter().copied(), enc)?;
-        self.write_int_stream(&v.values, &scalar_ctx(name), enc)
-    }
-
-    pub(crate) fn write_u64_scalar_col(
-        &mut self,
-        ct: ColumnType,
-        name: Option<&str>,
-        v: &StagedScalar<u64>,
-        enc: &mut Encoder,
-    ) -> MltResult<()> {
-        begin_scalar_col(ct, name, enc)?;
-        self.write_int_stream(&v.values, &scalar_ctx(name), enc)
-    }
-
-    pub(crate) fn write_opt_u64_scalar_col(
-        &mut self,
-        ct: ColumnType,
-        name: Option<&str>,
-        v: &StagedOptScalar<u64>,
-        enc: &mut Encoder,
-    ) -> MltResult<()> {
-        let presence_bools = v.presence.iter().copied();
-        begin_scalar_col(ct, name, enc)?;
-        self.write_presence_stream(presence_bools, enc)?;
         self.write_int_stream(&v.values, &scalar_ctx(name), enc)
     }
 }

--- a/rust/mlt-core/src/encoder/property/encode.rs
+++ b/rust/mlt-core/src/encoder/property/encode.rs
@@ -53,40 +53,16 @@ fn write_prop(prop: &StagedProperty, enc: &mut Encoder, codecs: &mut Codecs) -> 
             codecs.begin_opt_col(CT::OptF64, &v.name, &v.presence, enc)?;
             codecs.write_float_stream(&v.values, StreamType::Data(DictionaryType::None), enc)
         }
-        D::I8(v) => {
-            enc.write_column_header(CT::I8, &v.name)?;
-            codecs.write_int_stream(&v.values, &StreamCtx::prop_data(&v.name), enc)
-        }
-        D::OptI8(v) => {
-            codecs.begin_opt_col(CT::OptI8, &v.name, &v.presence, enc)?;
-            codecs.write_int_stream(&v.values, &StreamCtx::prop_data(&v.name), enc)
-        }
-        D::U8(v) => {
-            enc.write_column_header(CT::U8, &v.name)?;
-            codecs.write_int_stream(&v.values, &StreamCtx::prop_data(&v.name), enc)
-        }
-        D::OptU8(v) => {
-            codecs.begin_opt_col(CT::OptU8, &v.name, &v.presence, enc)?;
-            codecs.write_int_stream(&v.values, &StreamCtx::prop_data(&v.name), enc)
-        }
-        D::I32(v) => {
-            enc.write_column_header(CT::I32, &v.name)?;
-            codecs.write_int_stream(&v.values, &StreamCtx::prop_data(&v.name), enc)
-        }
-        D::OptI32(v) => {
-            codecs.begin_opt_col(CT::OptI32, &v.name, &v.presence, enc)?;
-            codecs.write_int_stream(&v.values, &StreamCtx::prop_data(&v.name), enc)
-        }
+        D::I8(v) => codecs.write_scalar_col(CT::I8, Some(&v.name), v, enc),
+        D::OptI8(v) => codecs.write_opt_scalar_col(CT::OptI8, Some(&v.name), v, enc),
+        D::U8(v) => codecs.write_scalar_col(CT::U8, Some(&v.name), v, enc),
+        D::OptU8(v) => codecs.write_opt_scalar_col(CT::OptU8, Some(&v.name), v, enc),
+        D::I32(v) => codecs.write_scalar_col(CT::I32, Some(&v.name), v, enc),
+        D::OptI32(v) => codecs.write_opt_scalar_col(CT::OptI32, Some(&v.name), v, enc),
         D::U32(v) => codecs.write_scalar_col(CT::U32, Some(&v.name), v, enc),
         D::OptU32(v) => codecs.write_opt_scalar_col(CT::OptU32, Some(&v.name), v, enc),
-        D::I64(v) => {
-            enc.write_column_header(CT::I64, &v.name)?;
-            codecs.write_int_stream(&v.values, &StreamCtx::prop_data(&v.name), enc)
-        }
-        D::OptI64(v) => {
-            codecs.begin_opt_col(CT::OptI64, &v.name, &v.presence, enc)?;
-            codecs.write_int_stream(&v.values, &StreamCtx::prop_data(&v.name), enc)
-        }
+        D::I64(v) => codecs.write_scalar_col(CT::I64, Some(&v.name), v, enc),
+        D::OptI64(v) => codecs.write_opt_scalar_col(CT::OptI64, Some(&v.name), v, enc),
         D::U64(v) => codecs.write_scalar_col(CT::U64, Some(&v.name), v, enc),
         D::OptU64(v) => codecs.write_opt_scalar_col(CT::OptU64, Some(&v.name), v, enc),
         D::Str(v) => {

--- a/rust/mlt-core/src/encoder/stream/codecs.rs
+++ b/rust/mlt-core/src/encoder/stream/codecs.rs
@@ -2,8 +2,6 @@ use std::collections::HashMap;
 
 use bytemuck::{NoUninit, cast_slice};
 use fastpfor::FastPFor256;
-use num_traits::WrappingSub;
-use zigzag::ZigZag;
 
 use crate::codecs::bytes::encode_bools_to_bytes;
 use crate::codecs::rle::encode_byte_rle;
@@ -111,7 +109,6 @@ impl Codecs {
     ) -> MltResult<()>
     where
         [T]: LogicalIntStreamKind<Input = T>,
-        <<[T] as LogicalIntStreamKind>::Profile as ZigZag>::UInt: WrappingSub,
         LogicalCodecs: LogicalIntCodec<[T]>,
     {
         type Output<T> = <[T] as LogicalIntStreamKind>::Output;

--- a/rust/mlt-core/src/encoder/stream/encode_stream.rs
+++ b/rust/mlt-core/src/encoder/stream/encode_stream.rs
@@ -32,24 +32,13 @@ pub(crate) fn dedup_strings<S: AsRef<str>>(values: &[S]) -> MltResult<(Vec<&str>
 
 #[cfg(any(test, feature = "__private"))]
 impl EncodedStream {
-    /// Encodes `f32`s into a stream
+    /// Encodes floating-point values (`f32` / `f64`) into a stream as raw little-endian bytes.
     #[hotpath::measure]
-    pub fn encode_f32(values: &[f32]) -> MltResult<Self> {
-        let data = values
-            .iter()
-            .flat_map(|f| f.to_le_bytes())
-            .collect::<Vec<u8>>();
-        let meta = StreamMeta::new_none(StreamType::Data(DictionaryType::None), values.len())?;
-        Ok(Self { meta, data })
-    }
-
-    /// Encodes `f64`s into a stream
-    #[hotpath::measure]
-    pub fn encode_f64(values: &[f64]) -> MltResult<Self> {
-        let data = values
-            .iter()
-            .flat_map(|v| v.to_le_bytes())
-            .collect::<Vec<u8>>();
+    pub fn encode_floats<T: num_traits::ToBytes>(values: &[T]) -> MltResult<Self> {
+        let mut data = Vec::with_capacity(size_of_val(values));
+        for v in values {
+            data.extend_from_slice(v.to_le_bytes().as_ref());
+        }
         let meta = StreamMeta::new_none(StreamType::Data(DictionaryType::None), values.len())?;
         Ok(Self { meta, data })
     }

--- a/rust/mlt-core/src/encoder/stream/mod.rs
+++ b/rust/mlt-core/src/encoder/stream/mod.rs
@@ -1,28 +1,34 @@
 mod codecs;
-mod encode_stream;
-pub(crate) use encode_stream::dedup_strings;
-mod encoder;
-pub(crate) mod logical;
-mod model;
-mod optimizer;
-mod physical;
-#[cfg(test)]
-mod tests;
-pub(crate) mod write;
-
+pub(crate) use codecs::LogicalCodecs;
 #[cfg(feature = "__private")]
 pub use codecs::{Codecs, PhysicalCodecs};
 #[cfg(not(feature = "__private"))]
 pub(crate) use codecs::{Codecs, PhysicalCodecs};
+
+mod encode_stream;
+pub(crate) use encode_stream::dedup_strings;
+
+mod encoder;
 pub use encoder::IntEncoder;
+pub(crate) mod logical;
 #[cfg(feature = "__private")]
 pub use logical::LogicalEncoder;
 #[cfg(all(test, not(feature = "__private")))]
 pub(crate) use logical::LogicalEncoder;
+
+mod model;
 #[cfg(any(test, feature = "__private"))]
 pub use model::*;
+
+mod optimizer;
+mod physical;
 #[cfg(feature = "__private")]
 pub use physical::PhysicalEncoder;
 #[cfg(all(test, not(feature = "__private")))]
 pub(crate) use physical::PhysicalEncoder;
-pub(crate) use write::write_stream_payload;
+
+#[cfg(test)]
+mod tests;
+
+pub(crate) mod write;
+pub(crate) use write::{LogicalIntCodec, LogicalIntStreamKind, write_stream_payload};

--- a/rust/mlt-core/src/encoder/stream/tests.rs
+++ b/rust/mlt-core/src/encoder/stream/tests.rs
@@ -478,7 +478,7 @@ proptest! {
 
     #[test]
     fn test_f32_roundtrip(values in prop::collection::vec(any::<f32>(), 0..100)) {
-        let owned_stream = EncodedStream::encode_f32(&values).unwrap();
+        let owned_stream = EncodedStream::encode_floats(&values).unwrap();
 
         let mut buf = Vec::new();
         let parsed_stream = roundtrip_stream(&mut buf, &owned_stream);
@@ -496,7 +496,7 @@ proptest! {
 
     #[test]
     fn test_f64_roundtrip(values in prop::collection::vec(any::<f64>(), 0..100)) {
-        let owned_stream = EncodedStream::encode_f64(&values).unwrap();
+        let owned_stream = EncodedStream::encode_floats(&values).unwrap();
 
         let mut buf = Vec::new();
         let parsed_stream = roundtrip_stream(&mut buf, &owned_stream);

--- a/rust/mlt-core/src/encoder/stream/tests.rs
+++ b/rust/mlt-core/src/encoder/stream/tests.rs
@@ -402,7 +402,7 @@ proptest! {
         let mut codecs = Codecs::default();
         codecs.write_int_stream(&widened, &StreamCtx::prop_data("test"), &mut enc).unwrap();
         let parsed_stream = assert_empty(RawStream::from_bytes(enc.data(), &mut parser()));
-        let decoded_values = parsed_stream.decode_i8s(&mut dec()).unwrap();
+        let decoded_values = parsed_stream.decode_narrow::<i8, i32>(&mut dec()).unwrap();
 
         assert_eq!(decoded_values, values);
     }
@@ -417,7 +417,7 @@ proptest! {
         let mut codecs = Codecs::default();
         codecs.write_int_stream(&widened, &StreamCtx::prop_data("test"), &mut enc).unwrap();
         let parsed_stream = assert_empty(RawStream::from_bytes(enc.data(), &mut parser()));
-        let decoded_values = parsed_stream.decode_u8s(&mut dec()).unwrap();
+        let decoded_values = parsed_stream.decode_narrow::<u8, u32>(&mut dec()).unwrap();
 
         assert_eq!(decoded_values, values);
     }
@@ -482,7 +482,7 @@ proptest! {
 
         let mut buf = Vec::new();
         let parsed_stream = roundtrip_stream(&mut buf, &owned_stream);
-        let decoded_values = parsed_stream.decode_f32s(&mut dec()).unwrap();
+        let decoded_values = parsed_stream.decode_floats::<f32>(&mut dec()).unwrap();
 
         assert_eq!(decoded_values.len(), values.len());
         for (v1, v2) in decoded_values.iter().zip(values.iter()) {
@@ -500,7 +500,7 @@ proptest! {
 
         let mut buf = Vec::new();
         let parsed_stream = roundtrip_stream(&mut buf, &owned_stream);
-        let decoded_values = parsed_stream.decode_f64s(&mut dec()).unwrap();
+        let decoded_values = parsed_stream.decode_floats::<f64>(&mut dec()).unwrap();
 
         assert_eq!(decoded_values.len(), values.len());
         for (v1, v2) in decoded_values.iter().zip(values.iter()) {

--- a/rust/mlt-core/src/encoder/stream/write.rs
+++ b/rust/mlt-core/src/encoder/stream/write.rs
@@ -1,7 +1,7 @@
 use bytemuck::{NoUninit, cast_slice};
 use fastpfor::AnyLenCodec as _;
 use integer_encoding::VarInt;
-use num_traits::PrimInt;
+use num_traits::{PrimInt, WrappingSub};
 use zigzag::ZigZag;
 
 use crate::MltError::UnsupportedPhysicalEncoding;
@@ -29,7 +29,7 @@ pub(crate) fn write_stream_payload(
 }
 
 pub(crate) trait PhysicalIntStreamKind {
-    type Value: Into<u64> + NoUninit + PrimInt;
+    type Value: Into<u64> + NoUninit + PrimInt + WrappingSub;
     const FASTPFOR_ALLOWED: bool;
 
     #[cfg(target_endian = "little")]
@@ -184,19 +184,11 @@ fn encode_i8_zigzag<'a>(values: &[i8], target: &'a mut Vec<u32>) -> &'a [u32] {
     target
 }
 
-fn encode_u8_delta<'a>(values: &[u8], target: &'a mut Vec<u32>) -> &'a [u32] {
-    target.clear();
-    target.reserve(values.len());
-    let mut prev = 0_i32;
-    for &v in values {
-        let v = i32::from(v);
-        target.push(i32::encode(v.wrapping_sub(prev)));
-        prev = v;
-    }
-    target
-}
-
-fn encode_i8_delta<'a>(values: &[i8], target: &'a mut Vec<u32>) -> &'a [u32] {
+/// Delta-then-zigzag-encode narrow (`u8`/`i8`) values, widening each to `i32` first.
+fn encode_narrow_delta<'a, T: Copy>(values: &[T], target: &'a mut Vec<u32>) -> &'a [u32]
+where
+    i32: From<T>,
+{
     target.clear();
     target.reserve(values.len());
     let mut prev = 0_i32;
@@ -220,7 +212,7 @@ impl LogicalIntCodec<[u8]> for LogicalCodecs {
     }
 
     fn delta<'a>(&'a mut self, values: &'a [u8]) -> &'a [u32] {
-        encode_u8_delta(values, &mut self.u32_tmp)
+        encode_narrow_delta(values, &mut self.u32_tmp)
     }
 
     fn rle<'a>(&'a mut self, values: &'a [u8]) -> MltResult<(LogicalEncoding, &'a [u32])> {
@@ -230,7 +222,7 @@ impl LogicalIntCodec<[u8]> for LogicalCodecs {
     }
 
     fn delta_rle<'a>(&'a mut self, values: &'a [u8]) -> MltResult<(LogicalEncoding, &'a [u32])> {
-        let data = encode_u8_delta(values, &mut self.u32_tmp);
+        let data = encode_narrow_delta(values, &mut self.u32_tmp);
         let meta = apply_rle(data, values.len(), &mut self.u32_tmp2)?;
         Ok((LogicalEncoding::DeltaRle(meta), &self.u32_tmp2))
     }
@@ -248,7 +240,7 @@ impl LogicalIntCodec<[i8]> for LogicalCodecs {
     }
 
     fn delta<'a>(&'a mut self, values: &'a [i8]) -> &'a [u32] {
-        encode_i8_delta(values, &mut self.u32_tmp)
+        encode_narrow_delta(values, &mut self.u32_tmp)
     }
 
     fn rle<'a>(&'a mut self, values: &'a [i8]) -> MltResult<(LogicalEncoding, &'a [u32])> {
@@ -258,7 +250,7 @@ impl LogicalIntCodec<[i8]> for LogicalCodecs {
     }
 
     fn delta_rle<'a>(&'a mut self, values: &'a [i8]) -> MltResult<(LogicalEncoding, &'a [u32])> {
-        let data = encode_i8_delta(values, &mut self.u32_tmp);
+        let data = encode_narrow_delta(values, &mut self.u32_tmp);
         let meta = apply_rle(data, values.len(), &mut self.u32_tmp2)?;
         Ok((LogicalEncoding::DeltaRle(meta), &self.u32_tmp2))
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Integer property/ID columns now use shared scalar integer encoding across signed/unsigned and 32/64/optional variants.
  * Float stream encoding/decoding is unified for both 32-bit and 64-bit values.
* **Bug Fixes**
  * Float round-trips continue to preserve identical bitwise results.
* **Refactor**
  * Narrow integer delta encoding and narrow decoding are consolidated into generic paths.
  * Stream float handling is consolidated into generic encode/decode routines.
* **Tests**
  * Updated stream round-trip tests to use the new generic APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->