### PR TITLE
perf(rust): speed up MVT-to-MLT ~30% by not calling fast-mvt's to_tile()

### DIFF
--- a/rust/mlt-core/src/convert/mvt/decode.rs
+++ b/rust/mlt-core/src/convert/mvt/decode.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use fast_mvt::{MvtLayer, MvtReaderRef, MvtValue};
+use fast_mvt::{MvtLayer, MvtLayerRef, MvtReaderRef, MvtValue, MvtValueRef};
 use serde_json::Value;
 
 use crate::decoder::{PropValue, TileFeature, TileLayer};
@@ -10,9 +10,6 @@ use crate::geojson::{Feature, FeatureCollection};
 use crate::{MltError, MltResult};
 
 /// Parse MVT bytes into a list of layers, each holding its raw features.
-///
-/// This is the single place where the `fast-mvt` API is called; both
-/// [`mvt_to_feature_collection`] and [`mvt_to_tile_layers`] build on top of it.
 fn read_mvt_layers(data: &[u8]) -> MltResult<Vec<MvtLayer>> {
     let layers = MvtReaderRef::new(data)?.to_tile()?.layers;
     if layers.iter().any(|layer| layer.name.is_empty()) {
@@ -56,10 +53,74 @@ pub fn mvt_to_feature_collection(data: impl AsRef<[u8]>) -> MltResult<FeatureCol
 /// determines its type, with `I64`+`U64` widened to `I64` and `F32`+`F64` widened
 /// to `F64`; all other type conflicts fall back to `Str`.
 pub fn mvt_to_tile_layers(data: impl AsRef<[u8]>) -> MltResult<Vec<TileLayer>> {
-    read_mvt_layers(data.as_ref())?
-        .into_iter()
-        .map(TileLayer::try_from)
-        .collect::<Result<Vec<_>, _>>()
+    MvtReaderRef::new(data.as_ref())?
+        .layers()
+        .map(tile_layer_from_ref)
+        .collect()
+}
+
+/// Build a [`TileLayer`] straight from the borrowed reader.
+fn tile_layer_from_ref(layer: MvtLayerRef<'_>) -> MltResult<TileLayer> {
+    let name = layer.name();
+    if name.is_empty() {
+        return Err(MltError::MissingLayerName);
+    }
+
+    // First pass: collect property names (insertion-ordered) and infer column types.
+    let mut col_names: Vec<String> = Vec::new();
+    let mut col_index: HashMap<&str, usize> = HashMap::new();
+    let mut col_types: Vec<InferredType> = Vec::new();
+    // Each value with its column, so the second pass resolves no keys.
+    let mut values: Vec<(usize, MvtValueRef<'_>)> = Vec::new();
+    let mut feature_ends: Vec<usize> = Vec::with_capacity(layer.feature_count());
+
+    for feat in layer.features() {
+        for prop in feat.properties() {
+            let (key, value) = prop?;
+            let idx = if let Some(&idx) = col_index.get(key) {
+                idx
+            } else {
+                let idx = col_names.len();
+                col_names.push(key.to_string());
+                col_index.insert(key, idx);
+                col_types.push(InferredType::Unknown);
+                idx
+            };
+            // One bounds check rather than one per index expression.
+            let slot = &mut col_types[idx];
+            *slot = slot.merge(InferredType::from_mvt(value));
+            values.push((idx, value));
+        }
+        feature_ends.push(values.len());
+    }
+
+    // Columns that were only ever null fall back to Str.
+    for t in &mut col_types {
+        if *t == InferredType::Unknown {
+            *t = InferredType::Str;
+        }
+    }
+
+    // Second pass: build TileFeature objects.
+    let mut tile_features = Vec::with_capacity(layer.feature_count());
+    let mut start = 0;
+    for (feat, &end) in layer.features().zip(&feature_ends) {
+        // Start every slot with a typed null; fill in present values below.
+        let mut properties: Vec<PropValue> = col_types.iter().map(|t| t.typed_null()).collect();
+        for &(idx, value) in &values[start..end] {
+            if !matches!(value, MvtValueRef::Null) {
+                properties[idx] = col_types[idx].convert(value.into_owned());
+            }
+        }
+        start = end;
+        tile_features.push(TileFeature {
+            id: feat.id(),
+            geometry: feat.geometry()?,
+            properties,
+        });
+    }
+
+    TileLayer::from_parts(name, layer.extent(), col_names, tile_features)
 }
 
 impl TryFrom<MvtLayer> for TileLayer {
@@ -83,7 +144,8 @@ impl TryFrom<MvtLayer> for TileLayer {
                     col_types.push(InferredType::Unknown);
                     i
                 });
-                col_types[idx] = col_types[idx].merge(InferredType::from_mvt(val));
+                let slot = &mut col_types[idx];
+                *slot = slot.merge(InferredType::from_mvt(as_value_ref(val)));
             }
         }
 
@@ -117,6 +179,20 @@ impl TryFrom<MvtLayer> for TileLayer {
     }
 }
 
