### PR TITLE
chore(rust): implement FusedIterator, ExactSizeIterator and DoubleEndedIterator for the decoder iterators

### DIFF
--- a/rust/mlt-core/src/decoder/iterators.rs
+++ b/rust/mlt-core/src/decoder/iterators.rs
@@ -17,11 +17,12 @@
 //! `.collect()` are **not** available directly.  Use a `while let` loop instead:
 
 use std::fmt;
+use std::iter::FusedIterator;
 
 use geo_types::Geometry;
 use usize_cast::IntoUsize as _;
 
-use crate::decoder::{Layer01, ParsedLayer01, ParsedProperty, ParsedScalar, RawProperty};
+use crate::decoder::{Layer01, ParsedLayer01, ParsedProperty, ParsedScalar, Property, RawProperty};
 use crate::{Lazy, LazyParsed, MltResult, Parsed};
 
 /// A minimal lending (streaming) iterator trait.
@@ -56,27 +57,8 @@ impl<'a> Layer01<'a, Lazy> {
     ///
     /// Pair with [`FeatureRef::iter_all_properties`] to associate per-feature
     /// values with their column names.
-    pub fn iterate_prop_names(&self) -> impl Iterator<Item = PropName<'a>> + '_ {
-        let props = &self.properties;
-        let mut col_idx = 0;
-        let mut dict_idx = 0;
-        std::iter::from_fn(move || {
-            loop {
-                let idx = col_idx;
-                col_idx += 1;
-                let name = match props.get(idx)? {
-                    LazyParsed::Raw(r) => raw_col_name(r, &mut dict_idx),
-                    LazyParsed::Parsed(p) => parsed_col_name(p, &mut dict_idx),
-                    LazyParsed::ParsingFailed => None,
-                };
-                if dict_idx != 0 {
-                    col_idx -= 1;
-                }
-                if let Some(n) = name {
-                    return Some(n);
-                }
-            }
-        })
+    pub fn iterate_prop_names(&self) -> PropNamesIter<'_, Property<'a, Lazy>> {
+        PropNamesIter::new(&self.properties)
     }
 }
 
@@ -106,8 +88,8 @@ impl<'a> ParsedLayer01<'a> {
 
     /// Iterate over the property column names of this layer, in order.
     /// See [`Layer01::iterate_prop_names`] for details.
-    pub fn iterate_prop_names(&self) -> impl Iterator<Item = PropName<'a>> + '_ {
-        Layer01PropNamesIter::new(&self.properties)
+    pub fn iterate_prop_names(&self) -> PropNamesIter<'_, ParsedProperty<'a>> {
+        PropNamesIter::new(&self.properties)
     }
 }
 
@@ -256,7 +238,13 @@ impl<'feat, 'layer: 'feat> FeatureRef<'feat, 'layer> {
     /// - `None` — the slot is null / absent.
     ///
     /// Use [`Layer01::iterate_prop_names`] to pair values with their column names.
-    pub fn iter_all_properties(&self) -> impl Iterator<Item = Option<PropValueRef<'layer>>> + '_ {
+    #[must_use]
+    pub fn iter_all_properties(
+        &self,
+    ) -> impl ExactSizeIterator<Item = Option<PropValueRef<'layer>>>
+    + DoubleEndedIterator
+    + FusedIterator
+    + '_ {
         self.values.iter().copied()
     }
 
@@ -264,8 +252,11 @@ impl<'feat, 'layer: 'feat> FeatureRef<'feat, 'layer> {
     ///
     /// `SharedDict` columns are transparently expanded into one [`ColumnRef`] per sub-item.
     /// Null / absent values are skipped entirely. The iterator is infallible.
-    pub fn iter_properties(&self) -> impl Iterator<Item = ColumnRef<'layer>> + '_ {
-        Layer01PropNamesIter::new(self.columns)
+    #[must_use]
+    pub fn iter_properties(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = ColumnRef<'layer>> + FusedIterator + '_ {
+        PropNamesIter::new(self.columns)
             .zip(self.values.iter().copied())
             .filter_map(|(name, opt_val)| opt_val.map(|value| ColumnRef { name, value }))
     }
@@ -284,99 +275,181 @@ impl<'feat, 'layer: 'feat> FeatureRef<'feat, 'layer> {
 
 // ── Column name helpers ───────────────────────────────────────────────────────
 
-/// Iterates the property column names of a fully-decoded [`ParsedLayer01`].
+/// A property column that contributes one or more [`PropName`]s.
+///
+/// Scalar and string columns contribute exactly one name; `SharedDict` columns
+/// contribute one per sub-item.
+pub trait ColNames {
+    type Name;
+
+    /// Number of names this column contributes.
+    fn name_count(&self) -> usize;
+
+    /// The name at sub-index `idx`, which must be less than [`Self::name_count`].
+    fn name_at(&self, idx: usize) -> Self::Name;
+}
+
+impl<'p> ColNames for ParsedProperty<'p> {
+    type Name = PropName<'p>;
+
+    fn name_count(&self) -> usize {
+        match self {
+            Self::SharedDict(sd) => sd.items.len(),
+            _ => 1,
+        }
+    }
+
+    fn name_at(&self, idx: usize) -> PropName<'p> {
+        use ParsedProperty as P;
+        match self {
+            P::Bool(s) => PropName(s.name, ""),
+            P::I8(s) => PropName(s.name, ""),
+            P::U8(s) => PropName(s.name, ""),
+            P::I32(s) => PropName(s.name, ""),
+            P::U32(s) => PropName(s.name, ""),
+            P::I64(s) => PropName(s.name, ""),
+            P::U64(s) => PropName(s.name, ""),
+            P::F32(s) => PropName(s.name, ""),
+            P::F64(s) => PropName(s.name, ""),
+            P::Str(s) => PropName(s.name, ""),
+            P::SharedDict(sd) => PropName(sd.prefix, sd.items[idx].suffix),
+        }
+    }
+}
+
+impl<'p> ColNames for RawProperty<'p> {
+    type Name = PropName<'p>;
+
+    fn name_count(&self) -> usize {
+        match self {
+            Self::SharedDict(sd) => sd.children.len(),
+            _ => 1,
+        }
+    }
+
+    fn name_at(&self, idx: usize) -> PropName<'p> {
+        use RawProperty as P;
+        match self {
+            P::Bool(s)
+            | P::I8(s)
+            | P::U8(s)
+            | P::I32(s)
+            | P::U32(s)
+            | P::I64(s)
+            | P::U64(s)
+            | P::F32(s)
+            | P::F64(s) => PropName(s.name, ""),
+            P::Str(s) => PropName(s.name, ""),
+            P::SharedDict(sd) => PropName(sd.name, sd.children[idx].name),
+        }
+    }
+}
+
+/// A column that failed to parse contributes no names at all.
+impl<'p> ColNames for LazyParsed<RawProperty<'p>, ParsedProperty<'p>> {
+    type Name = PropName<'p>;
+
+    fn name_count(&self) -> usize {
+        match self {
+            Self::Raw(r) => r.name_count(),
+            Self::Parsed(p) => p.name_count(),
+            Self::ParsingFailed => 0,
+        }
+    }
+
+    fn name_at(&self, idx: usize) -> PropName<'p> {
+        match self {
+            Self::Raw(r) => r.name_at(idx),
+            Self::Parsed(p) => p.name_at(idx),
+            Self::ParsingFailed => unreachable!("ParsingFailed contributes no names"),
+        }
+    }
+}
+
+/// Iterates the property column names of a layer, in column order.
 ///
 /// Regular columns yield one [`PropName`]; `SharedDict` columns yield one name per
 /// sub-item (`(prefix, suffix)`).
