### PR TITLE
perf(rust): decode boolean streams as packed bits instead of `Vec<bool>`

### DIFF
--- a/rust/mlt-core/src/codecs/bytes.rs
+++ b/rust/mlt-core/src/codecs/bytes.rs
@@ -82,27 +82,6 @@ pub fn decode_bytes_to_words<'a, T: PhysicalWord>(
     Ok((input, values))
 }
 
-/// Helper to unpack a `Vec<u8>` into `Vec<bool>` where each byte represents 8 booleans.
-/// TODO: Use `BitSlice` from bitvec crate and avoid copying?
-pub fn decode_bytes_to_bools(
-    bytes: &[u8],
-    num_bools: usize,
-    dec: &mut Decoder,
-) -> MltResult<Vec<bool>> {
-    if num_bools > bytes.len() * 8 {
-        return Err(BufferUnderflow(
-            u32::try_from(num_bools.div_ceil(8))?,
-            bytes.len(),
-        ));
-    }
-    let mut result = dec.alloc(num_bools)?;
-    for i in 0..num_bools {
-        result.push((bytes[i / 8] >> (i % 8)) & 1 == 1);
-    }
-    debug_assert_length(&result, num_bools);
-    Ok(result)
-}
-
 #[inline]
 pub fn debug_assert_length<T>(buffer: &[T], expected_len: usize) {
     debug_assert_eq!(
@@ -114,6 +93,8 @@ pub fn debug_assert_length<T>(buffer: &[T], expected_len: usize) {
 
 #[cfg(test)]
 mod tests {
+    use bitvec::order::Lsb0;
+    use bitvec::view::BitView as _;
     use proptest::prelude::*;
 
     use super::*;
@@ -124,8 +105,8 @@ mod tests {
         fn encode_bools_to_bytes_roundtrip(bools: Vec<bool>) {
             let mut bytes = Vec::new();
             let data = encode_bools_to_bytes(bools.iter().copied(), &mut bytes);
-            let bools_rountrip = decode_bytes_to_bools(data, bools.len(), &mut dec()).unwrap();
-            prop_assert_eq!(bools_rountrip, bools);
+            let packed = &data.view_bits::<Lsb0>()[..bools.len()];
+            prop_assert_eq!(packed.iter().by_vals().collect::<Vec<bool>>(), bools);
         }
 
         #[test]

--- a/rust/mlt-core/src/decoder/property/decode.rs
+++ b/rust/mlt-core/src/decoder/property/decode.rs
@@ -23,19 +23,6 @@ impl<'a> RawPresence<'a> {
             Self::Bitfield(bits) => Ok(Some(Cow::Borrowed(bits))),
         }
     }
-
-    /// Decode into one bool per feature, or `None` for a non-optional column.
-    pub(crate) fn decode_bools(self, dec: &mut Decoder) -> MltResult<Option<Vec<bool>>> {
-        match self {
-            Self::AllPresent => Ok(None),
-            Self::Stream(s) => Ok(Some(s.decode_bools(dec)?)),
-            #[cfg(feature = "unstable-v2")]
-            Self::Bitfield(bits) => {
-                dec.consume_items::<bool>(bits.len())?;
-                Ok(Some(bits.iter().by_vals().collect()))
-            }
-        }
-    }
 }
 
 impl<'a, T: Copy + PartialEq> ParsedScalar<'a, T> {

--- a/rust/mlt-core/src/decoder/property/model.rs
+++ b/rust/mlt-core/src/decoder/property/model.rs
@@ -226,8 +226,8 @@ pub struct RawFsstData<'a> {
 /// Raw presence/nullability data for a column.
 ///
 /// `AllPresent` represents a non-optional column; other variants encode presence in a
-/// layer-format-specific way. Decode through [`RawPresence::decode_bits`] or
-/// [`RawPresence::decode_bools`] instead of matching on it.
+/// layer-format-specific way. Decode through [`RawPresence::decode_bits`]
+/// instead of matching on it.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub enum RawPresence<'a> {
     /// Non-optional column - every feature has a value; nothing is stored.

--- a/rust/mlt-core/src/decoder/property/strings.rs
+++ b/rust/mlt-core/src/decoder/property/strings.rs
@@ -1,5 +1,7 @@
 use std::borrow::Cow;
 
+use bitvec::order::Lsb0;
+use bitvec::slice::BitSlice;
 use usize_cast::IntoUsize as _;
 
 use crate::MltError::{BufferUnderflow, DictIndexOutOfBounds};
@@ -98,22 +100,17 @@ pub(crate) fn shared_dict_spans(lengths: &[u32], dec: &mut Decoder) -> MltResult
 
 pub(crate) fn resolve_dict_spans(
     offsets: &[u32],
-    presence: Option<&[bool]>,
+    presence: Option<&BitSlice<u8, Lsb0>>,
     dict_spans: &[(u32, u32)],
     dec: &mut Decoder,
 ) -> MltResult<Vec<Option<(u32, u32)>>> {
-    let present_count = presence.map_or(offsets.len(), <[bool]>::len);
+    let present_count = presence.map_or(offsets.len(), BitSlice::len);
     let mut resolved = dec.alloc(present_count)?;
     let mut next = offsets.iter().copied();
 
     if let Some(presence) = presence {
-        let fail = || {
-            MltError::PresenceValueCountMismatch(
-                presence.iter().filter(|&&v| v).count(),
-                offsets.len(),
-            )
-        };
-        for &present in presence {
+        let fail = || MltError::PresenceValueCountMismatch(presence.count_ones(), offsets.len());
+        for present in presence.iter().by_vals() {
             if !present {
                 resolved.push(None);
                 continue;
@@ -280,7 +277,7 @@ impl<'a> RawStrings<'a> {
     /// Decode string property from its encoded column.
     pub fn decode(self, dec: &mut Decoder) -> MltResult<ParsedStrings<'a>> {
         let name = self.name;
-        let presence = self.presence.decode_bools(dec)?;
+        let presence = self.presence.decode_bits(dec)?;
 
         let parsed = match self.encoding {
             RawStringsEncoding::Plain(plain_data) => {
@@ -326,15 +323,15 @@ impl<'a> RawStrings<'a> {
 
 fn to_absolute_lengths(
     lengths: &[u32],
-    presence: Option<&[bool]>,
+    presence: Option<&BitSlice<u8, Lsb0>>,
     dec: &mut Decoder,
 ) -> MltResult<Vec<i32>> {
-    let capacity = presence.map_or(lengths.len(), <[bool]>::len);
+    let capacity = presence.map_or(lengths.len(), BitSlice::len);
     let mut absolute = dec.alloc(capacity)?;
     let mut iter = lengths.iter().copied();
     let mut end = 0_i32;
     if let Some(presence) = presence {
-        for &present in presence {
+        for present in presence.iter().by_vals() {
             if present {
                 let len = iter.next().ok_or(MltError::PresenceValueCountMismatch(
                     presence.len(),
@@ -348,7 +345,7 @@ fn to_absolute_lengths(
         }
         if iter.next().is_some() {
             return Err(MltError::PresenceValueCountMismatch(
-                presence.iter().filter(|v| **v).count(),
+                presence.count_ones(),
                 lengths.len(),
             ));
         }
@@ -365,7 +362,7 @@ fn decode_dictionary_strings<'a>(
     name: &'a str,
     dict_lengths: &[u32],
     offsets: &[u32],
-    presence: Option<&[bool]>,
+    presence: Option<&BitSlice<u8, Lsb0>>,
     dict_data: &str,
     dec: &mut Decoder,
 ) -> MltResult<ParsedStrings<'a>> {
@@ -445,7 +442,7 @@ impl<'a> RawSharedDict<'a> {
         let mut items = Vec::with_capacity(self.children.len());
         for child in self.children {
             let offsets: Vec<u32> = child.data.decode_ints(dec)?;
-            let presence = child.presence.decode_bools(dec)?;
+            let presence = child.presence.decode_bits(dec)?;
             let ranges = resolve_dict_spans(&offsets, presence.as_deref(), &dict_spans, dec)?
                 .into_iter()
                 .map(|span| match span {

--- a/rust/mlt-core/src/decoder/stream/decode.rs
+++ b/rust/mlt-core/src/decoder/stream/decode.rs
@@ -5,7 +5,7 @@ use bitvec::prelude::{BitSlice, BitVec, Lsb0};
 use bitvec::view::BitView as _;
 use usize_cast::IntoUsize as _;
 
-use crate::codecs::bytes::{PhysicalWord, decode_bytes_to_bools, decode_bytes_to_words};
+use crate::codecs::bytes::{PhysicalWord, debug_assert_length, decode_bytes_to_words};
 use crate::codecs::rle::decode_byte_rle;
 use crate::codecs::varint::{parse_varint_vec, parse_varint_vec_all};
 #[cfg(feature = "unstable-v2")]
@@ -15,52 +15,46 @@ use crate::errors::{AsMltError as _, fail_if_invalid_stream_size};
 use crate::{Decoder, MltError, MltResult};
 
 impl<'a> RawStream<'a> {
-    /// Decode a presence/nullability stream into a packed bitvector.
-    ///
-    /// Borrows directly from tile bytes (zero-copy) when both logical and physical
-    /// encodings are `None`; otherwise decompresses byte-RLE into an owned `BitVec`.
-    /// The result is always truncated to exactly `num_values` bits.
-    pub(crate) fn decode_bitvec(self, dec: &mut Decoder) -> MltResult<Cow<'a, BitSlice<u8, Lsb0>>> {
-        let num_values = self.meta.num_values.into_usize();
-        if self.meta.encoding.physical == PhysicalEncoding::VarInt {
-            return Err(MltError::NotImplemented("varint presence decoding"));
-        }
-        if self.meta.encoding.logical == LogicalEncoding::None
-            && self.meta.encoding.physical == PhysicalEncoding::None
-        {
-            // Zero-copy: raw tile bytes are the packed bitvector.
-            let num_bytes = num_values.div_ceil(8);
-            fail_if_invalid_stream_size(self.data.len(), num_bytes)?;
-            Ok(Cow::Borrowed(&self.data.view_bits::<Lsb0>()[..num_values]))
-        } else {
-            let num_bytes = num_values.div_ceil(8);
-            let bytes = decode_byte_rle(self.data, num_bytes, dec)?;
-            let mut bvec = BitVec::<u8, Lsb0>::from_vec(bytes);
-            bvec.truncate(num_values);
-            Ok(Cow::Owned(bvec))
-        }
-    }
-
-    /// Decode a boolean data stream into `Vec<bool>`, charging `dec`.
+    /// Decode a boolean stream (presence or bool data) into a packed bitvector.
     ///
     /// Both wire formats store one bit per value in an LSB-first packed bitmap;
     /// they differ only in how that bitmap is framed, which the logical encoding
     /// distinguishes:
-    /// - tag `0x01` (`logical = Rle`): byte-RLE compressed bitmap.
-    /// - tag `0x02` (`logical = None`): raw bitmap, no compression - the same
-    ///   representation as a v2 presence bitfield.
-    pub fn decode_bools(self, dec: &mut Decoder) -> MltResult<Vec<bool>> {
+    /// - tag `0x01` (`logical = Rle`): byte-RLE compressed bitmap, decompressed
+    ///   into an owned `BitVec`.
+    /// - tag `0x02` (`logical = None`): raw bitmap, borrowed straight from the tile
+    ///   bytes - the same representation as a v2 presence bitfield.
+    ///
+    /// The result is always exactly `num_values` bits.
+    pub(crate) fn decode_bitvec(self, dec: &mut Decoder) -> MltResult<Cow<'a, BitSlice<u8, Lsb0>>> {
         let num_values = self.meta.num_values.into_usize();
+        let num_bytes = num_values.div_ceil(8);
         match self.meta.encoding.logical {
             LogicalEncoding::Rle(_) => {
-                let bytes = decode_byte_rle(self.data, num_values.div_ceil(8), dec)?;
-                decode_bytes_to_bools(&bytes, num_values, dec)
+                let bytes = decode_byte_rle(self.data, num_bytes, dec)?;
+                fail_if_invalid_stream_size(bytes.len(), num_bytes)?;
+                let mut bits = BitVec::<u8, Lsb0>::from_vec(bytes);
+                bits.truncate(num_values);
+                Ok(Cow::Owned(bits))
             }
             LogicalEncoding::None if self.meta.encoding.physical == PhysicalEncoding::None => {
-                decode_bytes_to_bools(self.data, num_values, dec)
+                fail_if_invalid_stream_size(self.data.len(), num_bytes)?;
+                Ok(Cow::Borrowed(&self.data.view_bits::<Lsb0>()[..num_values]))
             }
             _ => Err(MltError::NotImplemented("unsupported bool stream encoding")),
         }
+    }
+
+    /// Decode a boolean data stream into one `bool` per value, charging `dec`.
+    ///
+    /// Prefer [`RawStream::decode_bitvec`], which keeps the wire's packed layout.
+    /// This 8x expansion exists for the dense `Vec<bool>` of a boolean column.
+    pub fn decode_bools(self, dec: &mut Decoder) -> MltResult<Vec<bool>> {
+        let bits = self.decode_bitvec(dec)?;
+        let mut bools = dec.alloc(bits.len())?;
+        bools.extend(bits.iter().by_vals());
+        debug_assert_length(&bools, bits.len());
+        Ok(bools)
     }
 
     /// Decode via physical type `W`, then narrow to `N`, erroring if a value is out of range.
@@ -272,5 +266,114 @@ impl LogicalEncoding {
     #[expect(clippy::unused_self, reason = "tmp because feature gate")]
     fn scans_to_end(self) -> bool {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+    use crate::codecs::bytes::encode_bools_to_bytes;
+    use crate::codecs::rle::encode_byte_rle;
+    use crate::decoder::{RleMeta, StreamMeta, StreamType};
+    use crate::test_helpers::dec;
+
+    fn packed(bools: &[bool]) -> Vec<u8> {
+        let mut target = Vec::new();
+        encode_bools_to_bytes(bools.iter().copied(), &mut target).to_vec()
+    }
+
+    fn raw_bitmap(data: &[u8], num_values: usize) -> RawStream<'_> {
+        let meta = StreamMeta::new_none(StreamType::Present, num_values).unwrap();
+        RawStream::new(meta, data)
+    }
+
+    fn byte_rle(data: &[u8], num_values: usize) -> RawStream<'_> {
+        let logical = LogicalEncoding::Rle(RleMeta::Split {
+            runs: u32::try_from(num_values.div_ceil(8)).unwrap(),
+            num_rle_values: u32::try_from(data.len()).unwrap(),
+        });
+        let meta = StreamMeta::new2(
+            StreamType::Present,
+            logical,
+            PhysicalEncoding::None,
+            num_values,
+        )
+        .unwrap();
+        RawStream::new(meta, data)
+    }
+
+    fn compressed(bools: &[bool]) -> Vec<u8> {
+        let mut encoded = Vec::new();
+        encode_byte_rle(&packed(bools), &mut encoded).to_vec()
+    }
+
+    proptest! {
+        #[test]
+        fn decode_bitvec_borrows_raw_bitmap_from_tile_bytes(bools: Vec<bool>) {
+            let bytes = packed(&bools);
+            let bits = raw_bitmap(&bytes, bools.len()).decode_bitvec(&mut dec()).unwrap();
+            prop_assert!(matches!(bits, Cow::Borrowed(_)));
+            prop_assert_eq!(bits.iter().by_vals().collect::<Vec<bool>>(), bools);
+        }
+
+        #[test]
+        fn decode_bitvec_expands_byte_rle(bools: Vec<bool>) {
+            let bytes = compressed(&bools);
+            let bits = byte_rle(&bytes, bools.len()).decode_bitvec(&mut dec()).unwrap();
+            prop_assert_eq!(bits.len(), bools.len());
+            prop_assert_eq!(bits.iter().by_vals().collect::<Vec<bool>>(), bools);
+        }
+
+        #[test]
+        fn decode_bools_agrees_with_decode_bitvec(bools: Vec<bool>) {
+            let bytes = compressed(&bools);
+            let decoded = byte_rle(&bytes, bools.len()).decode_bools(&mut dec()).unwrap();
+            prop_assert_eq!(decoded, bools);
+        }
+    }
+
+    #[test]
+    fn decode_bitvec_rejects_short_raw_bitmap() {
+        let err = raw_bitmap(&[0xFF], 9)
+            .decode_bitvec(&mut dec())
+            .unwrap_err();
+        assert!(matches!(err, MltError::InvalidDecodingStreamSize(1, 2)));
+    }
+
+    #[test]
+    fn decode_bitvec_rejects_truncated_byte_rle() {
+        // One literal byte, where nine bits need two.
+        let err = byte_rle(&[0xFF, 0b0101_0101], 9)
+            .decode_bitvec(&mut dec())
+            .unwrap_err();
+        assert!(matches!(err, MltError::InvalidDecodingStreamSize(1, 2)));
+    }
+
+    #[test]
+    fn decode_bools_rejects_truncated_byte_rle() {
+        let err = byte_rle(&[0xFF, 0b0101_0101], 9)
+            .decode_bools(&mut dec())
+            .unwrap_err();
+        assert!(matches!(err, MltError::InvalidDecodingStreamSize(1, 2)));
+    }
+
+    #[test]
+    fn decode_bitvec_rejects_varint_physical_encoding() {
+        let meta = StreamMeta::new2(
+            StreamType::Present,
+            LogicalEncoding::None,
+            PhysicalEncoding::VarInt,
+            8,
+        )
+        .unwrap();
+        let err = RawStream::new(meta, &[0x01])
+            .decode_bitvec(&mut dec())
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            MltError::NotImplemented("unsupported bool stream encoding")
+        ));
     }
 }


### PR DESCRIPTION
Resolves the `BitSlice` TODO in `decode_bytes_to_bools` by making `decode_bitvec` the single entry point for every boolean stream, so presence consumers keep the wire’s packed layout instead of expanding to one byte per feature.