### PR TITLE
chore(rust): express wire enum discriminants as their bit patterns

### DIFF
--- a/rust/mlt-core/src/decoder/mod.rs
+++ b/rust/mlt-core/src/decoder/mod.rs
@@ -39,6 +39,6 @@ pub(crate) use property::{
     RawSharedDictEncoding, RawSharedDictItem, RawStrings, RawStringsEncoding,
 };
 pub(crate) use stream::model::{
-    DictionaryType, IntEncoding, LengthType, LogicalEncoding, LogicalTechnique, LogicalValue,
-    Morton, OffsetType, PhysicalEncoding, RawStream, RleMeta, StreamMeta, StreamType,
+    DictionaryType, IntEncoding, LengthType, LogicalCombination, LogicalEncoding, LogicalTechnique,
+    LogicalValue, Morton, OffsetType, PhysicalEncoding, RawStream, RleMeta, StreamMeta, StreamType,
 };

--- a/rust/mlt-core/src/decoder/model01.rs
+++ b/rust/mlt-core/src/decoder/model01.rs
@@ -12,6 +12,9 @@ use crate::MltError::ParsingColumnType;
 use crate::utils::{BinarySerializer as _, parse_string, parse_u8};
 use crate::{MltRefResult, Parser};
 
+/// Bit 0 of the column type byte: the column has a presence stream.
+const OPTIONAL_FLAG: u8 = 0b0000_0001;
+
 /// Column definition
 #[derive(Debug, PartialEq)]
 pub struct Column<'a> {
@@ -20,36 +23,36 @@ pub struct Column<'a> {
     pub(crate) children: Vec<Self>,
 }
 
-/// Column data type, as stored in the tile
+/// Column data type, as stored in the tile.
 #[derive(Debug, Clone, Copy, PartialEq, TryFromPrimitive)]
 #[repr(u8)]
 pub enum ColumnType {
-    Id = 0,
-    OptId = 1,
-    LongId = 2,
-    OptLongId = 3,
-    Geometry = 4,
-    Bool = 10,
-    OptBool = 11,
-    I8 = 12,
-    OptI8 = 13,
-    U8 = 14,
-    OptU8 = 15,
-    I32 = 16,
-    OptI32 = 17,
-    U32 = 18,
-    OptU32 = 19,
-    I64 = 20,
-    OptI64 = 21,
-    U64 = 22,
-    OptU64 = 23,
-    F32 = 24,
-    OptF32 = 25,
-    F64 = 26,
-    OptF64 = 27,
-    Str = 28,
-    OptStr = 29,
-    SharedDict = 30,
+    Id = 0b0000_0000,
+    OptId = 0b0000_0001,
+    LongId = 0b0000_0010,
+    OptLongId = 0b0000_0011,
+    Geometry = 0b0000_0100,
+    Bool = 0b0000_1010,
+    OptBool = 0b0000_1011,
+    I8 = 0b0000_1100,
+    OptI8 = 0b0000_1101,
+    U8 = 0b0000_1110,
+    OptU8 = 0b0000_1111,
+    I32 = 0b0001_0000,
+    OptI32 = 0b0001_0001,
+    U32 = 0b0001_0010,
+    OptU32 = 0b0001_0011,
+    I64 = 0b0001_0100,
+    OptI64 = 0b0001_0101,
+    U64 = 0b0001_0110,
+    OptU64 = 0b0001_0111,
+    F32 = 0b0001_1000,
+    OptF32 = 0b0001_1001,
+    F64 = 0b0001_1010,
+    OptF64 = 0b0001_1011,
+    Str = 0b0001_1100,
+    OptStr = 0b0001_1101,
+    SharedDict = 0b0001_1110,
 }
 
 impl Column<'_> {
@@ -104,6 +107,6 @@ impl ColumnType {
     /// Check if the column type has a presence stream
     #[must_use]
     pub(crate) fn is_optional(self) -> bool {
-        (self as u8) & 1 != 0
+        (self as u8) & OPTIONAL_FLAG != 0
     }
 }

