### PR TITLE
chore(rust): share one encode/decode helper across the fuzz targets

### DIFF
--- a/rust/mlt-core/fuzz/README.md
+++ b/rust/mlt-core/fuzz/README.md
@@ -15,7 +15,10 @@ fuzz/
 ├── src/
 │   └── lib.rs              # mlt_fuzz library with LayerInput and fuzz_roundtrip logic
 ├── fuzz_targets/
-│   └── layer.rs            # Fuzz target that feeds random data to LayerInput
+│   ├── layer.rs            # Fuzz target that feeds random data to LayerInput
+│   ├── decoded_layer.rs    # Encode -> decode -> re-encode fixpoint
+│   ├── mvt_roundtrip.rs    # TileLayer -> MVT -> TileLayer fixpoint
+│   └── differential.rs     # Rust vs C++ decoder differential
 ├── tests/
 │   └── reproduce.rs        # Template for reproducing fuzzer-found issues
 ├── corpus/layer/           # Seed inputs for fuzzing

--- a/rust/mlt-core/fuzz/src/decoded_layer.rs
+++ b/rust/mlt-core/fuzz/src/decoded_layer.rs
@@ -1,58 +1,47 @@
 use mlt_core::encoder::SortStrategy::Unsorted;
-use mlt_core::encoder::{Codecs, Encoder, StagedLayer, stage_tile};
-use mlt_core::{Decoder, Layer, Parser, TileLayer};
+use mlt_core::encoder::{EncoderConfig, StagedLayer, stage_tile};
+
+use crate::roundtrip::encode_decode;
 
 /// Fuzz input that starts from a staged layer and tests encode -> decode roundtrip.
 ///
 /// Generates valid [`StagedLayer`] values directly and verifies that the
 /// canonical roundtrip (`Tile -> Staged -> bytes -> Tile`) is idempotent.
+/// The config carries the wire version, so every version is exercised.
+#[derive(arbitrary::Arbitrary)]
 pub struct DecodedLayerInput {
     pub layer: StagedLayer,
-}
-
-impl arbitrary::Arbitrary<'_> for DecodedLayerInput {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
-        let layer: StagedLayer = u.arbitrary()?;
-        Ok(Self { layer })
-    }
+    pub config: EncoderConfig,
 }
 
 impl DecodedLayerInput {
     pub fn fuzz_roundtrip(self) {
+        let cfg = self.config;
         // Normalize: encode the fuzzed StagedLayer and decode to TileLayer.
         // This drops all-null columns, etc. - expected encoder behavior.
-        let tile1 = encode_decode(self.layer);
-        let tile2 = encode_decode(stage_tile(tile1, Unsorted, false, false));
+        let Some(tile1) = encode_decode(self.layer, cfg) else {
+            return; // the wire version cannot represent this layer
+        };
+        let tile2 = restage_roundtrip(tile1, cfg);
 
         // Same roundtrip again - must be a fixpoint.
-        let tile3 = encode_decode(stage_tile(tile2.clone(), Unsorted, false, false));
+        let tile3 = restage_roundtrip(tile2.clone(), cfg);
         assert_eq!(tile2, tile3, "canonical roundtrip is not idempotent");
     }
 }
 
-/// Encode a [`StagedLayer`] to bytes, then parse and decode back to a
-/// row-oriented [`TileLayer`].
-fn encode_decode(staged: StagedLayer) -> TileLayer {
-    let mut codecs = Codecs::default();
-    let buffer = staged
-        .encode_into(Encoder::default(), &mut codecs)
-        .expect("encode should not fail")
-        .into_layer_bytes()
-        .expect("into_layer_bytes should not fail");
-
-    let mut layers = Parser::default()
-        .parse_layers(&buffer)
-        .expect("layer must re-parse");
-    assert_eq!(layers.len(), 1, "expected exactly one layer");
-    let Layer::Tag01(lazy) = layers.remove(0) else {
-        panic!("expected Tag01 layer");
-    };
-    lazy.into_tile(&mut Decoder::default())
-        .expect("into_tile should not fail")
+/// Re-stage an already-decoded layer and run it through the same wire version again.
+fn restage_roundtrip(tile: mlt_core::TileLayer, cfg: EncoderConfig) -> mlt_core::TileLayer {
+    let staged = stage_tile(tile, Unsorted, cfg.allow_shared_dict(), cfg.tessellate());
+    encode_decode(staged, cfg).expect("re-encoding a layer this version already produced")
 }
 
 impl std::fmt::Debug for DecodedLayerInput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "DecodedLayerInput {{\n\tlayer: {:#?}\n}}", self.layer)
