### PR TITLE
chore(rust): make RleMeta an enum over the RLE stream layout

### DIFF
--- a/rust/mlt-core/src/codecs/rle.rs
+++ b/rust/mlt-core/src/codecs/rle.rs
@@ -138,7 +138,7 @@ mod tests {
             combined.extend(vals);
             let runs = u32::try_from(runs.len()).unwrap();
             let num_rle_values = u32::try_from(data.len()).unwrap();
-            let rle = RleMeta { runs, num_rle_values };
+            let rle = RleMeta::Split { runs, num_rle_values };
             let decoded = rle.decode(&combined, &mut dec()).unwrap();
             prop_assert_eq!(data, decoded);
         }

--- a/rust/mlt-core/src/decoder/mod.rs
+++ b/rust/mlt-core/src/decoder/mod.rs
@@ -40,5 +40,6 @@ pub(crate) use property::{
 };
 pub(crate) use stream::model::{
     DictionaryType, IntEncoding, LengthType, LogicalCombination, LogicalEncoding, LogicalTechnique,
-    LogicalValue, Morton, OffsetType, PhysicalEncoding, RawStream, RleMeta, StreamMeta, StreamType,
+    LogicalValue, Morton, OffsetType, PhysicalEncoding, RawStream, RleLayout, RleMeta, StreamMeta,
+    StreamType,
 };

--- a/rust/mlt-core/src/decoder/stream/header01.rs
+++ b/rust/mlt-core/src/decoder/stream/header01.rs
@@ -163,7 +163,7 @@ pub(crate) fn parse_stream_meta<'a>(
             // Reserve decoded memory (worst case: u64 = 8 bytes per value)
             let decoded_bytes = num_rle_values.saturating_mul(8);
             parser.reserve(decoded_bytes)?;
