### PR TITLE
refactor(rust): give float columns their own raw model

### DIFF
--- a/rust/mlt-core/src/decoder/analyze.rs
+++ b/rust/mlt-core/src/decoder/analyze.rs
@@ -1,7 +1,8 @@
 use crate::decoder::{
-    Geometry, GeometryType, GeometryValues, Id, Layer01, Property, RawFsstData, RawGeometry, RawId,
-    RawIdValue, RawPlainData, RawPresence, RawProperty, RawScalar, RawSharedDict,
-    RawSharedDictEncoding, RawSharedDictItem, RawStrings, RawStringsEncoding, StreamMeta,
+    Geometry, GeometryType, GeometryValues, Id, Layer01, Property, RawFloats, RawFloatsEncoding,
+    RawFsstData, RawGeometry, RawId, RawIdValue, RawPlainData, RawPresence, RawProperty, RawScalar,
+    RawSharedDict, RawSharedDictEncoding, RawSharedDictItem, RawStrings, RawStringsEncoding,
+    StreamMeta,
 };
 use crate::{Analyze, DecodeState, StatType};
 
@@ -131,6 +132,21 @@ impl Analyze for RawScalar<'_> {
     }
 }
 
+impl Analyze for RawFloats<'_> {
+    fn for_each_stream(&self, cb: &mut dyn FnMut(StreamMeta)) {
+        self.presence.for_each_stream(cb);
+        self.encoding.for_each_stream(cb);
+    }
+}
+
+impl Analyze for RawFloatsEncoding<'_> {
+    fn for_each_stream(&self, cb: &mut dyn FnMut(StreamMeta)) {
+        match self {
+            Self::Single(data) => data.for_each_stream(cb),
+        }
+    }
+}
+
 impl Analyze for RawStrings<'_> {
     fn for_each_stream(&self, cb: &mut dyn FnMut(StreamMeta)) {
         self.presence.for_each_stream(cb);
@@ -170,9 +186,8 @@ impl Analyze for RawProperty<'_> {
             | Self::I32(s)
             | Self::U32(s)
             | Self::I64(s)
-            | Self::U64(s)
-            | Self::F32(s)
-            | Self::F64(s) => s.for_each_stream(cb),
+            | Self::U64(s) => s.for_each_stream(cb),
+            Self::F32(s) | Self::F64(s) => s.for_each_stream(cb),
             Self::Str(s) => s.for_each_stream(cb),
             Self::SharedDict(s) => s.for_each_stream(cb),
         }