-pub(crate) struct Layer01PropNamesIter<'a, 'p> {
-    props: &'a [ParsedProperty<'p>],
+#[must_use]
+pub struct PropNamesIter<'a, C> {
+    props: &'a [C],
+    /// Next column to read from the front.
     col_idx: usize,
-    dict_idx: usize,
+    /// Sub-index within `props[col_idx]` to read next from the front.
+    sub_idx: usize,
+    /// One past the last column to read from the back.
+    back_col: usize,
+    /// Number of names already taken from the back of `props[back_col - 1]`.
+    back_taken: usize,
+    /// Names not yet yielded from either end.
+    remaining: usize,
 }
 
-impl<'a, 'p> Layer01PropNamesIter<'a, 'p> {
-    pub(crate) fn new(props: &'a [ParsedProperty<'p>]) -> Self {
+impl<'a, C: ColNames> PropNamesIter<'a, C> {
+    pub(crate) fn new(props: &'a [C]) -> Self {
         Self {
             props,
             col_idx: 0,
-            dict_idx: 0,
+            sub_idx: 0,
+            back_col: props.len(),
+            back_taken: 0,
+            remaining: props.iter().map(ColNames::name_count).sum(),
         }
     }
 }
 
-impl<'a> Iterator for Layer01PropNamesIter<'_, 'a> {
-    type Item = PropName<'a>;
+impl<C: ColNames> Iterator for PropNamesIter<'_, C> {
+    type Item = C::Name;
 
-    fn next(&mut self) -> Option<PropName<'a>> {
+    fn next(&mut self) -> Option<C::Name> {
+        if self.remaining == 0 {
+            return None;
+        }
+        self.remaining -= 1;
         loop {
-            let col_idx = self.col_idx;
+            // `remaining` was non-zero, so a column at or after `col_idx` still has a name.
+            let col = &self.props[self.col_idx];
+            if self.sub_idx < col.name_count() {
+                let name = col.name_at(self.sub_idx);
+                self.sub_idx += 1;
+                return Some(name);
+            }
             self.col_idx += 1;
-            let name = parsed_col_name(self.props.get(col_idx)?, &mut self.dict_idx);
-            if self.dict_idx != 0 {
-                self.col_idx -= 1; // SharedDict not yet exhausted: revisit this column
+            self.sub_idx = 0;
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl<C: ColNames> DoubleEndedIterator for PropNamesIter<'_, C> {
+    fn next_back(&mut self) -> Option<C::Name> {
+        if self.remaining == 0 {
+            return None;
+        }
+        self.remaining -= 1;
+        loop {
+            let col = &self.props[self.back_col - 1];
+            let count = col.name_count();
+            if self.back_taken < count {
+                self.back_taken += 1;
+                return Some(col.name_at(count - self.back_taken));
             }
-            if let Some(n) = name {
-                return Some(n);
-            }
+            self.back_col -= 1;
+            self.back_taken = 0;
         }
     }
 }
 
-/// Yield the next [`PropName`] from a [`ParsedProperty`] column.
-#[inline]
-fn parsed_col_name<'p>(prop: &ParsedProperty<'p>, dict_idx: &mut usize) -> Option<PropName<'p>> {
-    use ParsedProperty as P;
-    match prop {
-        P::Bool(s) => Some(PropName(s.name, "")),
-        P::I8(s) => Some(PropName(s.name, "")),
-        P::U8(s) => Some(PropName(s.name, "")),
-        P::I32(s) => Some(PropName(s.name, "")),
-        P::U32(s) => Some(PropName(s.name, "")),
-        P::I64(s) => Some(PropName(s.name, "")),
-        P::U64(s) => Some(PropName(s.name, "")),
-        P::F32(s) => Some(PropName(s.name, "")),
-        P::F64(s) => Some(PropName(s.name, "")),
-        P::Str(s) => Some(PropName(s.name, "")),
-        P::SharedDict(sd) => {
-            if *dict_idx < sd.items.len() {
-                let idx = *dict_idx;
-                *dict_idx += 1;
-                Some(PropName(sd.prefix, sd.items[idx].suffix))
-            } else {
-                *dict_idx = 0;
-                None
-            }
-        }
+impl<C: ColNames> ExactSizeIterator for PropNamesIter<'_, C> {
+    fn len(&self) -> usize {
+        self.remaining
     }
 }
 
-/// Yield the next [`PropName`] from a [`RawProperty`] column.  See [`parsed_col_name`].
-#[inline]
-fn raw_col_name<'p>(prop: &RawProperty<'p>, dict_idx: &mut usize) -> Option<PropName<'p>> {
-    use RawProperty as P;
-    match prop {
-        P::Bool(s)
-        | P::I8(s)
-        | P::U8(s)
-        | P::I32(s)
-        | P::U32(s)
-        | P::I64(s)
-        | P::U64(s)
-        | P::F32(s)
-        | P::F64(s) => Some(PropName(s.name, "")),
-        P::Str(s) => Some(PropName(s.name, "")),
-        P::SharedDict(sd) => {
-            if *dict_idx < sd.children.len() {
-                let idx = *dict_idx;
-                *dict_idx += 1;
-                Some(PropName(sd.name, sd.children[idx].name))
-            } else {
-                *dict_idx = 0;
-                None
-            }
-        }
-    }
-}
+impl<C: ColNames> FusedIterator for PropNamesIter<'_, C> {}
 
 /// A boxed per-column-slot value iterator yielding one `Option<`[`PropValueRef`]`>` per feature.
 type ColValIter<'l> = Box<dyn Iterator<Item = Option<PropValueRef<'l>>> + 'l>;