--- a/rust/mlt-core/src/decoder/stream/header01.rs
+++ b/rust/mlt-core/src/decoder/stream/header01.rs
@@ -25,8 +25,8 @@ use usize_cast::IntoUsize as _;
 use crate::MltError::ParsingStreamType;
 use crate::codecs::varint::parse_varint;
 use crate::decoder::{
-    DictionaryType, IntEncoding, LengthType, LogicalEncoding, LogicalTechnique, Morton, OffsetType,
-    PhysicalEncoding, RawStream, RleMeta, StreamMeta, StreamType,
+    DictionaryType, IntEncoding, LengthType, LogicalCombination, LogicalEncoding, LogicalTechnique,
+    Morton, OffsetType, PhysicalEncoding, RawStream, RleMeta, StreamMeta, StreamType,
 };
 use crate::errors::{AsMltError as _, fail_if_invalid_stream_size};
 use crate::utils::{BinarySerializer as _, parse_u8, take};
@@ -47,6 +47,9 @@ const LOGICAL2_MASK: u8 = 0b0001_1100;
 /// Distance between the primary logical field and the secondary one.
 const LOGICAL2_SHIFT: u32 = 3;
 
+/// Mask of the encoding byte holding both logical fields, i.e. a [`LogicalCombination`].
+const LOGICAL_MASK: u8 = LOGICAL1_MASK | LOGICAL2_MASK;
+
 /// Mask of the encoding byte holding the [`PhysicalEncoding`].
 const PHYSICAL_MASK: u8 = 0b0000_0011;
 
@@ -60,14 +63,21 @@ enum CategoryField {
     Length = 0b0011_0000,
 }
 