--- a/rust/mlt-core/src/decoder/iterators.rs
+++ b/rust/mlt-core/src/decoder/iterators.rs
@@ -352,15 +352,10 @@ impl<'p> ColNames for RawProperty<'p> {
     fn name_at(&self, idx: usize) -> PropName<'p> {
         use RawProperty as P;
         match self {
-            P::Bool(s)
-            | P::I8(s)
-            | P::U8(s)
-            | P::I32(s)
-            | P::U32(s)
-            | P::I64(s)
-            | P::U64(s)
-            | P::F32(s)
-            | P::F64(s) => PropName(s.name, ""),
+            P::Bool(s) | P::I8(s) | P::U8(s) | P::I32(s) | P::U32(s) | P::I64(s) | P::U64(s) => {
+                PropName(s.name, "")
+            }
+            P::F32(s) | P::F64(s) => PropName(s.name, ""),
             P::Str(s) => PropName(s.name, ""),
             P::SharedDict(sd) => PropName(sd.name, sd.children[idx].name),
         }

--- a/rust/mlt-core/src/decoder/mod.rs
+++ b/rust/mlt-core/src/decoder/mod.rs
@@ -41,8 +41,9 @@ pub(crate) use model02::{ColumnType02, DataType02, GeoLayout, LayerLayout, Prese
 pub(crate) use property::strings;
 pub(crate) use property::{
     DictRange, ParsedProperty, ParsedScalar, ParsedSharedDict, ParsedSharedDictItem, ParsedStrings,
-    Property, RawFsstData, RawPlainData, RawPresence, RawProperty, RawScalar, RawSharedDict,
-    RawSharedDictEncoding, RawSharedDictItem, RawStrings, RawStringsEncoding,
+    Property, RawFloats, RawFloatsEncoding, RawFsstData, RawPlainData, RawPresence, RawProperty,
+    RawScalar, RawSharedDict, RawSharedDictEncoding, RawSharedDictItem, RawStrings,
+    RawStringsEncoding,
 };
 pub(crate) use stream::model::{
     DictionaryType, IntEncoding, LengthType, LogicalCombination, LogicalEncoding, LogicalTechnique,

--- a/rust/mlt-core/src/decoder/property/decode.rs
+++ b/rust/mlt-core/src/decoder/property/decode.rs
@@ -3,7 +3,9 @@ use std::borrow::Cow;
 use bitvec::order::Lsb0;
 use bitvec::slice::BitSlice;
 
-use crate::decoder::{ParsedProperty, ParsedScalar, RawPresence, RawProperty};
+use crate::decoder::{
+    ParsedProperty, ParsedScalar, RawFloats, RawFloatsEncoding, RawPresence, RawProperty,
+};
 use crate::utils::decode_presence;
 use crate::{Decode, Decoder, MltResult};
 
@@ -22,6 +24,20 @@ impl<'a> RawPresence<'a> {
             #[cfg(feature = "unstable-v2")]
             Self::Bitfield(bits) => Ok(Some(Cow::Borrowed(bits))),
         }
+    }
+}
+
+impl<'a> RawFloats<'a> {
+    /// Decode the column, reading whichever stream set its encoding uses.
+    fn decode<T>(self, dec: &mut Decoder) -> MltResult<ParsedScalar<'a, T>>
+    where
+        T: Copy + PartialEq + num_traits::FromBytes,
+        for<'b> <T as num_traits::FromBytes>::Bytes: TryFrom<&'b [u8]>,
+    {
+        let values = match self.encoding {
+            RawFloatsEncoding::Single(data) => data.decode_floats::<T>(dec)?,
+        };
+        ParsedScalar::from_parts(self.name, self.presence, values, dec)
     }
 }
 
@@ -77,14 +93,8 @@ impl<'a> Decode<ParsedProperty<'a>> for RawProperty<'a> {
                 let vals = v.data.decode_ints::<u64>(dec)?;
                 P::U64(S::from_parts(v.name, v.presence, vals, dec)?)
             }
-            Self::F32(v) => {
-                let vals = v.data.decode_floats::<f32>(dec)?;
-                P::F32(S::from_parts(v.name, v.presence, vals, dec)?)
-            }
-            Self::F64(v) => {
-                let vals = v.data.decode_floats::<f64>(dec)?;
-                P::F64(S::from_parts(v.name, v.presence, vals, dec)?)
-            }
+            Self::F32(v) => P::F32(v.decode::<f32>(dec)?),
+            Self::F64(v) => P::F64(v.decode::<f64>(dec)?),
             Self::Str(v) => P::Str(v.decode(dec)?),
             Self::SharedDict(v) => P::SharedDict(v.decode(dec)?),
         })

--- a/rust/mlt-core/src/decoder/property/model.rs
+++ b/rust/mlt-core/src/decoder/property/model.rs
@@ -36,6 +36,33 @@ impl<'a> RawScalar<'a> {
     }
 }
 
+/// Raw float column as read directly from the tile.
+/// Its encodings differ in how many streams they use, so it carries an encoding enum like [`RawStrings`] rather than one stream.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RawFloats<'a> {
+    pub name: &'a str,
+    pub presence: RawPresence<'a>,
+    pub encoding: RawFloatsEncoding<'a>,
+}
+
+impl<'a> RawFloats<'a> {
+    /// A column stored as one data stream.
+    pub(crate) fn single(name: &'a str, presence: RawPresence<'a>, data: RawStream<'a>) -> Self {
+        Self {
+            name,
+            presence,
+            encoding: RawFloatsEncoding::Single(data),
+        }
+    }
+}
+
+/// Raw encoding payload for a float column.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RawFloatsEncoding<'a> {
+    /// One data stream, its own logical encoding saying how to read it.
+    Single(RawStream<'a>),
+}
+
 /// Raw string column as read directly from the tile.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RawStrings<'a> {