@@ -538,7 +611,7 @@ mod tests {
     use crate::decoder::GeometryValues;
     use crate::encoder::model::StagedLayer;
     use crate::encoder::{Codecs, Encoder, Presence, StagedId, StagedProperty, StagedSharedDict};
-    use crate::test_helpers::{dec, parser};
+    use crate::test_helpers::{assert_size_hint_exact, dec, parser};
 
     fn layer_buf(staged: StagedLayer) -> Vec<u8> {
         staged
@@ -967,5 +1040,152 @@ mod tests {
 
         let names: Vec<_> = parsed.iterate_prop_names().map(|n| n.to_string()).collect();
         assert_eq!(names, ["addr:city", "addr:zip"]);
+    }
+
+    fn strs<'p>(iter: impl Iterator<Item = PropName<'p>>) -> Vec<String> {
+        iter.map(|n| n.to_string()).collect()
+    }
+
+    fn reversed<'p>(iter: impl DoubleEndedIterator<Item = PropName<'p>>) -> Vec<String> {
+        let mut names = strs(iter.rev());
+        names.reverse();
+        names
+    }
+
+    fn both_ends_layer() -> Vec<u8> {
+        let shared_dict = StagedSharedDict::new(
+            "addr:",
+            [
+                ("city", vec![Some("Paris"); 3], Presence::AllPresent),
+                ("zip", vec![Some("75001"); 3], Presence::AllPresent),
+                ("street", vec![Some("Rue"); 3], Presence::AllPresent),
+            ],
+        )
+        .unwrap();
+
+        layer_buf(staged_layer(
+            "test",
+            StagedId::None,
+            three_points(),
+            vec![
+                StagedProperty::str("before", ["a", "a", "a"]),
+                StagedProperty::u32("count", vec![1, 2, 3]),
+                StagedProperty::SharedDict(shared_dict),
+                StagedProperty::str("after", ["b", "b", "b"]),
+            ],
+        ))
+    }
+
+    const BOTH_ENDS_NAMES: [&str; 6] = [
+        "before",
+        "count",
+        "addr:city",
+        "addr:zip",
+        "addr:street",
+        "after",
+    ];
+
+    fn prop_names() -> Vec<PropName<'static>> {
+        BOTH_ENDS_NAMES.iter().map(|n| PropName(n, "")).collect()
+    }
+
+    #[test]
+    fn prop_names_iterate_from_both_ends_lazy() {
+        let buf = both_ends_layer();
+        let (_, layer) = Layer::from_bytes(&buf, &mut parser()).unwrap();
+        let Layer::Tag01(lazy) = layer else { panic!() };
+
+        assert_eq!(strs(lazy.iterate_prop_names()), BOTH_ENDS_NAMES);
+        assert_eq!(reversed(lazy.iterate_prop_names()), BOTH_ENDS_NAMES);
+        assert_size_hint_exact(|| lazy.iterate_prop_names(), &prop_names());
+    }
+
+    #[test]
+    fn prop_names_iterate_from_both_ends_parsed() {
+        let buf = both_ends_layer();
+        let (_, layer) = Layer::from_bytes(&buf, &mut parser()).unwrap();
+        let Layer::Tag01(lazy) = layer else { panic!() };
+        let parsed = lazy.decode_all(&mut dec()).unwrap();
+
+        assert_eq!(strs(parsed.iterate_prop_names()), BOTH_ENDS_NAMES);
+        assert_eq!(reversed(parsed.iterate_prop_names()), BOTH_ENDS_NAMES);
+
+        assert_size_hint_exact(|| parsed.iterate_prop_names(), &prop_names());
+    }
+
+    #[test]
+    fn prop_names_of_layer_without_properties() {
+        let buf = layer_buf(empty_layer("test"));
+        let (_, layer) = Layer::from_bytes(&buf, &mut parser()).unwrap();
+        let Layer::Tag01(lazy) = layer else { panic!() };
+
+        assert_eq!(lazy.iterate_prop_names().size_hint(), (0, Some(0)));
+        assert_eq!(lazy.iterate_prop_names().next(), None);
+        assert_eq!(lazy.iterate_prop_names().next_back(), None);
+
+        let parsed = lazy.decode_all(&mut dec()).unwrap();
+        assert_eq!(parsed.iterate_prop_names().size_hint(), (0, Some(0)));
+        assert_eq!(parsed.iterate_prop_names().next(), None);
+        assert_eq!(parsed.iterate_prop_names().next_back(), None);
+    }
+
+    /// `Layer01<Lazy>` only ever holds `Raw` columns today, so the `Parsed` and
+    /// `ParsingFailed` arms are exercised against a hand-built column slice.
+    #[test]
+    fn prop_names_skip_columns_that_failed_to_parse() {
+        let buf = both_ends_layer();
+        let (_, layer) = Layer::from_bytes(&buf, &mut parser()).unwrap();
+        let Layer::Tag01(lazy) = layer else { panic!() };
+        let raw = lazy.properties.clone();
+
+        let (_, layer) = Layer::from_bytes(&buf, &mut parser()).unwrap();
+        let Layer::Tag01(lazy) = layer else { panic!() };
+        let parsed = lazy.decode_all(&mut dec()).unwrap().properties;
+
+        let mixed = vec![
+            raw[0].clone(),
+            LazyParsed::ParsingFailed,
+            LazyParsed::Parsed(parsed[2].clone()),
+            LazyParsed::ParsingFailed,
+            raw[3].clone(),
+        ];
+        let expected = ["before", "addr:city", "addr:zip", "addr:street", "after"];
+
+        assert_eq!(strs(PropNamesIter::new(&mixed)), expected);
+        assert_eq!(reversed(PropNamesIter::new(&mixed)), expected);
+        assert_size_hint_exact(
+            || PropNamesIter::new(&mixed),
+            &expected.map(|n| PropName(n, "")),
+        );
+
+        let all_failed = vec![LazyParsed::ParsingFailed; 3];
+        assert_eq!(PropNamesIter::new(&all_failed).size_hint(), (0, Some(0)));
+        assert_eq!(PropNamesIter::new(&all_failed).next(), None);
+        assert_eq!(PropNamesIter::new(&all_failed).next_back(), None);
+    }
+
+    #[test]
+    fn feature_property_iterators_run_backwards() {
+        let buf = both_ends_layer();
+        let (_, layer) = Layer::from_bytes(&buf, &mut parser()).unwrap();
+        let Layer::Tag01(lazy) = layer else { panic!() };
+        let parsed = lazy.decode_all(&mut dec()).unwrap();
+
+        let mut iter = parsed.iter_features();
+        let feat = iter.next().unwrap().unwrap();
+
+        let all: Vec<_> = feat.iter_all_properties().collect();
+        assert_size_hint_exact(|| feat.iter_all_properties(), &all);
+        let mut all_back: Vec<_> = feat.iter_all_properties().rev().collect();
+        all_back.reverse();
+        assert_eq!(all_back, all);
+
+        let mut props_back: Vec<_> = feat
+            .iter_properties()
+            .rev()
+            .map(|c| c.name().to_string())
+            .collect();
+        props_back.reverse();
+        assert_eq!(props_back, BOTH_ENDS_NAMES);
     }
 }