-/// Read the secondary logical field, lifted into the primary field's bit positions.
-fn parse_logical2(encoding_byte: u8) -> MltResult<LogicalTechnique> {
-    LogicalTechnique::parse((encoding_byte & LOGICAL2_MASK) << LOGICAL2_SHIFT)
+/// Read both logical fields of the encoding byte as the combination they spell out.
+///
+/// Combinations that are not legal on the wire are reported as [`MltError::InvalidLogicalEncodings`]
+/// naming both fields, so decompose the byte again on that path.
+fn parse_logical(encoding_byte: u8) -> MltResult<LogicalCombination> {
+    LogicalCombination::try_from(encoding_byte & LOGICAL_MASK).or_else(|_| {
+        let primary = LogicalTechnique::parse(encoding_byte & LOGICAL1_MASK)?;
+        let secondary = LogicalTechnique::parse((encoding_byte & LOGICAL2_MASK) << LOGICAL2_SHIFT)?;
+        Err(MltError::InvalidLogicalEncodings(primary, secondary))
+    })
 }
 
-/// Place a technique into the encoding byte's secondary logical field.
-fn logical2_bits(technique: LogicalTechnique) -> u8 {
-    (technique as u8) >> LOGICAL2_SHIFT
+/// Assemble the encoding byte from its logical and physical fields.
+fn encoding_byte(logical: LogicalCombination, physical: PhysicalEncoding) -> u8 {
+    logical as u8 | physical as u8
 }
 
 /// Parse the v1 `stream_type` byte: category in the high nibble, subtype in the low nibble.
@@ -115,33 +125,32 @@ pub(crate) fn parse_stream_meta<'a>(
     is_bool: bool,
     parser: &mut Parser,
 ) -> MltRefResult<'a, (StreamMeta, u32)> {
-    use LogicalTechnique as LT;
+    use LogicalCombination as LC;
 
     let (input, st_byte) = parse_u8(input)?;
     let stream_type = stream_type_from_byte(st_byte).ok_or(ParsingStreamType(st_byte))?;
 
     let (input, val) = parse_u8(input)?;
-    let logical1 = LT::parse(val & LOGICAL1_MASK)?;
-    let logical2 = parse_logical2(val)?;
+    let logical = parse_logical(val)?;
     let physical_encoding = PhysicalEncoding::parse(val & PHYSICAL_MASK)?;
 
     let (input, num_values) = parse_varint::<u32>(input)?;
     let (input, byte_length) = parse_varint::<u32>(input)?;
 
     let mut input = input;
-    let logical_encoding = match (logical1, logical2) {
-        (LT::None | LT::Delta | LT::ComponentwiseDelta | LT::PseudoDecimal, LT::None) => {
+    let logical_encoding = match logical {
+        LC::None | LC::Delta | LC::ComponentwiseDelta | LC::PseudoDecimal => {
             // Reserve decoded memory upper bound: worst case u64 = 8 bytes per value
             let decoded_bytes = num_values.saturating_mul(8);
             parser.reserve(decoded_bytes)?;
-            match logical1 {
-                LT::None => LogicalEncoding::None,
-                LT::Delta => LogicalEncoding::Delta,
-                LT::ComponentwiseDelta => LogicalEncoding::ComponentwiseDelta,
+            match logical {
+                LC::None => LogicalEncoding::None,
+                LC::Delta => LogicalEncoding::Delta,
+                LC::ComponentwiseDelta => LogicalEncoding::ComponentwiseDelta,
                 _ => LogicalEncoding::PseudoDecimal,
             }
         }
-        (LT::Delta, LT::Rle) | (LT::Rle, LT::None) => {
+        LC::Rle | LC::DeltaRle => {
             let runs;
             let num_rle_values;
             if is_bool {
@@ -158,13 +167,13 @@ pub(crate) fn parse_stream_meta<'a>(
                 runs,
                 num_rle_values,
             };
-            if logical1 == LT::Rle {
+            if logical == LC::Rle {
                 LogicalEncoding::Rle(rle)
             } else {
                 LogicalEncoding::DeltaRle(rle)
             }
         }
-        (LT::Morton, LT::None | LT::Rle | LT::Delta) => {
+        LC::Morton | LC::MortonRle | LC::MortonDelta => {
             // Reserve decoded memory upper bound: worst case u64 = 8 bytes per value
             let decoded_bytes = num_values.saturating_mul(8);
             parser.reserve(decoded_bytes)?;
@@ -173,13 +182,12 @@ pub(crate) fn parse_stream_meta<'a>(
             (input, bits) = parse_varint::<u32>(input)?;
             (input, shift) = parse_varint::<u32>(input)?;
             let morton = Morton::new(bits, shift)?;
-            match logical2 {
-                LT::Rle => LogicalEncoding::MortonRle(morton),
-                LT::Delta => LogicalEncoding::MortonDelta(morton),
+            match logical {
+                LC::MortonRle => LogicalEncoding::MortonRle(morton),
+                LC::MortonDelta => LogicalEncoding::MortonDelta(morton),
                 _ => LogicalEncoding::Morton(morton),
             }
         }
-        _ => Err(MltError::InvalidLogicalEncodings(logical1, logical2))?,
     };
 
     let meta = StreamMeta::new(
@@ -200,22 +208,22 @@ pub(crate) fn write_stream_meta<W: io::Write>(
     is_bool: bool,
     byte_length: u32,
 ) -> MltResult<()> {
+    use LogicalCombination as LC;
     use LogicalEncoding as LE;
-    use LogicalTechnique as LT;
 
     writer.write_u8(stream_type_to_byte(meta.stream_type))?;
-    let (logical1, logical2) = match meta.encoding.logical {
-        LE::None => (LT::None, LT::None),
-        LE::Delta => (LT::Delta, LT::None),
-        LE::DeltaRle(_) => (LT::Delta, LT::Rle),
-        LE::ComponentwiseDelta => (LT::ComponentwiseDelta, LT::None),
-        LE::Rle(_) => (LT::Rle, LT::None),
-        LE::Morton(_) => (LT::Morton, LT::None),
-        LE::MortonRle(_) => (LT::Morton, LT::Rle),
-        LE::MortonDelta(_) => (LT::Morton, LT::Delta),
-        LE::PseudoDecimal => (LT::PseudoDecimal, LT::None),
+    let logical = match meta.encoding.logical {
+        LE::None => LC::None,
+        LE::Delta => LC::Delta,
+        LE::DeltaRle(_) => LC::DeltaRle,
+        LE::ComponentwiseDelta => LC::ComponentwiseDelta,
+        LE::Rle(_) => LC::Rle,
+        LE::Morton(_) => LC::Morton,
+        LE::MortonRle(_) => LC::MortonRle,
+        LE::MortonDelta(_) => LC::MortonDelta,
+        LE::PseudoDecimal => LC::PseudoDecimal,
     };
-    writer.write_u8(logical1 as u8 | logical2_bits(logical2) | meta.encoding.physical as u8)?;
+    writer.write_u8(encoding_byte(logical, meta.encoding.physical))?;
     writer.write_varint(meta.num_values)?;
     writer.write_varint(byte_length)?;
 
@@ -333,6 +341,11 @@ mod tests {
 
     const DATA: StreamType = StreamType::Data(DictionaryType::None);
 
+    /// Place two techniques into the logical fields of the encoding byte.
+    fn logical_bits(primary: LogicalTechnique, secondary: LogicalTechnique) -> u8 {
+        primary as u8 | ((secondary as u8) >> LOGICAL2_SHIFT)
+    }
+
     fn meta(logical: LogicalEncoding, physical: PhysicalEncoding, num: u32) -> StreamMeta {
         StreamMeta::new(DATA, IntEncoding::new(logical, physical), num)
     }
@@ -401,10 +414,59 @@ mod tests {
         assert_eq!(stream.data, payload);
     }
 
+    #[rstest]
+    #[case::none(
+        LogicalCombination::None,
+        LogicalTechnique::None,
+        LogicalTechnique::None
+    )]
+    #[case::delta(
+        LogicalCombination::Delta,
+        LogicalTechnique::Delta,
+        LogicalTechnique::None
+    )]
+    #[case::delta_rle(
+        LogicalCombination::DeltaRle,
+        LogicalTechnique::Delta,
+        LogicalTechnique::Rle
+    )]
+    #[case::cw_delta(
+        LogicalCombination::ComponentwiseDelta,
+        LogicalTechnique::ComponentwiseDelta,
+        LogicalTechnique::None
+    )]
+    #[case::rle(LogicalCombination::Rle, LogicalTechnique::Rle, LogicalTechnique::None)]
+    #[case::morton(
+        LogicalCombination::Morton,
+        LogicalTechnique::Morton,
+        LogicalTechnique::None
+    )]
+    #[case::morton_delta(
+        LogicalCombination::MortonDelta,
+        LogicalTechnique::Morton,
+        LogicalTechnique::Delta
+    )]
+    #[case::morton_rle(
+        LogicalCombination::MortonRle,
+        LogicalTechnique::Morton,
+        LogicalTechnique::Rle
+    )]
+    #[case::pseudo_decimal(
+        LogicalCombination::PseudoDecimal,
+        LogicalTechnique::PseudoDecimal,
+        LogicalTechnique::None
+    )]
+    fn combination_holds_both_field_bits(
+        #[case] combination: LogicalCombination,
+        #[case] primary: LogicalTechnique,
+        #[case] secondary: LogicalTechnique,
+    ) {
+        assert_eq!(combination as u8, logical_bits(primary, secondary));
+    }
+
     #[test]
     fn rejects_invalid_logical_combination() {
-        let enc_byte =
-            LogicalTechnique::ComponentwiseDelta as u8 | logical2_bits(LogicalTechnique::Rle);
+        let enc_byte = logical_bits(LogicalTechnique::ComponentwiseDelta, LogicalTechnique::Rle);
         let buf = [0u8, enc_byte, 0, 0];
         let err = parse_stream(&buf, &mut parser()).unwrap_err();
         assert!(matches!(err, MltError::InvalidLogicalEncodings(_, _)));

--- a/rust/mlt-core/src/decoder/stream/header01.rs
+++ b/rust/mlt-core/src/decoder/stream/header01.rs
@@ -19,6 +19,7 @@
 use std::io;
 
 use integer_encoding::VarIntWriter as _;
+use num_enum::TryFromPrimitive;
 use usize_cast::IntoUsize as _;
 
 use crate::MltError::ParsingStreamType;
@@ -31,40 +32,74 @@ use crate::errors::{AsMltError as _, fail_if_invalid_stream_size};
 use crate::utils::{BinarySerializer as _, parse_u8, take};
 use crate::{MltError, MltRefResult, MltResult, Parser};
 
+/// Mask of the `stream_type` byte holding the [`CategoryField`].
+const CATEGORY_MASK: u8 = 0b1111_0000;
+
+/// Mask of the `stream_type` byte holding the subtype.
+const SUBTYPE_MASK: u8 = 0b0000_1111;
+
+/// Mask of the encoding byte holding the primary [`LogicalTechnique`].
+const LOGICAL1_MASK: u8 = 0b1110_0000;
+
+/// Mask of the encoding byte holding the secondary [`LogicalTechnique`].
+const LOGICAL2_MASK: u8 = 0b0001_1100;
+
+/// Distance between the primary logical field and the secondary one.
+const LOGICAL2_SHIFT: u32 = 3;
+
+/// Mask of the encoding byte holding the [`PhysicalEncoding`].
+const PHYSICAL_MASK: u8 = 0b0000_0011;
+
+/// Category field (bits 7-4 of the `stream_type` byte), already shifted into place.
+#[derive(Debug, Clone, Copy, PartialEq, TryFromPrimitive)]
+#[repr(u8)]
+enum CategoryField {
+    Present = 0b0000_0000,
+    Data = 0b0001_0000,
+    Offset = 0b0010_0000,
+    Length = 0b0011_0000,
+}
+
+/// Read the secondary logical field, lifted into the primary field's bit positions.
+fn parse_logical2(encoding_byte: u8) -> MltResult<LogicalTechnique> {
+    LogicalTechnique::parse((encoding_byte & LOGICAL2_MASK) << LOGICAL2_SHIFT)
+}
+
+/// Place a technique into the encoding byte's secondary logical field.
+fn logical2_bits(technique: LogicalTechnique) -> u8 {
+    (technique as u8) >> LOGICAL2_SHIFT
+}
+
 /// Parse the v1 `stream_type` byte: category in the high nibble, subtype in the low nibble.
 fn stream_type_from_byte(value: u8) -> Option<StreamType> {
-    let high4 = value >> 4;
-    let low4 = value & 0x0F;
-    Some(match high4 {
-        #[cfg(fuzzing)]
-        // when fuzzing, we cannot have ignored bits, to preserve roundtrip-ability
-        0 if low4 == 0 => StreamType::Present,
-        #[cfg(not(fuzzing))]
-        0 => StreamType::Present,
-        1 => StreamType::Data(DictionaryType::try_from(low4).ok()?),
-        2 => StreamType::Offset(OffsetType::try_from(low4).ok()?),
-        3 => StreamType::Length(LengthType::try_from(low4).ok()?),
-        _ => return None,
+    let category = CategoryField::try_from(value & CATEGORY_MASK).ok()?;
+    let subtype = value & SUBTYPE_MASK;
+    // when fuzzing, we cannot have ignored bits, to preserve roundtrip-ability
+    #[cfg(fuzzing)]
+    if category == CategoryField::Present && subtype != 0 {
+        return None;
+    }
+    Some(match category {
+        CategoryField::Present => StreamType::Present,
+        CategoryField::Data => StreamType::Data(DictionaryType::try_from(subtype).ok()?),
+        CategoryField::Offset => StreamType::Offset(OffsetType::try_from(subtype).ok()?),
+        CategoryField::Length => StreamType::Length(LengthType::try_from(subtype).ok()?),
     })
 }
 
 /// Serialize to the v1 `stream_type` byte.
 fn stream_type_to_byte(stream_type: StreamType) -> u8 {
-    let proto_high4 = match stream_type {
-        StreamType::Present => 0,
-        StreamType::Data(_) => 1,
-        StreamType::Offset(_) => 2,
-        StreamType::Length(_) => 3,
+    let (category, subtype) = match stream_type {
+        StreamType::Present => (CategoryField::Present, 0),
+        StreamType::Data(i) => (CategoryField::Data, i as u8),
+        StreamType::Offset(i) => (CategoryField::Offset, i as u8),
+        StreamType::Length(i) => (CategoryField::Length, i as u8),
     };
-    let high4 = proto_high4 << 4;
-    let low4 = match stream_type {
-        StreamType::Present => 0,
-        StreamType::Data(i) => i as u8,
-        StreamType::Offset(i) => i as u8,
-        StreamType::Length(i) => i as u8,
-    };
-    debug_assert!(low4 <= 0x0F, "secondary types should not exceed 4 bit");
-    high4 | low4
+    debug_assert!(
+        subtype <= SUBTYPE_MASK,
+        "secondary types should not exceed 4 bit"
+    );
+    category as u8 | subtype
 }
 
 /// Parse the metadata portion of a v1 stream header (everything before the payload).
@@ -86,9 +121,9 @@ pub(crate) fn parse_stream_meta<'a>(
     let stream_type = stream_type_from_byte(st_byte).ok_or(ParsingStreamType(st_byte))?;
 
     let (input, val) = parse_u8(input)?;
-    let logical1 = LT::parse(val >> 5)?;
-    let logical2 = LT::parse((val >> 2) & 0x7)?;
-    let physical_encoding = PhysicalEncoding::parse(val & 0x3)?;
+    let logical1 = LT::parse(val & LOGICAL1_MASK)?;
+    let logical2 = parse_logical2(val)?;
+    let physical_encoding = PhysicalEncoding::parse(val & PHYSICAL_MASK)?;
 
     let (input, num_values) = parse_varint::<u32>(input)?;
     let (input, byte_length) = parse_varint::<u32>(input)?;
@@ -169,23 +204,18 @@ pub(crate) fn write_stream_meta<W: io::Write>(
     use LogicalTechnique as LT;
 
     writer.write_u8(stream_type_to_byte(meta.stream_type))?;
-    let logical_enc_u8: u8 = match meta.encoding.logical {
-        LE::None => (LT::None as u8) << 5,
-        LE::Delta => (LT::Delta as u8) << 5,
-        LE::DeltaRle(_) => ((LT::Delta as u8) << 5) | ((LT::Rle as u8) << 2),
-        LE::ComponentwiseDelta => (LT::ComponentwiseDelta as u8) << 5,
-        LE::Rle(_) => (LT::Rle as u8) << 5,
-        LE::Morton(_) => (LT::Morton as u8) << 5,
-        LE::MortonRle(_) => (LT::Morton as u8) << 5 | ((LT::Rle as u8) << 2),
-        LE::MortonDelta(_) => (LT::Morton as u8) << 5 | ((LT::Delta as u8) << 2),
-        LE::PseudoDecimal => (LT::PseudoDecimal as u8) << 5,
+    let (logical1, logical2) = match meta.encoding.logical {
+        LE::None => (LT::None, LT::None),
+        LE::Delta => (LT::Delta, LT::None),
+        LE::DeltaRle(_) => (LT::Delta, LT::Rle),
+        LE::ComponentwiseDelta => (LT::ComponentwiseDelta, LT::None),
+        LE::Rle(_) => (LT::Rle, LT::None),
+        LE::Morton(_) => (LT::Morton, LT::None),
+        LE::MortonRle(_) => (LT::Morton, LT::Rle),
+        LE::MortonDelta(_) => (LT::Morton, LT::Delta),
+        LE::PseudoDecimal => (LT::PseudoDecimal, LT::None),
     };
-    let physical_enc_u8: u8 = match meta.encoding.physical {
-        PhysicalEncoding::None => 0x0,
-        PhysicalEncoding::FastPFor256 => 0x1,
-        PhysicalEncoding::VarInt => 0x2,
-    };
-    writer.write_u8(logical_enc_u8 | physical_enc_u8)?;
+    writer.write_u8(logical1 as u8 | logical2_bits(logical2) | meta.encoding.physical as u8)?;
     writer.write_varint(meta.num_values)?;
     writer.write_varint(byte_length)?;
 
@@ -373,9 +403,8 @@ mod tests {
 
     #[test]
     fn rejects_invalid_logical_combination() {
-        let logical1 = LogicalTechnique::ComponentwiseDelta as u8;
-        let logical2 = LogicalTechnique::Rle as u8;
-        let enc_byte = (logical1 << 5) | (logical2 << 2);
+        let enc_byte =
+            LogicalTechnique::ComponentwiseDelta as u8 | logical2_bits(LogicalTechnique::Rle);
         let buf = [0u8, enc_byte, 0, 0];
         let err = parse_stream(&buf, &mut parser()).unwrap_err();
         assert!(matches!(err, MltError::InvalidLogicalEncodings(_, _)));

--- a/rust/mlt-core/src/decoder/stream/model.rs
+++ b/rust/mlt-core/src/decoder/stream/model.rs
@@ -5,15 +5,19 @@ use crate::utils::formatter::{bytes_dbg, compact_dbg};
 use crate::{MltError, MltResult};
 
 /// Logical encoding technique used for a column, as stored in the tile
+///
+/// Variants are already shifted into the primary logical field of the v1 encoding byte (bits 7-5),
+/// so that field is matched with a mask rather than shifted down first.
+/// The secondary field (bits 4-2) holds the same patterns three bits lower.
 #[derive(Debug, Clone, Copy, PartialEq, TryFromPrimitive)]
 #[repr(u8)]
 pub enum LogicalTechnique {
-    None = 0,
-    Delta = 1,
-    ComponentwiseDelta = 2,
-    Rle = 3,
-    Morton = 4,
-    PseudoDecimal = 5,
+    None = 0b0000_0000,
+    Delta = 0b0010_0000,
+    ComponentwiseDelta = 0b0100_0000,
+    Rle = 0b0110_0000,
+    Morton = 0b1000_0000,
+    PseudoDecimal = 0b1010_0000,
 }
 
 /// Metadata for RLE decoding
@@ -76,35 +80,35 @@ pub struct LogicalValue {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, TryFromPrimitive)]
 #[repr(u8)]
 pub enum DictionaryType {
-    None = 0,
-    Single = 1,
-    Shared = 2,
-    Vertex = 3,
-    Morton = 4,
-    Fsst = 5,
+    None = 0b0000_0000,
+    Single = 0b0000_0001,
+    Shared = 0b0000_0010,
+    Vertex = 0b0000_0011,
+    Morton = 0b0000_0100,
+    Fsst = 0b0000_0101,
 }
 
 /// Offset type used for a column, as stored in the tile
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, TryFromPrimitive)]
 #[repr(u8)]
 pub enum OffsetType {
-    Vertex = 0,
-    Index = 1,
-    String = 2,
-    Key = 3,
+    Vertex = 0b0000_0000,
+    Index = 0b0000_0001,
+    String = 0b0000_0010,
+    Key = 0b0000_0011,
 }
 
 /// Length type used for a column, as stored in the tile
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, TryFromPrimitive)]
 #[repr(u8)]
 pub enum LengthType {
-    VarBinary = 0,
-    Geometries = 1,
-    Parts = 2,
-    Rings = 3,
-    Triangles = 4,
-    Symbol = 5,
-    Dictionary = 6,
+    VarBinary = 0b0000_0000,
+    Geometries = 0b0000_0001,
+    Parts = 0b0000_0010,
+    Rings = 0b0000_0011,
+    Triangles = 0b0000_0100,
+    Symbol = 0b0000_0101,
+    Dictionary = 0b0000_0110,
 }
 
 /// How should the stream be interpreted at the physical level (first pass of decoding)
@@ -120,13 +124,13 @@ pub enum StreamType {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, TryFromPrimitive)]
 #[repr(u8)]
 pub enum PhysicalEncoding {
-    None = 0,
+    None = 0b0000_0000,
     /// Preferred, tends to produce the best compression ratio and decoding performance.
     /// But currently limited to 32-bit integer.
-    FastPFor256 = 1,
+    FastPFor256 = 0b0000_0001,
     /// Can produce better results in combination with a heavyweight compression scheme like `Gzip`.
     /// Simple compression scheme where the encoding is easier to implement compared to `FastPfor`.
-    VarInt = 2,
+    VarInt = 0b0000_0010,
 }
 
 // RawStream types

--- a/rust/mlt-core/src/decoder/stream/model.rs
+++ b/rust/mlt-core/src/decoder/stream/model.rs
@@ -20,6 +20,25 @@ pub enum LogicalTechnique {
     PseudoDecimal = 0b1010_0000,
 }
 
+/// The combinations of the two [`LogicalTechnique`] fields that are legal on the wire
+///
+/// Each variant is the whole logical part of the v1 encoding byte, i.e. the primary field
+/// (bits 7-5) or-ed with the secondary field (bits 4-2).
+/// Any other pairing of the two fields is rejected while parsing.
+#[derive(Debug, Clone, Copy, PartialEq, TryFromPrimitive)]
+#[repr(u8)]
+pub enum LogicalCombination {
+    None = 0b0000_0000,
+    Delta = 0b0010_0000,
+    DeltaRle = 0b0010_1100,
+    ComponentwiseDelta = 0b0100_0000,
+    Rle = 0b0110_0000,
+    Morton = 0b1000_0000,
+    MortonDelta = 0b1000_0100,
+    MortonRle = 0b1000_1100,
+    PseudoDecimal = 0b1010_0000,
+}
+
 /// Metadata for RLE decoding
 /// TODO v2 optimizations:
 ///   * runs is identical to half the size of the associated array

--- a/rust/mlt-core/src/dump/walker01.rs
+++ b/rust/mlt-core/src/dump/walker01.rs
@@ -480,8 +480,10 @@ fn encoding_bits(byte: u8) -> Vec<BitField> {
     let l1 = byte >> 5;
     let l2 = (byte >> 2) & 0x7;
     let ph = byte & 0x3;
+    // both logical fields hold the same patterns, which the enum carries pre-shifted into bits 7-5
     let name_lt = |v: u8| {
-        LogicalTechnique::try_from(v).map_or_else(|_| format!("invalid({v})"), |t| format!("{t:?}"))
+        LogicalTechnique::try_from(v << 5)
+            .map_or_else(|_| format!("invalid({v})"), |t| format!("{t:?}"))
     };
     let name_ph = PhysicalEncoding::try_from(ph)
         .map_or_else(|_| format!("invalid({ph})"), |p| format!("{p:?}"));

--- a/rust/mlt-core/src/lib.rs
+++ b/rust/mlt-core/src/lib.rs
@@ -32,10 +32,6 @@ pub use decoder::{
     Layer01FeatureIter, LendingIterator, ParsedLayer, ParsedLayer01, Parser, PropName,
     PropNamesIter, PropValueRef, Unknown,
 };
-pub use tile::{
-    Extent, PropKind, PropValue, PropertyKey, TileFeature, TileFeatureBuilder, TileLayer,
-    TileLayerBuilder,
-};
 // Crate-internal re-exports: allow internal modules to use `crate::Lazy` etc.
 // without exposing these implementation details to external users.
 pub(crate) use decoder::{
@@ -44,6 +40,10 @@ pub(crate) use decoder::{
 };
 pub(crate) use errors::MltRefResult;
 pub use errors::{MltError, MltResult};
+pub use tile::{
+    Extent, PropKind, PropValue, PropertyKey, TileFeature, TileFeatureBuilder, TileLayer,
+    TileLayerBuilder,
+};
 pub(crate) use utils::analyze::{Analyze, StatType};
 pub(crate) use utils::lazy_state::{Decode, DecodeState, Lazy, LazyParsed, Parsed};
 


### PR DESCRIPTION
Gives each v1 wire enum its actual bit pattern and reads the packed `stream_type` and encoding bytes through named masks, so the byte layout lives on the enums rather than in the parser (no wire change).