+/// Borrow an owned [`MvtValue`], so both conversion paths share one inference pass.
+fn as_value_ref(value: &MvtValue) -> MvtValueRef<'_> {
+    match value {
+        MvtValue::String(s) => MvtValueRef::String(s),
+        MvtValue::Float(f) => MvtValueRef::Float(*f),
+        MvtValue::Double(f) => MvtValueRef::Double(*f),
+        MvtValue::Int(i) => MvtValueRef::Int(*i),
+        MvtValue::UInt(u) => MvtValueRef::UInt(*u),
+        MvtValue::SInt(i) => MvtValueRef::SInt(*i),
+        MvtValue::Bool(b) => MvtValueRef::Bool(*b),
+        MvtValue::Null => MvtValueRef::Null,
+    }
+}
+
 /// Column type inferred from MVT property values across all features in a layer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InferredType {
@@ -130,15 +206,15 @@ enum InferredType {
 }
 
 impl InferredType {
-    fn from_mvt(val: &MvtValue) -> Self {
+    fn from_mvt(val: MvtValueRef<'_>) -> Self {
         match val {
-            MvtValue::Bool(_) => Self::Bool,
-            MvtValue::Int(_) | MvtValue::SInt(_) => Self::I64,
-            MvtValue::UInt(_) => Self::U64,
-            MvtValue::Float(_) => Self::F32,
-            MvtValue::Double(_) => Self::F64,
-            MvtValue::String(_) => Self::Str,
-            MvtValue::Null => Self::Unknown,
+            MvtValueRef::Bool(_) => Self::Bool,
+            MvtValueRef::Int(_) | MvtValueRef::SInt(_) => Self::I64,
+            MvtValueRef::UInt(_) => Self::U64,
+            MvtValueRef::Float(_) => Self::F32,
+            MvtValueRef::Double(_) => Self::F64,
+            MvtValueRef::String(_) => Self::Str,
+            MvtValueRef::Null => Self::Unknown,
         }
     }
 
@@ -195,5 +271,79 @@ impl InferredType {
             // Type conflict at runtime: fall back to a debug string.
             (_, v) => PropValue::Str(Some(format!("{v:?}"))),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn malformed_tags_are_reported() {
+        for (tags, expected) in [
+            (&[5, 0][..], "invalid key index 5"),
+            (&[0, 9][..], "invalid value index 9"),
+            (&[0][..], "invalid feature tags length: 1"),
+        ] {
+            let err = mvt_to_tile_layers(mvt_with_tags(tags))
+                .expect_err("malformed tags must error")
+                .to_string();
+            assert!(err.contains(expected), "got {err:?}, wanted {expected:?}");
+        }
+    }
+
+    /// Minimal hand-written MVT
+    fn mvt_with_tags(tags: &[u32]) -> Vec<u8> {
+        fn field(number: u32, wire: u32) -> u8 {
+            u8::try_from((number << 3) | wire).expect("small field number")
+        }
+        fn varint(mut value: u64, out: &mut Vec<u8>) {
+            loop {
+                let byte = u8::try_from(value & 0x7f).expect("masked");
+                value >>= 7;
+                if value == 0 {
+                    out.push(byte);
+                    return;
+                }
+                out.push(byte | 0x80);
+            }
+        }
+        fn packed(number: u32, values: &[u64], out: &mut Vec<u8>) {
+            let mut body = Vec::new();
+            for value in values {
+                varint(*value, &mut body);
+            }
+            out.push(field(number, 2));
+            varint(u64::try_from(body.len()).expect("small"), out);
+            out.extend(&body);
+        }
+        fn bytes(number: u32, body: &[u8], out: &mut Vec<u8>) {
+            out.push(field(number, 2));
+            varint(u64::try_from(body.len()).expect("small"), out);
+            out.extend(body);
+        }
+
+        let mut feat = Vec::new();
+        packed(
+            2,
+            &tags.iter().copied().map(u64::from).collect::<Vec<_>>(),
+            &mut feat,
+        );
+        feat.push(field(3, 0));
+        varint(1, &mut feat); // POINT
+        packed(4, &[9, 2, 2], &mut feat); // MoveTo(1, 1)
+
+        let mut layer = Vec::new();
+        layer.push(field(15, 0));
+        varint(2, &mut layer); // version
+        bytes(1, b"l", &mut layer); // name
+        bytes(2, &feat, &mut layer); // features
+        bytes(3, b"k", &mut layer); // keys
+        layer.push(field(5, 0));
+        varint(4096, &mut layer); // extent
+
+        let mut tile = Vec::new();
+        bytes(3, &layer, &mut tile);
+        tile
     }
 }

--- a/rust/mlt-ffi/generated/cpp/MltBuffer.d.hpp
+++ b/rust/mlt-ffi/generated/cpp/MltBuffer.d.hpp
@@ -28,7 +28,7 @@ public:
     /**
      * Borrow the contents as a byte slice.
      */
-    inline diplomat::span<const uint8_t> as_bytes() const;
+    inline diplomat::span<const uint8_t> as_bytes() const DIPLOMAT_LIFETIME_BOUND;
 
     /**
      * Number of bytes in the buffer.

--- a/rust/mlt-ffi/generated/cpp/MltBuffer.hpp
+++ b/rust/mlt-ffi/generated/cpp/MltBuffer.hpp
@@ -27,7 +27,7 @@ void MltBuffer_destroy(MltBuffer* self);
 } // namespace capi
 } // namespace diplomat
 
-inline diplomat::span<const uint8_t> MltBuffer::as_bytes() const {
+inline diplomat::span<const uint8_t> MltBuffer::as_bytes() const DIPLOMAT_LIFETIME_BOUND {
     auto result = diplomat::capi::MltBuffer_as_bytes(this->AsFFI());
     return diplomat::span<const uint8_t>(result.data, result.len);
 }

--- a/rust/mlt-ffi/generated/cpp/diplomat_runtime.hpp
+++ b/rust/mlt-ffi/generated/cpp/diplomat_runtime.hpp
@@ -17,6 +17,20 @@
 #include <array>
 #endif
 
+#ifndef DIPLOMAT_LIFETIME_BOUND
+#if defined(__has_cpp_attribute)
+#if __has_cpp_attribute(msvc::lifetimebound)
+#define DIPLOMAT_LIFETIME_BOUND [[msvc::lifetimebound]]
+#elif __has_cpp_attribute(clang::lifetimebound)
+#define DIPLOMAT_LIFETIME_BOUND [[clang::lifetimebound]]
+#endif
+#endif
+#endif
+
+#ifndef DIPLOMAT_LIFETIME_BOUND
+#define DIPLOMAT_LIFETIME_BOUND
+#endif
+
 namespace diplomat {
 
 namespace capi {
@@ -106,12 +120,16 @@ extern "C" inline void _flush(capi::DiplomatWrite* w) {
     string->resize(w->len);
 }
 
-extern "C" inline bool _grow(capi::DiplomatWrite* w, uintptr_t requested) {
+extern "C" inline bool _grow_impl(capi::DiplomatWrite* w, uintptr_t requested) {
     std::string* string = reinterpret_cast<std::string*>(w->context);
     string->resize(requested);
     w->cap = string->length();
     w->buf = &(*string)[0];
     return true;
+}
+
+extern "C" inline bool _grow(capi::DiplomatWrite* w, size_t requested) {
+    return _grow_impl(w, static_cast<uintptr_t>(requested));
 }
 
 inline capi::DiplomatWrite WriteFromString(std::string& string) {
@@ -374,6 +392,11 @@ struct as_ffi<T, std::void_t<decltype(std::declval<std::remove_pointer_t<T>>().A
 };
 
 template <typename T>
+struct as_ffi<std::unique_ptr<T>> {
+    using type = decltype(std::declval<T>().AsFFI());
+};
+
+template <typename T>
 using as_ffi_t = typename as_ffi<T>::type;
 
 template <typename T>
@@ -394,7 +417,11 @@ struct diplomat_c_span_convert {
         using type = diplomat::capi::Diplomat##name##ViewMut;                                  \
     };
 
+#if !defined(__sun) || !defined(_CHAR_IS_SIGNED)
+// int8_t and char are the same type on Solaris. Guard this definition to avoid
+// conflicts.
 MAKE_SLICE_CONVERTERS(I8, int8_t)
+#endif
 MAKE_SLICE_CONVERTERS(U8, uint8_t)
 MAKE_SLICE_CONVERTERS(I16, int16_t)
 MAKE_SLICE_CONVERTERS(U16, uint16_t)
@@ -411,6 +438,34 @@ MAKE_SLICE_CONVERTERS(String16, char16_t)
 
 template <typename T>
 using diplomat_c_span_convert_t = typename diplomat_c_span_convert<T>::type;
+
+template <typename T>
+struct is_unique_ptr {
+    static constexpr bool value = false;
+    using type = T;
+};
+
+template <typename T>
+struct is_unique_ptr<std::unique_ptr<T>> {
+    static constexpr bool value = true;
+    using type = T;
+};
+
+template <typename T>
+constexpr bool is_unique_ptr_v = is_unique_ptr<T>::value;
+
+template <typename T>
+struct is_optional {
+    static constexpr bool value = false;
+};
+
+template <typename T>
+struct is_optional<std::optional<T>> {
+    static constexpr bool value = true;
+};
+
+template <typename T>
+constexpr bool is_optional_v = is_optional<T>::value;
 
 /// Replace the argument types from the std::function with the argument types for th function pointer
 template <typename T>
@@ -432,6 +487,8 @@ struct fn_traits<std::function<Ret(Args...)>> {
         } else if constexpr (!std::is_same_v<T, as_ffi_t<T>>) {
             if constexpr (std::is_lvalue_reference_v<T>) {
                 return *std::remove_reference_t<T>::FromFFI(val);
+            } else if constexpr (is_unique_ptr_v<T>) {
+                return T(is_unique_ptr<T>::type::FromFFI(val));
             } else {
                 return T::FromFFI(val);
             }
@@ -463,6 +520,23 @@ struct fn_traits<std::function<Ret(Args...)>> {
         return (*reinterpret_cast<const function_t*>(cb))(replace<Args>(args)...);
     }
 
+    template <typename TOut, typename T>
+    static TOut replace_optional_ret(std::optional<T> optional) {
+        constexpr bool has_ok = !std::is_same_v<T, std::monostate>;
+
+        bool is_ok = optional.has_value();
+
+        TOut out;
+        out.is_ok = is_ok;
+
+        if constexpr (has_ok) {
+            if (is_ok) {
+                out.ok = replace_ret<T>(optional.value());
+            }
+        }
+        return out;
+    }
+
     template <typename T, typename E, typename TOut>
     static TOut c_run_callback_result(const void* cb, replace_fn_t<Args>... args) {
         result<T, E> res = c_run_callback(cb, args...);
@@ -477,13 +551,21 @@ struct fn_traits<std::function<Ret(Args...)>> {
 
         if constexpr (has_ok) {
             if (is_ok) {
-                out.ok = replace_ret<T>(std::get<Ok<T>>(res.val).inner);
+                if constexpr (is_optional_v<T>) {
+                    out.ok = replace_optional_ret<decltype(out.ok)>(std::get<Ok<T>>(res.val).inner);
+                } else {
+                    out.ok = replace_ret<T>(std::get<Ok<T>>(res.val).inner);
+                }
             }
         }
 
         if constexpr (has_err) {
             if (!is_ok) {
-                out.err = replace_ret<E>(std::get<Err<E>>(res.val).inner);
+                if constexpr (is_optional_v<T>) {
+                    out.err = replace_optional_ret<decltype(out.err)>(std::get<Err<E>>(res.val).inner);
+                } else {
+                    out.err = replace_ret<E>(std::get<Err<E>>(res.val).inner);
+                }
             }
         }
 
@@ -493,21 +575,9 @@ struct fn_traits<std::function<Ret(Args...)>> {
     // For DiplomatOption<>
     template <typename T, typename TOut>
     static TOut c_run_callback_diplomat_option(const void* cb, replace_fn_t<Args>... args) {
-        constexpr bool has_ok = !std::is_same_v<T, std::monostate>;
-
         std::optional<T> ret = c_run_callback(cb, args...);
 
-        bool is_ok = ret.has_value();
-
-        TOut out;
-        out.is_ok = is_ok;
-
-        if constexpr (has_ok) {
-            if (is_ok) {
-                out.ok = replace_ret<T>(ret.value());
-            }
-        }
-        return out;
+        return replace_optional_ret<TOut>(ret);
     }
 
     // All we need to do is just convert one pointer to another, while keeping the arguments the same:
@@ -515,7 +585,11 @@ struct fn_traits<std::function<Ret(Args...)>> {
     static T c_run_callback_diplomat_opaque(const void* cb, replace_fn_t<Args>... args) {
         Ret out = c_run_callback(cb, args...);
 
-        return out->AsFFI();
+        if constexpr (std::is_pointer_v<Ret>) {
+            return out->AsFFI();
+        } else {
+            return out.AsFFI();
+        }
     }
 
     static void c_delete(const void* cb) { delete reinterpret_cast<const function_t*>(cb); }


### PR DESCRIPTION
We can speed up MVT -> MLT conversion ~30%: `mvt_to_tile_layers` no longer calls `fast-mvt`'s `to_tile()` (which materialises an owned `MvtTile`) and reads through `MvtLayerRef` instead.

The first pass records each value's column, so the second pass resolves no keys.

Output is byte-identical on all 134 fixtures. The `TryFrom<MvtLayer>` route and malformed-tag errors are unchanged.

## Benchmark

95 `test/fixtures/omt/*.mvt` (34 MB), release, min of 12 interleaved runs.

| round | main | this PR | change |
|---|---:|---:|---:|
| 1 | 586,371 µs | 394,162 µs | −32.8% |
| 2 | 589,907 µs | 397,826 µs | −32.6% |
| 3 | 591,560 µs | 397,882 µs | −32.7% |