--- a/rust/mlt-core/src/decoder/iterators.rs
+++ b/rust/mlt-core/src/decoder/iterators.rs
@@ -18,6 +18,7 @@
 
 use std::fmt;
 use std::iter::FusedIterator;
+use std::ops::Range;
 
 use geo_types::Geometry;
 use usize_cast::IntoUsize as _;
@@ -376,15 +377,15 @@ impl<'p> ColNames for LazyParsed<RawProperty<'p>, ParsedProperty<'p>> {
 #[must_use]
 pub struct PropNamesIter<'a, C> {
     props: &'a [C],
-    /// Next column to read from the front.
-    col_idx: usize,
-    /// Sub-index within `props[col_idx]` to read next from the front.
-    sub_idx: usize,
-    /// One past the last column to read from the back.
-    back_col: usize,
-    /// Number of names already taken from the back of `props[back_col - 1]`.
-    back_taken: usize,
-    /// Names not yet yielded from either end.
+    /// Columns that may still yield a name: `cols.start` is the front column,
+    /// `cols.end - 1` the back one.  The two coincide once they meet.
+    cols: Range<usize>,
+    /// Next sub-index to yield from `props[cols.start]`.
+    front_sub: usize,
+    /// One past the next sub-index to yield from `props[cols.end - 1]`.
+    back_sub: usize,
+    /// Names not yet yielded from either end.  Both ends decrement it, so it is
+    /// what stops them crossing while they share a column.
     remaining: usize,
 }
 