+        write!(
+            f,
+            "DecodedLayerInput {{\n\tconfig: {:#?}\n\tlayer: {:#?}\n}}",
+            self.config, self.layer
+        )
     }
 }

--- a/rust/mlt-core/fuzz/src/lib.rs
+++ b/rust/mlt-core/fuzz/src/lib.rs
@@ -2,6 +2,7 @@ mod decoded_layer;
 mod differential;
 mod layer;
 mod mvt_roundtrip;
+mod roundtrip;
 pub use decoded_layer::*;
 pub use differential::*;
 pub use layer::*;

--- a/rust/mlt-core/fuzz/src/mvt_roundtrip.rs
+++ b/rust/mlt-core/fuzz/src/mvt_roundtrip.rs
@@ -1,53 +1,30 @@
-use mlt_core::encoder::{Codecs, Encoder, StagedLayer};
+use mlt_core::TileLayer;
+use mlt_core::encoder::{EncoderConfig, StagedLayer};
 use mlt_core::mvt::{mvt_to_tile_layers, tile_layers_to_mvt};
 use mlt_core::test_helpers::assert_mvt_equivalent_layers;
-use mlt_core::{Decoder, Layer, Parser, TileLayer};
+
+use crate::roundtrip::encode_decode;
 
 /// Fuzz input exercising `TileLayer -> MVT -> TileLayer`.
 ///
 /// MVT's wire types are narrower than MLT's (all narrow integer widths
 /// collapse to `sint64`/`uint64`, etc.), so the first round-trip is
 /// normalizing; subsequent round-trips must be fixpoints.
+#[derive(arbitrary::Arbitrary)]
 pub struct MvtRoundtripInput {
     pub layer: StagedLayer,
-}
-
-impl arbitrary::Arbitrary<'_> for MvtRoundtripInput {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
-        Ok(Self {
-            layer: u.arbitrary()?,
-        })
-    }
+    pub config: EncoderConfig,
 }
 
 impl MvtRoundtripInput {
     pub fn fuzz_roundtrip(self) {
-        let canonical = mlt_encode_decode(self.layer);
+        let Some(canonical) = encode_decode(self.layer, self.config) else {
+            return; // the wire version cannot represent this layer
+        };
         let normalized = mvt_roundtrip(canonical);
         let again = mvt_roundtrip(normalized.clone());
         assert_mvt_equivalent_layers(&normalized, &again);
     }
-}
-
-/// Encode a [`StagedLayer`] to MLT bytes, then parse + decode back into a
-/// row-oriented [`TileLayer`]. Mirrors `decoded_layer::encode_decode`.
-fn mlt_encode_decode(staged: StagedLayer) -> TileLayer {
-    let mut codecs = Codecs::default();
-    let buffer = staged
-        .encode_into(Encoder::default(), &mut codecs)
-        .expect("encode should not fail")
-        .into_layer_bytes()
-        .expect("into_layer_bytes should not fail");
-
-    let mut layers = Parser::default()
-        .parse_layers(&buffer)
-        .expect("layer must re-parse");
-    assert_eq!(layers.len(), 1, "expected exactly one MLT layer");
-    let Layer::Tag01(lazy) = layers.remove(0) else {
-        panic!("expected Tag01 layer");
-    };
-    lazy.into_tile(&mut Decoder::default())
-        .expect("into_tile should not fail")
 }
 
 fn mvt_roundtrip(layer: TileLayer) -> TileLayer {
@@ -59,6 +36,10 @@ fn mvt_roundtrip(layer: TileLayer) -> TileLayer {
 
 impl std::fmt::Debug for MvtRoundtripInput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "MvtRoundtripInput {{\n\tlayer: {:#?}\n}}", self.layer)
+        write!(
+            f,
+            "MvtRoundtripInput {{\n\tconfig: {:#?}\n\tlayer: {:#?}\n}}",
+            self.config, self.layer
+        )
     }
 }

