### PR TITLE
chore(rust): extract the v1 layer encoder into encoder::encode01

### DIFF
--- a/rust/mlt-core/src/encoder/encode01.rs
+++ b/rust/mlt-core/src/encoder/encode01.rs
@@ -1,0 +1,34 @@
+//! Layer envelope and column ordering for tag `0x01` (v1) layers.
+
+use crate::MltResult;
+use crate::encoder::model::StagedLayer;
+use crate::encoder::property::encode::write_prop;
+use crate::encoder::{Codecs, Encoder, StagedId};
+
+/// Encode and serialize a staged layer as a v1 (tag `0x01`) body into `enc`.
+pub(crate) fn encode_into01(
+    layer: StagedLayer,
+    mut enc: Encoder,
+    codecs: &mut Codecs,
+) -> MltResult<Encoder> {
+    let column_count = usize::from(!matches!(layer.id, StagedId::None))
+        + 1 // geometry
+        + layer.properties.len();
+
+    let StagedLayer {
+        name,
+        extent,
+        id,
+        geometry,
+        properties,
+    } = layer;
+
+    id.write_to(&mut enc, codecs)?;
+    geometry.write_to(&mut enc, codecs)?;
+    for prop in properties {
+        write_prop(&prop, &mut enc, codecs)?;
+    }
+    enc.write_header01(&name, extent.get(), column_count)?;
+
+    Ok(enc)
+}

--- a/rust/mlt-core/src/encoder/mod.rs
+++ b/rust/mlt-core/src/encoder/mod.rs
@@ -1,4 +1,5 @@
 mod analyze;
+mod encode01;
 #[cfg(all(not(test), feature = "arbitrary"))]
 mod fuzzing;
 mod geometry;

--- a/rust/mlt-core/src/encoder/optimizer.rs
+++ b/rust/mlt-core/src/encoder/optimizer.rs
@@ -2,9 +2,8 @@ use bitvec::vec::BitVec;
 
 use crate::decoder::Morton;
 use crate::encoder::model::{CurveParams, StagedLayer, WireVersion};
-use crate::encoder::property::encode::write_properties;
 use crate::encoder::{
-    Codecs, Encoder, EncoderConfig, SortStrategy, StagedId, spatial_sort_likely_to_help,
+    Codecs, Encoder, EncoderConfig, SortStrategy, encode01, spatial_sort_likely_to_help,
 };
 use crate::tile::{PropKind, TileLayer};
 use crate::{MltError, MltResult, PropValue};