@@ -392,10 +393,9 @@ impl<'a, C: ColNames> PropNamesIter<'a, C> {
     pub(crate) fn new(props: &'a [C]) -> Self {
         Self {
             props,
-            col_idx: 0,
-            sub_idx: 0,
-            back_col: props.len(),
-            back_taken: 0,
+            cols: 0..props.len(),
+            front_sub: 0,
+            back_sub: props.last().map_or(0, ColNames::name_count),
             remaining: props.iter().map(ColNames::name_count).sum(),
         }
     }
@@ -410,15 +410,15 @@ impl<C: ColNames> Iterator for PropNamesIter<'_, C> {
         }
         self.remaining -= 1;
         loop {
-            // `remaining` was non-zero, so a column at or after `col_idx` still has a name.
-            let col = &self.props[self.col_idx];
-            if self.sub_idx < col.name_count() {
-                let name = col.name_at(self.sub_idx);
-                self.sub_idx += 1;
+            // `remaining` was non-zero, so some column in `cols` still has a name.
+            let col = &self.props[self.cols.start];
+            if self.front_sub < col.name_count() {
+                let name = col.name_at(self.front_sub);
+                self.front_sub += 1;
                 return Some(name);
             }
-            self.col_idx += 1;
-            self.sub_idx = 0;
+            self.cols.start += 1;
+            self.front_sub = 0;
         }
     }
 