@@ -96,8 +123,8 @@ pub enum RawProperty<'a> {
     U32(RawScalar<'a>),
     I64(RawScalar<'a>),
     U64(RawScalar<'a>),
-    F32(RawScalar<'a>),
-    F64(RawScalar<'a>),
+    F32(RawFloats<'a>),
+    F64(RawFloats<'a>),
     Str(RawStrings<'a>),
     SharedDict(RawSharedDict<'a>),
 }

--- a/rust/mlt-core/src/decoder/root01.rs
+++ b/rust/mlt-core/src/decoder/root01.rs
@@ -11,8 +11,8 @@ use crate::MltError::{
 use crate::codecs::varint::parse_varint;
 use crate::decoder::stream::header01;
 use crate::decoder::{
-    Column, ColumnType, DictionaryType, Geometry, Id, Layer01, RawFsstData, RawGeometry, RawId,
-    RawIdValue, RawPlainData, RawPresence, RawProperty, RawScalar, RawSharedDict,
+    Column, ColumnType, DictionaryType, Geometry, Id, Layer01, RawFloats, RawFsstData, RawGeometry,
+    RawId, RawIdValue, RawPlainData, RawPresence, RawProperty, RawScalar, RawSharedDict,
     RawSharedDictEncoding, RawSharedDictItem, RawStrings, RawStringsEncoding, StreamType,
 };
 use crate::errors::AsMltError as _;
@@ -115,12 +115,12 @@ impl<'a> Layer01<'a, Lazy> {
                 ColumnType::F32 | ColumnType::OptF32 => {
                     (input, presence) = parse_optional(column.typ, input, parser)?;
                     (input, value) = header01::parse_stream(input, parser)?;
-                    properties.push(Raw(RP::F32(RawScalar::new(name, presence, value))));
+                    properties.push(Raw(RP::F32(RawFloats::single(name, presence, value))));
                 }
                 ColumnType::F64 | ColumnType::OptF64 => {
                     (input, presence) = parse_optional(column.typ, input, parser)?;
                     (input, value) = header01::parse_stream(input, parser)?;
-                    properties.push(Raw(RP::F64(RawScalar::new(name, presence, value))));
+                    properties.push(Raw(RP::F64(RawFloats::single(name, presence, value))));
                 }
                 ColumnType::Str | ColumnType::OptStr => {
                     let prop;

--- a/rust/mlt-core/src/decoder/root02.rs
+++ b/rust/mlt-core/src/decoder/root02.rs
@@ -42,7 +42,7 @@ use crate::decoder::stream::header02;
 use crate::decoder::stream::header02::StreamCtx02;
 use crate::decoder::{
     ColumnType02, DataType02, GeoLayout, Id, Layer01, LayerLayout, LengthType, Presence02,
-    RawGeometry, RawId, RawIdValue, RawPresence, RawScalar,
+    RawFloats, RawGeometry, RawId, RawIdValue, RawPresence, RawScalar,
 };
 use crate::tile::Extent;
 use crate::utils::{SetOptionOnce as _, parse_string, parse_u8, take};
@@ -134,8 +134,8 @@ pub(crate) fn parse_layer02<'a>(
             DataType02::U32 => RP::U32(RawScalar::new(name, presence, value)),
             DataType02::I64 => RP::I64(RawScalar::new(name, presence, value)),
             DataType02::U64 => RP::U64(RawScalar::new(name, presence, value)),
-            DataType02::F32 => RP::F32(RawScalar::new(name, presence, value)),
-            DataType02::F64 => RP::F64(RawScalar::new(name, presence, value)),
+            DataType02::F32 => RP::F32(RawFloats::single(name, presence, value)),
+            DataType02::F64 => RP::F64(RawFloats::single(name, presence, value)),
         };
         properties.push(Raw(prop));
     }


### PR DESCRIPTION
Float columns move off `RawScalar`, which holds exactly one stream, onto a per-encoding enum carrying each variant's stream set, so a dictionary-encoded column can hold two. No wire changes