--- a/rust/mlt-core/fuzz/src/roundtrip.rs
+++ b/rust/mlt-core/fuzz/src/roundtrip.rs
@@ -1,0 +1,53 @@
+use mlt_core::encoder::{Codecs, Encoder, EncoderConfig, StagedLayer, WireVersion};
+use mlt_core::{Decoder, Layer, MltError, Parser, TileLayer};
+
+/// Encode `staged` with `cfg`, then parse and decode it back to a row-oriented [`TileLayer`].
+///
+/// Returns `None` when the wire version cannot represent the layer.
+/// Every other encode failure is a bug and panics.
+pub fn encode_decode(staged: StagedLayer, cfg: EncoderConfig) -> Option<TileLayer> {
+    let bytes = encode(staged, cfg)?;
+    Some(decode(&bytes, expected_tag(cfg)))
+}
+
+/// Encode `staged` to a complete layer record, or `None` if `cfg`'s wire version lacks the feature.
+pub fn encode(staged: StagedLayer, cfg: EncoderConfig) -> Option<Vec<u8>> {
+    let mut codecs = Codecs::default();
+    match staged.encode_into(Encoder::new(cfg), &mut codecs) {
+        Ok(enc) => Some(
+            enc.into_layer_bytes()
+                .expect("into_layer_bytes should not fail"),
+        ),
+        Err(MltError::NotImplemented(_)) => None,
+        Err(e) => panic!("encode should not fail: {e}"),
+    }
+}
+
+/// Parse and decode a single-layer record, asserting it was written with `tag`.
+pub fn decode(bytes: &[u8], tag: u8) -> TileLayer {
+    let mut layers = Parser::default()
+        .parse_layers(bytes)
+        .expect("layer must re-parse");
+    assert_eq!(layers.len(), 1, "expected exactly one layer");
+    let layer = layers.remove(0);
+    assert_eq!(actual_tag(&layer), tag, "encoder wrote the wrong layer tag");
+    layer
+        .into_layer01()
+        .expect("layer01 representation")
+        .into_tile(&mut Decoder::default())
+        .expect("into_tile should not fail")
+}
+
+pub fn expected_tag(cfg: EncoderConfig) -> u8 {
+    match cfg.wire_version() {
+        WireVersion::V01 => 1,
+    }
+}
+
+fn actual_tag(layer: &Layer<'_>) -> u8 {
+    match layer {
+        Layer::Tag01(_) => 1,
+        Layer::Unknown(u) => panic!("expected a Tag01 layer, got tag {:#04x}", u.tag()),
+        other => panic!("expected a Tag01 layer, got {other:?}"),
+    }
+}

--- a/rust/mlt-core/src/encoder/fuzzing.rs
+++ b/rust/mlt-core/src/encoder/fuzzing.rs
@@ -8,6 +8,7 @@ use crate::encoder::{EncoderConfig, StagedId, StagedProperty, StagedSharedDict, 
 impl Arbitrary<'_> for EncoderConfig {
     fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
         Ok(Self::default()
+            .with_wire_version(u.arbitrary()?)
             .with_tessellation(u.arbitrary()?)
             .with_spatial_morton_sort(u.arbitrary()?)
             .with_spatial_hilbert_sort(u.arbitrary()?)

--- a/rust/mlt-core/src/encoder/model.rs
+++ b/rust/mlt-core/src/encoder/model.rs
@@ -174,6 +174,7 @@ impl StagedLayer {
 
 /// Which wire format layers are encoded to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum WireVersion {
     /// Tag `0x01` - the stable v1 format.
     #[default]


### PR DESCRIPTION
Extracts the encode/parse/decode helper that `decoded_layer` and `mvt_roundtrip` had each copied into `fuzz::roundtrip`, drops two hand-written `Arbitrary` impls that only forwarded to the derive, and lets both targets fuzz an arbitrary `EncoderConfig`.