@@ -434,14 +434,12 @@ impl<C: ColNames> DoubleEndedIterator for PropNamesIter<'_, C> {
         }
         self.remaining -= 1;
         loop {
-            let col = &self.props[self.back_col - 1];
-            let count = col.name_count();
-            if self.back_taken < count {
-                self.back_taken += 1;
-                return Some(col.name_at(count - self.back_taken));
+            if self.back_sub > 0 {
+                self.back_sub -= 1;
+                return Some(self.props[self.cols.end - 1].name_at(self.back_sub));
             }
-            self.back_col -= 1;
-            self.back_taken = 0;
+            self.cols.end -= 1;
+            self.back_sub = self.props[self.cols.end - 1].name_count();
         }
     }
 }

--- a/rust/mlt-core/src/decoder/iterators.rs
+++ b/rust/mlt-core/src/decoder/iterators.rs
@@ -280,6 +280,9 @@ impl<'feat, 'layer: 'feat> FeatureRef<'feat, 'layer> {
 /// Scalar and string columns contribute exactly one name; `SharedDict` columns
 /// contribute one per sub-item.
 pub trait ColNames {
+    /// Always `PropName<'tile>`.  It cannot be written as `PropName<'_>` directly:
+    /// that would tie names to the `&self` borrow rather than to the tile buffer,
+    /// so they could no longer outlive the layer.
     type Name;
 
     /// Number of names this column contributes.

--- a/rust/mlt-core/src/decoder/mod.rs
+++ b/rust/mlt-core/src/decoder/mod.rs
@@ -23,7 +23,8 @@ pub use id::ParsedId;
 // pub (not pub(crate)) so __private module can re-export it
 pub(crate) use id::{Id, RawId, RawIdValue};
 pub use iterators::{
-    ColumnRef, FeatureRef, Layer01FeatureIter, LendingIterator, PropName, PropValueRef,
+    ColNames, ColumnRef, FeatureRef, Layer01FeatureIter, LendingIterator, PropName, PropNamesIter,
+    PropValueRef,
 };
 pub(crate) use model::Column;
 pub use model::{

--- a/rust/mlt-core/src/lib.rs
+++ b/rust/mlt-core/src/lib.rs
@@ -27,10 +27,10 @@ pub(crate) mod utils;
 
 pub use convert::{geojson, mvt};
 pub use decoder::{
-    ColumnRef, Decoder, Extent, FeatureRef, GeometryType, GeometryValues, Layer, Layer01,
+    ColNames, ColumnRef, Decoder, Extent, FeatureRef, GeometryType, GeometryValues, Layer, Layer01,
     Layer01FeatureIter, LendingIterator, ParsedLayer, ParsedLayer01, Parser, PropKind, PropName,
-    PropValue, PropValueRef, PropertyKey, TileFeature, TileFeatureBuilder, TileLayer,
-    TileLayerBuilder, Unknown,
+    PropNamesIter, PropValue, PropValueRef, PropertyKey, TileFeature, TileFeatureBuilder,
+    TileLayer, TileLayerBuilder, Unknown,
 };
 // Crate-internal re-exports: allow internal modules to use `crate::Lazy` etc.
 // without exposing these implementation details to external users.

--- a/rust/mlt-core/src/utils/presence.rs
+++ b/rust/mlt-core/src/utils/presence.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::iter::FusedIterator;
 
 use bitvec::order::Lsb0;
 use bitvec::slice::BitSlice;
@@ -91,13 +92,17 @@ impl<T: Copy> Presence<'_, T> {
                 bits: None,
                 values,
                 feat_idx: 0,
+                end: values.len(),
                 dense_idx: 0,
+                back_dense: None,
             },
             Self::Bits { bits, values } => PresenceOptIter {
                 bits: Some(bits),
                 values,
                 feat_idx: 0,
+                end: bits.len(),
                 dense_idx: 0,
+                back_dense: None,
             },
         }
     }