@@ -17,30 +16,12 @@ impl StagedLayer {
     /// trial calls this method on its own fresh `Encoder`, and only the
     /// `Encoder` with the smallest `total_len()` is kept.
     #[hotpath::measure]
-    pub fn encode_into(self, mut enc: Encoder, codecs: &mut Codecs) -> MltResult<Encoder> {
+    pub fn encode_into(self, enc: Encoder, codecs: &mut Codecs) -> MltResult<Encoder> {
         if self.name.is_empty() {
             return Err(MltError::MissingLayerName);
         }
         match enc.config().wire_version() {
-            WireVersion::V01 => {
-                let column_count = usize::from(!matches!(self.id, StagedId::None))
-                    + 1 // geometry
-                    + self.properties.len();
-
-                let Self {
-                    name,
-                    extent,
-                    id,
-                    geometry,
-                    properties,
-                } = self;
-
-                id.write_to(&mut enc, codecs)?;
-                geometry.write_to(&mut enc, codecs)?;
-                write_properties(&properties, &mut enc, codecs)?;
-                enc.write_header01(&name, extent.get(), column_count)?;
-                Ok(enc)
-            }
+            WireVersion::V01 => encode01::encode_into01(self, enc, codecs),
             #[cfg(feature = "unstable-v2")]
             WireVersion::V02 => Err(MltError::NotImplemented("mltv2 encoding")),
         }

--- a/rust/mlt-core/src/encoder/property/encode.rs
+++ b/rust/mlt-core/src/encoder/property/encode.rs
@@ -7,22 +7,13 @@ use crate::encoder::{
     StagedStrings,
 };
 
-/// Encode all property columns and write them to `enc`.
+/// Encode a single property column, dispatching on variant.
 #[hotpath::measure]
-pub fn write_properties(
-    props: &[StagedProperty],
+pub(crate) fn write_prop(
+    prop: &StagedProperty,
     enc: &mut Encoder,
     codecs: &mut Codecs,
 ) -> MltResult<()> {
-    for prop in props {
-        write_prop(prop, enc, codecs)?;
-    }
-    Ok(())
-}
-
-/// Encode a single property column, dispatching on variant.
-#[hotpath::measure]
-fn write_prop(prop: &StagedProperty, enc: &mut Encoder, codecs: &mut Codecs) -> MltResult<()> {
     use ColumnType as CT;
     use StagedProperty as D;
 

--- a/rust/mlt-core/src/encoder/property/tests.rs
+++ b/rust/mlt-core/src/encoder/property/tests.rs
@@ -7,7 +7,7 @@ use rstest::rstest;
 use crate::encoder::SortStrategy::Unsorted;
 use crate::encoder::model::{ExplicitEncoder, StagedLayer, StrEncoding};
 use crate::encoder::optimizer::{Presence, PropertyTypedStats, SharedDictRole};
-use crate::encoder::property::encode::write_properties;
+use crate::encoder::property::encode::write_prop;
 use crate::encoder::{
     Codecs, Encoder, EncoderConfig, IntEncoder, LogicalEncoder, PhysicalEncoder, StagedId,
     StagedProperty, StagedSharedDict, stage_tile,
@@ -1176,7 +1176,9 @@ fn no_nulls_produces_encoded_output() {
     let props = vec![StagedProperty::u32("pop", vec![1, 2, 3])];
     let mut enc = Encoder::default();
     let mut codecs = Codecs::default();
-    write_properties(&props, &mut enc, &mut codecs).unwrap();
+    for prop in props {
+        write_prop(&prop, &mut enc, &mut codecs).unwrap();
+    }
     assert!(
         !enc.meta().is_empty(),
         "non-null column should write one column"
@@ -1188,7 +1190,9 @@ fn all_nulls_encodes_without_error() {
     let props = vec![StagedProperty::opt_i32("x", vec![None, None, None])];
     let mut enc = Encoder::default();
     let mut codecs = Codecs::default();
-    write_properties(&props, &mut enc, &mut codecs).unwrap();
+    for prop in props {
+        write_prop(&prop, &mut enc, &mut codecs).unwrap();
+    }
 }
 
 #[test]
@@ -1196,7 +1200,9 @@ fn sequential_u32_encodes_successfully() {
     let props = vec![StagedProperty::u32("id", (0u32..1_000).collect())];
     let mut enc = Encoder::default();
     let mut codecs = Codecs::default();
-    write_properties(&props, &mut enc, &mut codecs).unwrap();
+    for prop in props {
+        write_prop(&prop, &mut enc, &mut codecs).unwrap();
+    }
     assert_ne!(enc.meta(), [] as [u8; 0]);
 }
 
@@ -1205,7 +1211,9 @@ fn constant_u32_encodes_successfully() {
     let props = vec![StagedProperty::u32("val", vec![42u32; 500])];
     let mut enc = Encoder::default();
     let mut codecs = Codecs::default();
-    write_properties(&props, &mut enc, &mut codecs).unwrap();
+    for prop in props {
+        write_prop(&prop, &mut enc, &mut codecs).unwrap();
+    }
     assert_ne!(enc.meta(), [] as [u8; 0]);
 }
 
@@ -1369,6 +1377,8 @@ fn encode_with_explicit_encoder_works() {
     let props = vec![StagedProperty::u32("id", (1_000u32..2_000).collect())];
     let mut enc = Encoder::default();
     let mut codecs = Codecs::default();
-    write_properties(&props, &mut enc, &mut codecs).unwrap();
+    for prop in props {
+        write_prop(&prop, &mut enc, &mut codecs).unwrap();
+    }
     assert_ne!(enc.meta(), [] as [u8; 0]);
 }


### PR DESCRIPTION
Extracts the v1 layer envelope and column ordering out of `StagedLayer::encode_into` into `encoder::encode01`, so the wire-version dispatch is a two-line match; pure move, no behaviour change.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>