-            let rle = RleMeta {
+            let rle = RleMeta::Split {
                 runs,
                 num_rle_values,
             };
@@ -229,11 +229,12 @@ pub(crate) fn write_stream_meta<W: io::Write>(
 
     // some encoding have settings inside them
     match meta.encoding.logical {
-        LE::DeltaRle(RleMeta {
+        // v1 always uses the Split layout.
+        LE::DeltaRle(RleMeta::Split {
             runs,
             num_rle_values,
         })
-        | LE::Rle(RleMeta {
+        | LE::Rle(RleMeta::Split {
             runs,
             num_rle_values,
         }) => {
@@ -299,11 +300,11 @@ fn parse_stream_internal<'a>(
 
     // For RLE with VarInt physical encoding, validate stream: run lengths must sum to num_rle_values.
     // v1 parsing only ever produces the Split layout.
-    if let LE::Rle(RleMeta {
+    if let LE::Rle(RleMeta::Split {
         runs,
         num_rle_values,
     })
-    | LE::DeltaRle(RleMeta {
+    | LE::DeltaRle(RleMeta::Split {
         runs,
         num_rle_values,
     }) = meta.encoding.logical
@@ -388,7 +389,7 @@ mod tests {
     fn rle_header_roundtrip(#[case] plain_rle: bool) {
         let run_lengths = [2_u8, 3];
         let values = [10_u8, 20];
-        let rle = RleMeta {
+        let rle = RleMeta::Split {
             runs: u32::try_from(run_lengths.len()).unwrap(),
             num_rle_values: u32::from(run_lengths.iter().sum::<u8>()),
         };

--- a/rust/mlt-core/src/decoder/stream/logical.rs
+++ b/rust/mlt-core/src/decoder/stream/logical.rs
@@ -14,16 +14,31 @@ impl RleMeta {
     /// Decode RLE (Run-Length Encoding) data.
     /// Charges the decoder for the expanded output allocation.
     pub fn decode<T: PrimInt + Debug>(self, data: &[T], dec: &mut Decoder) -> MltResult<Vec<T>> {
-        let expected_len = self.runs.into_usize().checked_mul(2).or_overflow()?;
+        match self {
+            Self::Split {
+                runs,
+                num_rle_values,
+            } => Self::decode_split(runs, num_rle_values, data, dec),
+        }
+    }
+
+    /// Tag `0x01` layout: `[run_len × runs][value × runs]`.
+    fn decode_split<T: PrimInt + Debug>(
+        runs: u32,
+        num_rle_values: u32,
+        data: &[T],
+        dec: &mut Decoder,
+    ) -> MltResult<Vec<T>> {
+        let expected_len = runs.into_usize().checked_mul(2).or_overflow()?;
         fail_if_invalid_stream_size(data.len(), expected_len)?;
 
-        let (run_lens, values) = data.split_at(self.runs.into_usize());
+        let (run_lens, values) = data.split_at(runs.into_usize());
         fail_if_invalid_stream_size(
-            self.num_rle_values.into_usize(),
+            num_rle_values.into_usize(),
             Self::calc_size(run_lens)?.into_usize(),
         )?;
 
-        let alloc_size = self.num_rle_values.into_usize();
+        let alloc_size = num_rle_values.into_usize();
         let mut result = dec.alloc(alloc_size)?;
         for (&run_len, &val) in run_lens.iter().zip(values.iter()) {
             let run = run_len
@@ -165,7 +180,7 @@ mod tests {
 
     #[test]
     fn test_decode_rle_empty() {
-        let rle = RleMeta {
+        let rle = RleMeta::Split {
             runs: 0,
             num_rle_values: 0,
         };
@@ -175,7 +190,7 @@ mod tests {
     #[test]
     fn test_decode_rle_invalid_stream_size() {
         // Valid RLE for runs=2 needs 4 elements (2 run lengths + 2 values). Only 3 provided.
-        let rle = RleMeta {
+        let rle = RleMeta::Split {
             runs: 2,
             num_rle_values: 3,
         };

--- a/rust/mlt-core/src/decoder/stream/model.rs
+++ b/rust/mlt-core/src/decoder/stream/model.rs
@@ -39,15 +39,23 @@ pub enum LogicalCombination {
     PseudoDecimal = 0b1010_0000,
 }
 
-/// Metadata for RLE decoding
-/// TODO v2 optimizations:
-///   * runs is identical to half the size of the associated array
-///   * `num_rle_values` is identical to the size of the sum of the first half of the array.
-///     Computing checked sum should not be too expensive.
+/// Which RLE stream layout the encoder should produce.
+///
+/// A data-less selector chosen up front by the wire format (see
+/// [`WireVersion::rle_layout`](crate::encoder::WireVersion)); the realized
+/// per-stream metadata is [`RleMeta`], whose variants mirror these.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RleLayout {
+    /// Tag `0x01`: all run lengths first, then all values.
+    Split,
+}
+
+/// Metadata for RLE decoding, one variant per [`RleLayout`].
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct RleMeta {
-    pub(crate) runs: u32,
-    pub(crate) num_rle_values: u32,
+pub enum RleMeta {
+    /// Tag `0x01`: physically-decoded words are `[run_len × runs][value × runs]`.
+    /// `runs` is the split point; `num_rle_values` is the expanded element count.
+    Split { runs: u32, num_rle_values: u32 },
 }
 
 /// Metadata for Morton decoding

--- a/rust/mlt-core/src/encoder/model.rs
+++ b/rust/mlt-core/src/encoder/model.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 
 use derive_debug::Dbg;
 
-use crate::decoder::{DictionaryType, GeometryValues, StreamType};
+use crate::decoder::{DictionaryType, GeometryValues, RleLayout, StreamType};
 use crate::encoder::geometry::VertexBufferType;
 use crate::encoder::{IntEncoder, StagedId, StagedProperty};
 use crate::tile::Extent;
@@ -197,6 +197,17 @@ impl WireVersion {
             Self::V02 => 2,
         }
     }
+
+    /// The RLE stream data layout used by this format.
+    #[must_use]
+    pub(crate) fn rle_layout(self) -> RleLayout {
+        match self {
+            Self::V01 => RleLayout::Split,
+            // TODO(v2): v2 uses interleaved `(run, value)` pairs.
+            #[cfg(feature = "unstable-v2")]
+            Self::V02 => RleLayout::Split,
+        }
+    }
 }
 
 /// Global encoder settings controlling which optimization strategies are attempted.
@@ -269,12 +280,11 @@ impl EncoderConfig {
         self.allow_fsst
     }
 
-    /// Whether the `FastPFor` physical encoding may compete for streams.
-    // TODO(v2): race FastPFor128-LE for `WireVersion::V02`.
-    // v2 will use `FastPFor128` in little-endian byte order.
-    // Until that codec lands, `FastPFor` is only attempted for v1 layers.
     #[must_use]
     pub fn allow_fastpfor(self) -> bool {
+        // TODO(v2): race FastPFor128-LE for `WireVersion::V02`.
+        // v2 will use `FastPFor128` in little-endian byte order.
+        // Until that codec lands, `FastPFor` is only attempted for v1 layers.
         self.allow_fastpfor && self.wire_version == WireVersion::V01
     }
 

--- a/rust/mlt-core/src/encoder/stream/codecs.rs
+++ b/rust/mlt-core/src/encoder/stream/codecs.rs
@@ -55,7 +55,7 @@ impl LogicalCodecs {
         let num_values = u32::try_from(values.len())?;
         let data = encode_bools_to_bytes(values, &mut self.u8_tmp);
         let encoded = encode_byte_rle(data, &mut self.u8_tmp2);
-        let meta = LogicalEncoding::Rle(RleMeta {
+        let meta = LogicalEncoding::Rle(RleMeta::Split {
             runs: num_values.div_ceil(8),
             num_rle_values: u32::try_from(encoded.len())?,
         });
@@ -118,11 +118,12 @@ impl Codecs {
 
         // FIXME: does StreamMeta encode values.len() or vals1.len()?
         if let Some(int_enc) = enc.override_int_enc(ctx) {
+            let rle_layout = enc.config().wire_version().rle_layout();
             let (le, vals) = match int_enc.logical {
                 LogicalEncoder::None => (LE::None, self.logical.none(values)),
                 LogicalEncoder::Delta => (LE::Delta, self.logical.delta(values)),
-                LogicalEncoder::Rle => self.logical.rle(values)?,
-                LogicalEncoder::DeltaRle => self.logical.delta_rle(values)?,
+                LogicalEncoder::Rle => self.logical.rle(values, rle_layout)?,
+                LogicalEncoder::DeltaRle => self.logical.delta_rle(values, rle_layout)?,
             };
             let phys = int_enc.physical;
             return self
@@ -156,6 +157,7 @@ impl Codecs {
         }
 
         let allow_fastpfor = enc.config().allow_fastpfor();
+        let rle_layout = enc.config().wire_version().rle_layout();
         let mut alt = enc.try_alternatives();
 
         let sample = logical.none(DataProfile::take_sample(values));
@@ -164,7 +166,7 @@ impl Codecs {
         if profile.delta_is_beneficial()
             && (profile.rle_is_viable() || profile.delta_rle_is_viable())
         {
-            let (logical_enc, values) = logical.delta_rle(values)?;
+            let (logical_enc, values) = logical.delta_rle(values, rle_layout)?;
             physical.write_alternatives::<Output<T>>(
                 &mut alt,
                 values,
@@ -184,7 +186,7 @@ impl Codecs {
             )?;
         }
         if profile.rle_is_viable() {
-            let (logical_enc, values) = logical.rle(values)?;
+            let (logical_enc, values) = logical.rle(values, rle_layout)?;
             physical.write_alternatives::<Output<T>>(
                 &mut alt,
                 values,

--- a/rust/mlt-core/src/encoder/stream/logical.rs
+++ b/rust/mlt-core/src/encoder/stream/logical.rs
@@ -4,25 +4,32 @@ use num_traits::PrimInt;
 
 use crate::MltResult;
 use crate::codecs::rle::encode_rle;
-use crate::decoder::RleMeta;
+use crate::decoder::{RleLayout, RleMeta};
 
 /// RLE-encode `data` into `target` and return the matching `RleMeta`.
 ///
 /// `target` is treated as a scratch buffer: cleared before writing.
 /// `num_logical` is the expanded output length (stored in `RleMeta::num_rle_values`).
+/// `layout` selects the wire layout: currently only split run/value halves (tag `0x01`).
 pub(crate) fn apply_rle<T: PrimInt + Debug>(
     data: &[T],
     num_logical: usize,
+    layout: RleLayout,
     target: &mut Vec<T>,
 ) -> MltResult<RleMeta> {
     let (runs_vec, vals_vec) = encode_rle(data);
-    let meta = RleMeta {
-        runs: u32::try_from(runs_vec.len())?,
-        num_rle_values: u32::try_from(num_logical)?,
-    };
+    let num_rle_values = u32::try_from(num_logical)?;
     target.clear();
-    target.extend_from_slice(&runs_vec);
-    target.extend_from_slice(&vals_vec);
+    let meta = match layout {
+        RleLayout::Split => {
+            target.extend_from_slice(&runs_vec);
+            target.extend_from_slice(&vals_vec);
+            RleMeta::Split {
+                runs: u32::try_from(runs_vec.len())?,
+                num_rle_values,
+            }
+        }
+    };
     Ok(meta)
 }
 

--- a/rust/mlt-core/src/encoder/stream/tests.rs
+++ b/rust/mlt-core/src/encoder/stream/tests.rs
@@ -115,7 +115,7 @@ fn test_decode_bits_u32() {
 // RLE: [3,2] [0,2] -> [0,0,0,2,2]
 // ZigZag: [0,0,0,2,2] -> [0,0,0,1,1]
 // Delta: [0,0,0,1,1] -> [0,0,0,1,2]
-#[case::delta_rle(LogicalEncoding::DeltaRle(RleMeta { runs: 2, num_rle_values: 5 }), vec![3u32, 2, 0, 2], vec![0i32, 0, 0, 1, 2]
+#[case::delta_rle(LogicalEncoding::DeltaRle(RleMeta::Split { runs: 2, num_rle_values: 5 }), vec![3u32, 2, 0, 2], vec![0i32, 0, 0, 1, 2]
 )]
 #[case::delta_empty(LogicalEncoding::Delta, vec![], vec![])]
 fn test_decode_i32(
@@ -132,7 +132,7 @@ fn test_decode_i32(
 #[rstest]
 #[case::empty(LogicalEncoding::None, vec![], vec![])]
 #[case::new_encoded(LogicalEncoding::None, vec![10u32, 20, 30, 40], vec![10u32, 20, 30, 40])]
-#[case::rle(LogicalEncoding::Rle(RleMeta { runs: 3, num_rle_values: 6 }), vec![3u32, 2, 1, 10, 20, 30], vec![10u32, 10, 10, 20, 20, 30]
+#[case::rle(LogicalEncoding::Rle(RleMeta::Split { runs: 3, num_rle_values: 6 }), vec![3u32, 2, 1, 10, 20, 30], vec![10u32, 10, 10, 20, 20, 30]
 )]
 // ZigZag: [0,2,2,2,2] -> [0,1,1,1,1]
 // Delta: [0,1,1,1,1] -> [0,1,2,3,4]
@@ -260,13 +260,13 @@ fn allow_fastpfor_gates_fastpfor_selection() {
 )]
 #[case::varint(StreamType::Length(LengthType::VarBinary), 3, LogicalEncoding::Delta, PhysicalEncoding::VarInt, vec![0x00, 0x02, 0x02], false
 )]
-#[case::rle(StreamType::Data(DictionaryType::None), 6, LogicalEncoding::Rle(RleMeta { runs: 3, num_rle_values: 6 }), PhysicalEncoding::VarInt, vec![0x03, 0x02, 0x01, 0x0A, 0x14, 0x1E], false
+#[case::rle(StreamType::Data(DictionaryType::None), 6, LogicalEncoding::Rle(RleMeta::Split { runs: 3, num_rle_values: 6 }), PhysicalEncoding::VarInt, vec![0x03, 0x02, 0x01, 0x0A, 0x14, 0x1E], false
 )]
-#[case::rle(StreamType::Data(DictionaryType::None), 5, LogicalEncoding::DeltaRle(RleMeta { runs: 2, num_rle_values: 5 }), PhysicalEncoding::VarInt, vec![0x03, 0x02, 0x00, 0x02], false
+#[case::rle(StreamType::Data(DictionaryType::None), 5, LogicalEncoding::DeltaRle(RleMeta::Split { runs: 2, num_rle_values: 5 }), PhysicalEncoding::VarInt, vec![0x03, 0x02, 0x00, 0x02], false
 )]
 #[case::morton(StreamType::Data(DictionaryType::Morton), 4, LogicalEncoding::Morton(Morton { bits: 16, shift: 0 }), PhysicalEncoding::VarInt, vec![0x01, 0x02, 0x03, 0x04], false
 )]
-#[case::boolean(StreamType::Present, 16, LogicalEncoding::Rle(RleMeta { runs: 2, num_rle_values: 2 }), PhysicalEncoding::VarInt, vec![0xFF, 0x00], true
+#[case::boolean(StreamType::Present, 16, LogicalEncoding::Rle(RleMeta::Split { runs: 2, num_rle_values: 2 }), PhysicalEncoding::VarInt, vec![0xFF, 0x00], true
 )]
 fn test_stream_roundtrip(
     #[case] stream_type: StreamType,
@@ -351,7 +351,7 @@ fn test_varint_stream_huge_num_values_empty_data() {
 fn test_rle_num_rle_values_mismatch() {
     // runs=1, num_rle_values=u32::MAX (declared), but the single run has value 1.
     // Sum of runs = 1 ≠ u32::MAX -> must error before allocating ~16 GB.
-    let rle = RleMeta {
+    let rle = RleMeta::Split {
         runs: 1,
         num_rle_values: u32::MAX,
     };

--- a/rust/mlt-core/src/encoder/stream/write.rs
+++ b/rust/mlt-core/src/encoder/stream/write.rs
@@ -8,13 +8,13 @@ use crate::MltError::UnsupportedPhysicalEncoding;
 use crate::MltResult;
 use crate::codecs::zigzag::{encode_zigzag, encode_zigzag_delta};
 use crate::decoder::stream::header01;
-use crate::decoder::{LogicalEncoding, PhysicalEncoding, StreamMeta, StreamType};
-use crate::encoder::model::StreamCtx;
+use crate::decoder::{LogicalEncoding, PhysicalEncoding, RleLayout, StreamMeta, StreamType};
+use crate::encoder::Encoder;
+use crate::encoder::model::{StreamCtx, WireVersion};
 use crate::encoder::stream::codecs::{LogicalCodecs, PhysicalCodecs};
 use crate::encoder::stream::logical::apply_rle;
 use crate::encoder::stream::physical::PhysicalEncoder;
 use crate::encoder::writer::AltSession;
-use crate::encoder::{Encoder, WireVersion};
 
 /// Write one stream (header + payload) to `enc`, using the stream-header codec [`EncoderConfig::wire_version`](crate::encoder::EncoderConfig::wire_version).
 #[inline]
@@ -170,6 +170,7 @@ pub(crate) trait LogicalIntCodec<T: LogicalIntStreamKind + ?Sized> {
     fn rle<'a>(
         &'a mut self,
         values: &'a T,
+        layout: RleLayout,
     ) -> MltResult<(
         LogicalEncoding,
         &'a [<T::Output as PhysicalIntStreamKind>::Value],
@@ -178,6 +179,7 @@ pub(crate) trait LogicalIntCodec<T: LogicalIntStreamKind + ?Sized> {
     fn delta_rle<'a>(
         &'a mut self,
         values: &'a T,
+        layout: RleLayout,
     ) -> MltResult<(
         LogicalEncoding,
         &'a [<T::Output as PhysicalIntStreamKind>::Value],
@@ -227,15 +229,23 @@ impl LogicalIntCodec<[u8]> for LogicalCodecs {
         encode_narrow_delta(values, &mut self.u32_tmp)
     }
 
-    fn rle<'a>(&'a mut self, values: &'a [u8]) -> MltResult<(LogicalEncoding, &'a [u32])> {
+    fn rle<'a>(
+        &'a mut self,
+        values: &'a [u8],
+        layout: RleLayout,
+    ) -> MltResult<(LogicalEncoding, &'a [u32])> {
         let data = encode_u8_as_u32(values, &mut self.u32_tmp);
-        let meta = apply_rle(data, values.len(), &mut self.u32_tmp2)?;
+        let meta = apply_rle(data, values.len(), layout, &mut self.u32_tmp2)?;
         Ok((LogicalEncoding::Rle(meta), &self.u32_tmp2))
     }
 
-    fn delta_rle<'a>(&'a mut self, values: &'a [u8]) -> MltResult<(LogicalEncoding, &'a [u32])> {
+    fn delta_rle<'a>(
+        &'a mut self,
+        values: &'a [u8],
+        layout: RleLayout,
+    ) -> MltResult<(LogicalEncoding, &'a [u32])> {
         let data = encode_narrow_delta(values, &mut self.u32_tmp);
-        let meta = apply_rle(data, values.len(), &mut self.u32_tmp2)?;
+        let meta = apply_rle(data, values.len(), layout, &mut self.u32_tmp2)?;
         Ok((LogicalEncoding::DeltaRle(meta), &self.u32_tmp2))
     }
 }
@@ -255,15 +265,23 @@ impl LogicalIntCodec<[i8]> for LogicalCodecs {
         encode_narrow_delta(values, &mut self.u32_tmp)
     }
 
-    fn rle<'a>(&'a mut self, values: &'a [i8]) -> MltResult<(LogicalEncoding, &'a [u32])> {
+    fn rle<'a>(
+        &'a mut self,
+        values: &'a [i8],
+        layout: RleLayout,
+    ) -> MltResult<(LogicalEncoding, &'a [u32])> {
         let data = encode_i8_zigzag(values, &mut self.u32_tmp);
-        let meta = apply_rle(data, values.len(), &mut self.u32_tmp2)?;
+        let meta = apply_rle(data, values.len(), layout, &mut self.u32_tmp2)?;
         Ok((LogicalEncoding::Rle(meta), &self.u32_tmp2))
     }
 
-    fn delta_rle<'a>(&'a mut self, values: &'a [i8]) -> MltResult<(LogicalEncoding, &'a [u32])> {
+    fn delta_rle<'a>(
+        &'a mut self,
+        values: &'a [i8],
+        layout: RleLayout,
+    ) -> MltResult<(LogicalEncoding, &'a [u32])> {
         let data = encode_narrow_delta(values, &mut self.u32_tmp);
-        let meta = apply_rle(data, values.len(), &mut self.u32_tmp2)?;
+        let meta = apply_rle(data, values.len(), layout, &mut self.u32_tmp2)?;
         Ok((LogicalEncoding::DeltaRle(meta), &self.u32_tmp2))
     }
 }
@@ -283,14 +301,22 @@ impl LogicalIntCodec<[u32]> for LogicalCodecs {
         encode_zigzag_delta(cast_slice::<u32, i32>(values), &mut self.u32_tmp)
     }
 
-    fn rle<'a>(&'a mut self, values: &'a [u32]) -> MltResult<(LogicalEncoding, &'a [u32])> {
-        let meta = apply_rle(values, values.len(), &mut self.u32_tmp)?;
+    fn rle<'a>(
+        &'a mut self,
+        values: &'a [u32],
+        layout: RleLayout,
+    ) -> MltResult<(LogicalEncoding, &'a [u32])> {
+        let meta = apply_rle(values, values.len(), layout, &mut self.u32_tmp)?;
         Ok((LogicalEncoding::Rle(meta), &self.u32_tmp))
     }
 
-    fn delta_rle<'a>(&'a mut self, values: &'a [u32]) -> MltResult<(LogicalEncoding, &'a [u32])> {
+    fn delta_rle<'a>(
+        &'a mut self,
+        values: &'a [u32],
+        layout: RleLayout,
+    ) -> MltResult<(LogicalEncoding, &'a [u32])> {
         let data = encode_zigzag_delta(cast_slice::<u32, i32>(values), &mut self.u32_tmp);
-        let meta = apply_rle(data, values.len(), &mut self.u32_tmp2)?;
+        let meta = apply_rle(data, values.len(), layout, &mut self.u32_tmp2)?;
         Ok((LogicalEncoding::DeltaRle(meta), &self.u32_tmp2))
     }
 }
@@ -310,15 +336,23 @@ impl LogicalIntCodec<[i32]> for LogicalCodecs {
         encode_zigzag_delta(values, &mut self.u32_tmp)
     }
 
-    fn rle<'a>(&'a mut self, values: &'a [i32]) -> MltResult<(LogicalEncoding, &'a [u32])> {
+    fn rle<'a>(
+        &'a mut self,
+        values: &'a [i32],
+        layout: RleLayout,
+    ) -> MltResult<(LogicalEncoding, &'a [u32])> {
         let data = encode_zigzag(values, &mut self.u32_tmp);
-        let meta = apply_rle(data, values.len(), &mut self.u32_tmp2)?;
+        let meta = apply_rle(data, values.len(), layout, &mut self.u32_tmp2)?;
         Ok((LogicalEncoding::Rle(meta), &self.u32_tmp2))
     }
 
-    fn delta_rle<'a>(&'a mut self, values: &'a [i32]) -> MltResult<(LogicalEncoding, &'a [u32])> {
+    fn delta_rle<'a>(
+        &'a mut self,
+        values: &'a [i32],
+        layout: RleLayout,
+    ) -> MltResult<(LogicalEncoding, &'a [u32])> {
         let data = encode_zigzag_delta(values, &mut self.u32_tmp);
-        let meta = apply_rle(data, values.len(), &mut self.u32_tmp2)?;
+        let meta = apply_rle(data, values.len(), layout, &mut self.u32_tmp2)?;
         Ok((LogicalEncoding::DeltaRle(meta), &self.u32_tmp2))
     }
 }
@@ -338,14 +372,22 @@ impl LogicalIntCodec<[u64]> for LogicalCodecs {
         encode_zigzag_delta(cast_slice::<u64, i64>(values), &mut self.u64_tmp)
     }
 
-    fn rle<'a>(&'a mut self, values: &'a [u64]) -> MltResult<(LogicalEncoding, &'a [u64])> {
-        let meta = apply_rle(values, values.len(), &mut self.u64_tmp)?;
+    fn rle<'a>(
+        &'a mut self,
+        values: &'a [u64],
+        layout: RleLayout,
+    ) -> MltResult<(LogicalEncoding, &'a [u64])> {
+        let meta = apply_rle(values, values.len(), layout, &mut self.u64_tmp)?;
         Ok((LogicalEncoding::Rle(meta), &self.u64_tmp))
     }
 
-    fn delta_rle<'a>(&'a mut self, values: &'a [u64]) -> MltResult<(LogicalEncoding, &'a [u64])> {
+    fn delta_rle<'a>(
+        &'a mut self,
+        values: &'a [u64],
+        layout: RleLayout,
+    ) -> MltResult<(LogicalEncoding, &'a [u64])> {
         let data = encode_zigzag_delta(cast_slice::<u64, i64>(values), &mut self.u64_tmp);
-        let meta = apply_rle(data, values.len(), &mut self.u64_tmp2)?;
+        let meta = apply_rle(data, values.len(), layout, &mut self.u64_tmp2)?;
         Ok((LogicalEncoding::DeltaRle(meta), &self.u64_tmp2))
     }
 }
@@ -365,15 +407,23 @@ impl LogicalIntCodec<[i64]> for LogicalCodecs {
         encode_zigzag_delta(values, &mut self.u64_tmp)
     }
 
-    fn rle<'a>(&'a mut self, values: &'a [i64]) -> MltResult<(LogicalEncoding, &'a [u64])> {
+    fn rle<'a>(
+        &'a mut self,
+        values: &'a [i64],
+        layout: RleLayout,
+    ) -> MltResult<(LogicalEncoding, &'a [u64])> {
         let data = encode_zigzag(values, &mut self.u64_tmp);
-        let meta = apply_rle(data, values.len(), &mut self.u64_tmp2)?;
+        let meta = apply_rle(data, values.len(), layout, &mut self.u64_tmp2)?;
         Ok((LogicalEncoding::Rle(meta), &self.u64_tmp2))
     }
 
-    fn delta_rle<'a>(&'a mut self, values: &'a [i64]) -> MltResult<(LogicalEncoding, &'a [u64])> {
+    fn delta_rle<'a>(
+        &'a mut self,
+        values: &'a [i64],
+        layout: RleLayout,
+    ) -> MltResult<(LogicalEncoding, &'a [u64])> {
         let data = encode_zigzag_delta(values, &mut self.u64_tmp);
-        let meta = apply_rle(data, values.len(), &mut self.u64_tmp2)?;
+        let meta = apply_rle(data, values.len(), layout, &mut self.u64_tmp2)?;
         Ok((LogicalEncoding::DeltaRle(meta), &self.u64_tmp2))
     }
 }

--- a/rust/mlt-core/src/lib.rs
+++ b/rust/mlt-core/src/lib.rs
@@ -56,7 +56,7 @@ pub mod wire {
     pub use crate::decoder::ColumnType;
     pub use crate::decoder::stream::model::{
         DictionaryType, IntEncoding, LengthType, LogicalEncoding, LogicalTechnique, Morton,
-        OffsetType, PhysicalEncoding, RleMeta, StreamMeta, StreamType,
+        OffsetType, PhysicalEncoding, RleLayout, RleMeta, StreamMeta, StreamType,
     };
     pub use crate::utils::analyze::{Analyze, StatType};
 }


### PR DESCRIPTION
Turns `RleMeta` from a struct describing v1's one RLE layout into an enum over layouts, with an `RleLayout` selector the encoder picks from `WireVersion`, so a second layout becomes a new variant instead of a reinterpretation of the existing fields.