@@ -127,44 +132,165 @@ pub struct PresenceOptIter<'p, T: Copy> {
     /// `None` for `AllPresent`, `Some(bits)` for `Bits`.
     bits: Option<&'p BitSlice<u8, Lsb0>>,
     values: &'p [T],
+    /// Next feature index to yield from the front.
     feat_idx: usize,
+    /// One past the last feature index to yield from the back.
+    end: usize,
+    /// Dense index of the value belonging to `feat_idx`.
     dense_idx: usize,
+    /// Dense index just past the next back value, filled in on the first
+    /// `next_back` call so forward-only iteration never pays for the `count_ones`.
+    back_dense: Option<usize>,
 }
 
 impl<T: Copy> Iterator for PresenceOptIter<'_, T> {
     type Item = Option<T>;
 
     fn next(&mut self) -> Option<Option<T>> {
+        if self.feat_idx >= self.end {
+            return None;
+        }
+        let idx = self.feat_idx;
+        self.feat_idx += 1;
         match self.bits {
-            None => {
-                let v = self.values.get(self.feat_idx).copied()?;
-                self.feat_idx += 1;
+            None => Some(Some(self.values[idx])),
+            Some(bits) if bits[idx] => {
+                let v = self.values[self.dense_idx];
+                self.dense_idx += 1;
                 Some(Some(v))
             }
+            Some(_) => Some(None),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.len();
+        (remaining, Some(remaining))
+    }
+}
+
+impl<T: Copy> DoubleEndedIterator for PresenceOptIter<'_, T> {
+    fn next_back(&mut self) -> Option<Option<T>> {
+        if self.feat_idx >= self.end {
+            return None;
+        }
+        self.end -= 1;
+        let idx = self.end;
+        match self.bits {
+            None => Some(Some(self.values[idx])),
             Some(bits) => {
-                if self.feat_idx >= bits.len() {
-                    return None;
-                }
-                let present = bits[self.feat_idx];
-                self.feat_idx += 1;
-                if present {
-                    let v = self.values[self.dense_idx];
-                    self.dense_idx += 1;
-                    Some(Some(v))
+                // Invariant: `back_dense` counts the present features in `0..=idx`.
+                let dense = self
+                    .back_dense
+                    .get_or_insert_with(|| bits[..=idx].count_ones());
+                if bits[idx] {
+                    *dense -= 1;
+                    Some(Some(self.values[*dense]))
                 } else {
                     Some(None)
                 }
             }
         }
     }
+}
 
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = match self.bits {
-            None => self.values.len().saturating_sub(self.feat_idx),
-            Some(bits) => bits.len().saturating_sub(self.feat_idx),
-        };
-        (remaining, Some(remaining))
+impl<T: Copy> ExactSizeIterator for PresenceOptIter<'_, T> {
+    fn len(&self) -> usize {
+        self.end - self.feat_idx
     }
 }
 
