### PR TITLE
Unconditionally enable C++ library exporting

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -211,6 +211,4 @@ if(MLT_WITH_TOOLS)
 endif(MLT_WITH_TOOLS)
 
 list(APPEND MLT_EXPORT_TARGETS mlt-cpp-encoder)
-if(NOT MLT_AS_OBJECT_LIBRARY)
-    export(TARGETS ${MLT_EXPORT_TARGETS} FILE MLTTargets.cmake)
-endif()
+export(TARGETS ${MLT_EXPORT_TARGETS} FILE MLTTargets.cmake)


### PR DESCRIPTION
Unconditionally enable C++ library exporting as it also seems to be needed for object libraries if one depends on them. Not sure why this did not work before. Maybe some PR interference.

/cc @louwers @CommanderStorm 