### PR TITLE
chore(rust): release

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -204,7 +204,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -344,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.143.0"
+version = "1.144.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ade5433c9561daac7c0c6bc910f1240b4f8ec0d6148b0b463aac0691d747c9"
+checksum = "30dc8bf6baaf7d46336a0ca2c69f223d9b90d7a801fb3e28f7ea17b00dc6b1de"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -371,7 +371,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.5.0",
  "http-body 1.1.0",
- "lru 0.16.4",
+ "lru",
  "percent-encoding",
  "regex-lite",
  "sha2 0.11.0",
@@ -481,12 +481,12 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.18",
+ "h2 0.4.19",
  "http 0.2.12",
  "http 1.5.0",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper 1.11.0",
+ "hyper 1.11.1",
  "hyper-rustls 0.24.2",
  "hyper-rustls 0.27.9",
  "hyper-util",
@@ -653,7 +653,7 @@ dependencies = [
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
- "hyper 1.11.0",
+ "hyper 1.11.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -922,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -946,12 +946,12 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -1033,7 +1033,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1065,9 +1065,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -1202,9 +1202,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -1236,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -1453,7 +1453,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1475,7 +1475,7 @@ checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
  "darling_core 0.24.1",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1587,7 +1587,7 @@ dependencies = [
  "diplomat_core",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1607,7 +1607,7 @@ dependencies = [
  "serde",
  "smallvec",
  "strck",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1639,7 +1639,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1949,12 +1949,13 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2090,7 +2091,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2301,9 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2413,9 +2414,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -2673,15 +2674,15 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.18",
+ "h2 0.4.19",
  "http 1.5.0",
  "http-body 1.1.0",
  "httparse",
@@ -2715,7 +2716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.5.0",
- "hyper 1.11.0",
+ "hyper 1.11.1",
  "hyper-util",
  "rustls 0.23.43",
  "rustls-native-certs",
@@ -2737,7 +2738,7 @@ dependencies = [
  "futures-util",
  "http 1.5.0",
  "http-body 1.1.0",
- "hyper 1.11.0",
+ "hyper 1.11.1",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -2932,9 +2933,9 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -2984,7 +2985,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3010,9 +3011,9 @@ checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is-macro"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4"
+checksum = "8267aa6001e25494f3015f9663bbd88a18240c74483afa5f0934a1b3e4c388e9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3201,9 +3202,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
 dependencies = [
  "libc",
 ]
@@ -3257,24 +3258,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
-dependencies = [
- "hashbrown 0.16.1",
-]
-
-[[package]]
-name = "lru"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+checksum = "0d317b4b9eb398e6acce275758ec6125535505e7a146fb1a9b8bda2451b0ff4c"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -3444,9 +3436,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -3466,7 +3458,7 @@ dependencies = [
 
 [[package]]
 name = "mlt"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3502,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-core"
-version = "0.12.6"
+version = "0.12.7"
 dependencies = [
  "arbitrary",
  "bitvec",
@@ -3543,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-ffi"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
@@ -3552,7 +3544,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-py"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "mlt-core",
  "pyo3",
@@ -3573,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-wasm"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "js-sys",
  "mlt-core",
@@ -3882,9 +3874,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "5.3.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+checksum = "8c7c9e0d9b23589f26070720bac724174bfec1083e82f7854cdd0267518343c0"
 dependencies = [
  "num-traits",
 ]
@@ -4090,7 +4082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.7",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -4428,7 +4420,7 @@ dependencies = [
  "maplit",
  "num-complex 0.4.6",
  "numpy",
- "ordered-float 5.3.0",
+ "ordered-float 5.5.0",
  "pyo3",
  "pyo3-stub-gen-derive",
  "rustpython-parser",
@@ -4592,9 +4584,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4749,7 +4741,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
- "lru 0.18.2",
+ "lru",
  "palette",
  "serde",
  "strum",
@@ -4894,7 +4886,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4951,7 +4943,7 @@ dependencies = [
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
- "hyper 1.11.0",
+ "hyper 1.11.1",
  "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
@@ -4991,7 +4983,7 @@ dependencies = [
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
- "hyper 1.11.0",
+ "hyper 1.11.1",
  "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
@@ -5267,7 +5259,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.14",
+ "rustls-webpki 0.103.15",
  "subtle",
  "zeroize",
 ]
@@ -5308,7 +5300,7 @@ dependencies = [
  "rustls 0.23.43",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.14",
+ "rustls-webpki 0.103.15",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -5333,9 +5325,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.14"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -5474,7 +5466,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5563,7 +5555,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5574,7 +5566,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5672,7 +5664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -5694,7 +5686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -6178,9 +6170,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6421,7 +6413,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6553,7 +6545,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6738,9 +6730,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
-version = "2.1.3"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
+checksum = "5283634e518fe9e82c7b20520bb4bc209009fd16c82077c802f8111ecbb0117a"
 
 [[package]]
 name = "typenum"
@@ -6887,7 +6879,7 @@ dependencies = [
  "getopts",
  "log",
  "phf_codegen",
- "rand 0.8.7",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -6940,9 +6932,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.1"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "atomic",
  "getrandom 0.4.3",
@@ -7635,7 +7627,7 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -7646,6 +7638,12 @@ checksum = "70b40401a28d86ce16a330b863b86fd7dbee4d7c940587ab09ab8c019f9e3fdf"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -50,7 +50,7 @@ js-sys = "0.3"
 martin-tile-utils = "0.7"
 mbtiles = { version = "0.19", default-features = false, features = ["transcode"] }
 mimalloc = "0.1.52"
-mlt-core = { version = "0.12.6", path = "mlt-core" }
+mlt-core = { version = "0.12.7", path = "mlt-core" }
 moka = { version = "0.12", features = ["sync"] }
 num-traits = "0.2.19"
 num_enum = "0.7.6"

--- a/rust/mlt-core/CHANGELOG.md
+++ b/rust/mlt-core/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.7](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-core-v0.12.6...rust-mlt-core-v0.12.7) - 2026-08-31
+
+### Added
+
+- *(rust)* implement basic header and metadata format ([#1571](https://github.com/maplibre/maplibre-tile-spec/pull/1571))
+- *(rust)* inital v2 plumbing ([#1570](https://github.com/maplibre/maplibre-tile-spec/pull/1570))
+
+### Fixed
+
+- *(java)* move the Java nested-property fixtures to 0x02-java ([#1582](https://github.com/maplibre/maplibre-tile-spec/pull/1582))
+
+### Other
+
+- *(rust)* share one encode/decode helper across the fuzz targets ([#1588](https://github.com/maplibre/maplibre-tile-spec/pull/1588))
+- *(rust)* make RleMeta an enum over the RLE stream layout ([#1587](https://github.com/maplibre/maplibre-tile-spec/pull/1587))
+- *(rust)* express wire enum discriminants as their bit patterns ([#1586](https://github.com/maplibre/maplibre-tile-spec/pull/1586))
+- *(rust)* split the geometry encoder into encode01 and streams ([#1580](https://github.com/maplibre/maplibre-tile-spec/pull/1580))
+- *(rust)* extract the v1 layer encoder into encoder::encode01 ([#1579](https://github.com/maplibre/maplibre-tile-spec/pull/1579))
+- *(rust)* move the public tile model out of decoder into crate::tile ([#1578](https://github.com/maplibre/maplibre-tile-spec/pull/1578))
+- *(rust)* split decoder::root into limits and root01 ([#1577](https://github.com/maplibre/maplibre-tile-spec/pull/1577))
+
 ## [0.12.6](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-core-v0.12.5...rust-mlt-core-v0.12.6) - 2026-08-21
 
 ### Other

--- a/rust/mlt-core/Cargo.toml
+++ b/rust/mlt-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-core"
 description = "MapLibre Tile library code"
-version = "0.12.6"
+version = "0.12.7"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/rust/mlt-ffi/CHANGELOG.md
+++ b/rust/mlt-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-ffi-v0.1.14...rust-mlt-ffi-v0.1.15) - 2026-08-31
+
+### Other
+
+- updated the following local packages: mlt-core
+
 ## [0.1.14](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-ffi-v0.1.13...rust-mlt-ffi-v0.1.14) - 2026-08-21
 
 ### Other

--- a/rust/mlt-ffi/Cargo.toml
+++ b/rust/mlt-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-ffi"
 description = "Diplomat FFI bindings for mlt-core"
-version = "0.1.14"
+version = "0.1.15"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/rust/mlt-py/CHANGELOG.md
+++ b/rust/mlt-py/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.28](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.27...python-mlt-v0.1.28) - 2026-08-31
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.27](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.26...python-mlt-v0.1.27) - 2026-08-21
 
 ### Other

--- a/rust/mlt-py/Cargo.toml
+++ b/rust/mlt-py/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-py"
 description = "Python bindings for MapLibre Tile (MLT) format via PyO3"
-version = "0.1.27"
+version = "0.1.28"
 readme = "README.md"
 repository.workspace = true
 edition.workspace = true

--- a/rust/mlt-py/pyproject.toml
+++ b/rust/mlt-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "maplibre-tiles"
-version = "0.1.27"
+version = "0.1.28"
 description = "Python bindings for MapLibre Tile (MLT) format"
 requires-python = ">=3.10"
 license = { text = "MIT OR Apache-2.0" }

--- a/rust/mlt-wasm/CHANGELOG.md
+++ b/rust/mlt-wasm/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.21](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-wasm-v0.1.20...rust-mlt-wasm-v0.1.21) - 2026-08-31
+
+### Added
+
+- *(rust)* implement basic header and metadata format ([#1571](https://github.com/maplibre/maplibre-tile-spec/pull/1571))
+
+### Fixed
+
+- *(java)* move the Java nested-property fixtures to 0x02-java ([#1582](https://github.com/maplibre/maplibre-tile-spec/pull/1582))
+
 ## [0.1.20](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-wasm-v0.1.19...rust-mlt-wasm-v0.1.20) - 2026-08-21
 
 ### Other

--- a/rust/mlt-wasm/Cargo.toml
+++ b/rust/mlt-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-wasm"
 description = "WebAssembly bindings for the MapLibre Tile (MLT) format"
-version = "0.1.20"
+version = "0.1.21"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/rust/mlt-wasm/package-lock.json
+++ b/rust/mlt-wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/mlt-wasm",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/mlt-wasm",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@mapbox/point-geometry": "1.1.0"

--- a/rust/mlt-wasm/package.json
+++ b/rust/mlt-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/mlt-wasm",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "WebAssembly-backed MapLibre Tile (MLT) decoder",
   "type": "module",
   "main": "dist/index.js",

--- a/rust/mlt/CHANGELOG.md
+++ b/rust/mlt/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.26](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.25...rust-mlt-v0.1.26) - 2026-08-31
+
+### Added
+
+- *(rust)* inital v2 plumbing ([#1570](https://github.com/maplibre/maplibre-tile-spec/pull/1570))
+
 ## [0.1.25](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.24...rust-mlt-v0.1.25) - 2026-08-21
 
 ### Other

--- a/rust/mlt/Cargo.toml
+++ b/rust/mlt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt"
 description = "MapLibre Tile Tools"
-version = "0.1.25"
+version = "0.1.26"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `mlt-core`: 0.12.6 -> 0.12.7 (✓ API compatible changes)
* `mlt`: 0.1.25 -> 0.1.26
* `mlt-py`: 0.1.27 -> 0.1.28
* `mlt-wasm`: 0.1.20 -> 0.1.21
* `mlt-ffi`: 0.1.14 -> 0.1.15

<details><summary><i><b>Changelog</b></i></summary><p>

## `mlt-core`

<blockquote>

## [0.12.7](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-core-v0.12.6...rust-mlt-core-v0.12.7) - 2026-08-31

### Added

- *(rust)* implement basic header and metadata format ([#1571](https://github.com/maplibre/maplibre-tile-spec/pull/1571))
- *(rust)* inital v2 plumbing ([#1570](https://github.com/maplibre/maplibre-tile-spec/pull/1570))

### Fixed

- *(java)* move the Java nested-property fixtures to 0x02-java ([#1582](https://github.com/maplibre/maplibre-tile-spec/pull/1582))

### Other

- *(rust)* share one encode/decode helper across the fuzz targets ([#1588](https://github.com/maplibre/maplibre-tile-spec/pull/1588))
- *(rust)* make RleMeta an enum over the RLE stream layout ([#1587](https://github.com/maplibre/maplibre-tile-spec/pull/1587))
- *(rust)* express wire enum discriminants as their bit patterns ([#1586](https://github.com/maplibre/maplibre-tile-spec/pull/1586))
- *(rust)* split the geometry encoder into encode01 and streams ([#1580](https://github.com/maplibre/maplibre-tile-spec/pull/1580))
- *(rust)* extract the v1 layer encoder into encoder::encode01 ([#1579](https://github.com/maplibre/maplibre-tile-spec/pull/1579))
- *(rust)* move the public tile model out of decoder into crate::tile ([#1578](https://github.com/maplibre/maplibre-tile-spec/pull/1578))
- *(rust)* split decoder::root into limits and root01 ([#1577](https://github.com/maplibre/maplibre-tile-spec/pull/1577))
</blockquote>

## `mlt`

<blockquote>

## [0.1.26](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.25...rust-mlt-v0.1.26) - 2026-08-31

### Added

- *(rust)* inital v2 plumbing ([#1570](https://github.com/maplibre/maplibre-tile-spec/pull/1570))
</blockquote>

## `mlt-py`

<blockquote>

## [0.1.28](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.27...python-mlt-v0.1.28) - 2026-08-31

### Other

- update Cargo.lock dependencies
</blockquote>

## `mlt-wasm`

<blockquote>

## [0.1.21](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-wasm-v0.1.20...rust-mlt-wasm-v0.1.21) - 2026-08-31

### Added

- *(rust)* implement basic header and metadata format ([#1571](https://github.com/maplibre/maplibre-tile-spec/pull/1571))

### Fixed

- *(java)* move the Java nested-property fixtures to 0x02-java ([#1582](https://github.com/maplibre/maplibre-tile-spec/pull/1582))
</blockquote>

## `mlt-ffi`

<blockquote>

## [0.1.15](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-ffi-v0.1.14...rust-mlt-ffi-v0.1.15) - 2026-08-31

### Other

- updated the following local packages: mlt-core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).