-impl<T: Copy> ExactSizeIterator for PresenceOptIter<'_, T> {}
+impl<T: Copy> FusedIterator for PresenceOptIter<'_, T> {}
+
+#[cfg(test)]
+mod tests {
+    use bitvec::bitvec;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::test_helpers::assert_size_hint_exact;
+
+    fn sparse(pattern: &[bool]) -> Presence<'static, u8> {
+        let mut bits = bitvec![u8, Lsb0;];
+        let mut values = Vec::new();
+        for (idx, &present) in pattern.iter().enumerate() {
+            bits.push(present);
+            if present {
+                values.push(u8::try_from(idx).unwrap());
+            }
+        }
+        Presence::Bits {
+            bits: Cow::Owned(bits),
+            values,
+        }
+    }
+
+    fn expected(pattern: &[bool]) -> Vec<Option<u8>> {
+        pattern
+            .iter()
+            .enumerate()
+            .map(|(idx, &p)| p.then(|| u8::try_from(idx).unwrap()))
+            .collect()
+    }
+
+    #[rstest]
+    #[case::empty(&[])]
+    #[case::single_present(&[true])]
+    #[case::single_absent(&[false])]
+    #[case::alternating(&[true, false, true, false, true])]
+    #[case::leading_absent(&[false, false, true, true, false, true, false])]
+    #[case::all_present(&[true; 9])]
+    #[case::all_absent(&[false; 9])]
+    #[case::spans_two_bytes(&[true, false, true, true, false, false, true, false, true, true, false])]
+    fn iter_optional_runs_backwards(#[case] pattern: &[bool]) {
+        let presence = sparse(pattern);
+        let want = expected(pattern);
+
+        assert_eq!(presence.iter_optional().collect::<Vec<_>>(), want);
+        assert_size_hint_exact(|| presence.iter_optional(), &want);
+
+        let mut back = presence.iter_optional().rev().collect::<Vec<_>>();
+        back.reverse();
+        assert_eq!(back, want);
+    }
+
+    #[rstest]
+    #[case::empty(&[])]
+    #[case::single(&[10])]
+    #[case::many(&[10, 20, 30, 40])]
+    fn iter_optional_runs_backwards_all_present(#[case] values: &[u8]) {
+        let presence = Presence::AllPresent(values.to_vec());
+        let want: Vec<_> = values.iter().copied().map(Some).collect();
+
+        assert_eq!(presence.iter_optional().collect::<Vec<_>>(), want);
+        assert_size_hint_exact(|| presence.iter_optional(), &want);
+
+        let mut back = presence.iter_optional().rev().collect::<Vec<_>>();
+        back.reverse();
+        assert_eq!(back, want);
+        assert_eq!(presence.iter_optional().next_back(), want.last().copied());
+    }
+
+    #[rstest]
+    #[case::sparse(&[true, false, true, false, true])]
+    #[case::all_absent(&[false, false])]
+    fn get_matches_iter_optional(#[case] pattern: &[bool]) {
+        let dense: Vec<u8> = expected(pattern).into_iter().flatten().collect();
+        for presence in [sparse(pattern), Presence::AllPresent(dense.clone())] {
+            let want = match presence {
+                Presence::AllPresent(_) => dense.iter().copied().map(Some).collect(),
+                Presence::Bits { .. } => expected(pattern),
+            };
+
+            assert_eq!(presence.feature_count(), want.len());
+            assert_eq!(presence.dense_values(), dense);
+            assert_eq!(presence.materialize(), want);
+            for (idx, &value) in want.iter().enumerate() {
+                assert_eq!(presence.get(idx), value);
+                assert_eq!(presence.is_present(idx), value.is_some());
+            }
+            assert_eq!(presence.get(want.len()), None);
+            assert!(!presence.is_present(want.len()));
+        }
+    }
+}

--- a/rust/mlt-core/src/utils/test_helpers.rs
+++ b/rust/mlt-core/src/utils/test_helpers.rs
@@ -1,9 +1,65 @@
 //! Shared helpers for unit tests, integration tests, and benchmarks.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Debug;
 
 use crate::decoder::Layer01;
 use crate::{Decoder, Layer, MltRefResult, Parser, PropValue, TileLayer};
+
+/// Assert that `len`/`size_hint` equal the number of items actually left, at every
+/// position reachable by consuming from the front, the back, or both alternately.
+///
+/// `make` must produce a fresh iterator over `expected` on each call.
+pub fn assert_size_hint_exact<I, T>(make: impl Fn() -> I, expected: &[T])
+where
+    I: ExactSizeIterator<Item = T> + DoubleEndedIterator,
+    T: PartialEq + Debug,
+{
+    fn check<I: ExactSizeIterator>(iter: &I, left: usize) {
+        assert_eq!(iter.len(), left, "len");
+        assert_eq!(iter.size_hint(), (left, Some(left)), "size_hint");
+    }
+
+    let count = expected.len();
+
+    for taken in 0..=count {
+        let mut iter = make();
+        for _ in 0..taken {
+            iter.next().expect("front item");
+        }
+        check(&iter, count - taken);
+        assert_eq!(iter.collect::<Vec<_>>().as_slice(), &expected[taken..]);
+    }
+
+    for taken in 0..=count {
+        let mut iter = make();
+        for _ in 0..taken {
+            iter.next_back().expect("back item");
+        }
+        check(&iter, count - taken);
+        assert_eq!(
+            iter.collect::<Vec<_>>().as_slice(),
+            &expected[..count - taken]
+        );
+    }
+
+    let mut iter = make();
+    let mut left = count;
+    check(&iter, left);
+    while left > 0 {
+        iter.next().expect("front item");
+        left -= 1;
+        check(&iter, left);
+        if left > 0 {
+            iter.next_back().expect("back item");
+            left -= 1;
+            check(&iter, left);
+        }
+    }
+    assert!(iter.next().is_none());
+    assert!(iter.next_back().is_none());
+    check(&iter, 0);
+}
 
 /// Default decoder for decoding in tests.
 #[must_use]


### PR DESCRIPTION
Implements `FusedIterator`, `size_hint`/`ExactSizeIterator` and `DoubleEndedIterator` for `PresenceOptIter` and the property-name iterators, unifying the two duplicated name-iterator implementations into one `PropNamesIter` over a `ColNames` trait.

Likely a minor performance boost in some impls, not likely to be major though.