### PR TITLE
refactor(rust): split the logical encoding per value kind

### DIFF
--- a/rust/mlt-core/src/codecs/fsst.rs
+++ b/rust/mlt-core/src/codecs/fsst.rs
@@ -155,7 +155,7 @@ mod tests {
     use super::*;
     use crate::MltError;
     use crate::decoder::stream::header01;
-    use crate::decoder::{DictionaryType, LengthType, RawFsstData, StreamType};
+    use crate::decoder::{DictionaryType, LengthType, RawFsstData, StreamType, ValueKind};
     use crate::encoder::model::StreamCtx;
     use crate::encoder::{
         Codecs, EncodedStream, Encoder, EncoderConfig, ExplicitEncoder, IntEncoder,
@@ -184,7 +184,7 @@ mod tests {
         };
         let byte_stream = |data: &[u8], ty: StreamType, num_values: usize| {
             let stream = EncodedStream {
-                meta: StreamMeta::new_none(ty, num_values).unwrap(),
+                meta: StreamMeta::new_none(ty, ValueKind::Int, num_values).unwrap(),
                 data: data.to_vec(),
             };
             let mut buf = Vec::new();
@@ -220,7 +220,11 @@ mod tests {
     fn parse_streams(buffers: &[Vec<u8>; 4]) -> RawFsstData<'_> {
         let mut raw_streams = Vec::new();
         for buf in buffers {
-            raw_streams.push(assert_empty(header01::parse_stream(buf, &mut parser())));
+            raw_streams.push(assert_empty(header01::parse_stream(
+                buf,
+                ValueKind::Int,
+                &mut parser(),
+            )));
         }
         let [s0, s1, s2, s3] = raw_streams.try_into().expect("expected 4 streams");
         RawFsstData::new(s0, s1, s2, s3).expect("RawFsstData::new failed")

--- a/rust/mlt-core/src/decoder/geometry/decode.rs
+++ b/rust/mlt-core/src/decoder/geometry/decode.rs
@@ -4,7 +4,7 @@ use crate::codecs::varint::parse_varint;
 use crate::decoder::stream::header01;
 use crate::decoder::{
     DictionaryType, GeometryType, GeometryValues, IntEncoding, LengthType, OffsetType, RawGeometry,
-    RawStream, StreamMeta, StreamType,
+    RawStream, StreamMeta, StreamType, ValueKind,
 };
 use crate::errors::AsMltError as _;
 use crate::utils::SetOptionOnce as _;
@@ -230,7 +230,7 @@ impl<'a> RawGeometry<'a> {
                     meta: RawStream::new(
                         StreamMeta::new(
                             StreamType::Data(DictionaryType::None),
-                            IntEncoding::none(),
+                            IntEncoding::none(ValueKind::Int),
                             0,
                         ),
                         &[],
@@ -240,9 +240,10 @@ impl<'a> RawGeometry<'a> {
             ));
         }
 
-        let (input, meta) = header01::parse_stream(input, parser)?;
+        let (input, meta) = header01::parse_stream(input, ValueKind::Int, parser)?;
         // Safety: stream_count is validated != 0
-        let (input, items) = header01::parse_multiple_streams(input, stream_count - 1, parser)?;
+        let (input, items) =
+            header01::parse_multiple_streams(input, stream_count - 1, ValueKind::Int, parser)?;
 
         Ok((input, Self { meta, items }))
     }

--- a/rust/mlt-core/src/decoder/mod.rs
+++ b/rust/mlt-core/src/decoder/mod.rs
@@ -46,7 +46,8 @@ pub(crate) use property::{
     RawStringsEncoding,
 };
 pub(crate) use stream::model::{
-    DictionaryType, IntEncoding, LengthType, LogicalCombination, LogicalEncoding, LogicalTechnique,
-    LogicalValue, Morton, OffsetType, PhysicalEncoding, RawStream, RleLayout, RleMeta, StreamMeta,
-    StreamType,
+    BoolLogical, DictionaryType, FloatLogical, IntEncoding, IntLogical, LengthType,
+    LogicalCombination, LogicalEncoding, LogicalTechnique, LogicalValue, Morton, OffsetType,
+    PhysicalEncoding, RawStream, RleLayout, RleMeta, StreamMeta, StreamType, ValueKind,
+    VertexLogical,
 };

--- a/rust/mlt-core/src/decoder/root01.rs
+++ b/rust/mlt-core/src/decoder/root01.rs
@@ -14,6 +14,7 @@ use crate::decoder::{
     Column, ColumnType, DictionaryType, Geometry, Id, Layer01, RawFloats, RawFsstData, RawGeometry,
     RawId, RawIdValue, RawPlainData, RawPresence, RawProperty, RawScalar, RawSharedDict,
     RawSharedDictEncoding, RawSharedDictItem, RawStrings, RawStringsEncoding, StreamType,
+    ValueKind,
 };
 use crate::errors::AsMltError as _;
 use crate::tile::Extent;
@@ -60,7 +61,7 @@ impl<'a> Layer01<'a, Lazy> {
             match column.typ {
                 ColumnType::Id | ColumnType::OptId => {
                     (input, presence) = parse_optional(column.typ, input, parser)?;
-                    (input, value) = header01::parse_stream(input, parser)?;
+                    (input, value) = header01::parse_stream(input, ValueKind::Int, parser)?;
                     id_column.set_once(Raw(RawId {
                         presence,
                         value: RawIdValue::Id32(value),
@@ -68,7 +69,7 @@ impl<'a> Layer01<'a, Lazy> {
                 }
                 ColumnType::LongId | ColumnType::OptLongId => {
                     (input, presence) = parse_optional(column.typ, input, parser)?;
-                    (input, value) = header01::parse_stream(input, parser)?;
+                    (input, value) = header01::parse_stream(input, ValueKind::Int, parser)?;
                     id_column.set_once(Raw(RawId {
                         presence,
                         value: RawIdValue::Id64(value),
@@ -84,42 +85,42 @@ impl<'a> Layer01<'a, Lazy> {
                 }
                 ColumnType::I8 | ColumnType::OptI8 => {
                     (input, presence) = parse_optional(column.typ, input, parser)?;
-                    (input, value) = header01::parse_stream(input, parser)?;
+                    (input, value) = header01::parse_stream(input, ValueKind::Int, parser)?;
                     properties.push(Raw(RP::I8(RawScalar::new(name, presence, value))));
                 }
                 ColumnType::U8 | ColumnType::OptU8 => {
                     (input, presence) = parse_optional(column.typ, input, parser)?;
-                    (input, value) = header01::parse_stream(input, parser)?;
+                    (input, value) = header01::parse_stream(input, ValueKind::Int, parser)?;
                     properties.push(Raw(RP::U8(RawScalar::new(name, presence, value))));
                 }
                 ColumnType::I32 | ColumnType::OptI32 => {
                     (input, presence) = parse_optional(column.typ, input, parser)?;
-                    (input, value) = header01::parse_stream(input, parser)?;
+                    (input, value) = header01::parse_stream(input, ValueKind::Int, parser)?;
                     properties.push(Raw(RP::I32(RawScalar::new(name, presence, value))));
                 }
                 ColumnType::U32 | ColumnType::OptU32 => {
                     (input, presence) = parse_optional(column.typ, input, parser)?;
-                    (input, value) = header01::parse_stream(input, parser)?;
+                    (input, value) = header01::parse_stream(input, ValueKind::Int, parser)?;
                     properties.push(Raw(RP::U32(RawScalar::new(name, presence, value))));
                 }
                 ColumnType::I64 | ColumnType::OptI64 => {
                     (input, presence) = parse_optional(column.typ, input, parser)?;
-                    (input, value) = header01::parse_stream(input, parser)?;
+                    (input, value) = header01::parse_stream(input, ValueKind::Int, parser)?;
                     properties.push(Raw(RP::I64(RawScalar::new(name, presence, value))));
                 }
                 ColumnType::U64 | ColumnType::OptU64 => {
                     (input, presence) = parse_optional(column.typ, input, parser)?;
-                    (input, value) = header01::parse_stream(input, parser)?;
+                    (input, value) = header01::parse_stream(input, ValueKind::Int, parser)?;
                     properties.push(Raw(RP::U64(RawScalar::new(name, presence, value))));
                 }
                 ColumnType::F32 | ColumnType::OptF32 => {
                     (input, presence) = parse_optional(column.typ, input, parser)?;
-                    (input, value) = header01::parse_stream(input, parser)?;
+                    (input, value) = header01::parse_stream(input, ValueKind::Float, parser)?;
                     properties.push(Raw(RP::F32(RawFloats::single(name, presence, value))));
                 }
                 ColumnType::F64 | ColumnType::OptF64 => {
                     (input, presence) = parse_optional(column.typ, input, parser)?;
-                    (input, value) = header01::parse_stream(input, parser)?;
+                    (input, value) = header01::parse_stream(input, ValueKind::Float, parser)?;
                     properties.push(Raw(RP::F64(RawFloats::single(name, presence, value))));
                 }
                 ColumnType::Str | ColumnType::OptStr => {
@@ -165,7 +166,7 @@ fn parse_shared_dict_children<'a>(
         {
             return Err(UnexpectedStructChildCount(data_count));
         }
-        let (inp, data) = header01::parse_stream(inp, parser)?;
+        let (inp, data) = header01::parse_stream(inp, ValueKind::Int, parser)?;
         children.push(RawSharedDictItem {
             name: child.name.unwrap_or(""),
             presence,
@@ -204,9 +205,10 @@ fn parse_geometry_column<'a>(
         return Err(BufferUnderflow(stream_count, input.len()));
     }
     // metadata
-    let (input, meta) = header01::parse_stream(input, parser)?;
+    let (input, meta) = header01::parse_stream(input, ValueKind::Int, parser)?;
     // geometry items
-    let (input, items) = header01::parse_multiple_streams(input, stream_count_capa - 1, parser)?;
+    let (input, items) =
+        header01::parse_multiple_streams(input, stream_count_capa - 1, ValueKind::Int, parser)?;
     geometry.set_once(Raw(RawGeometry { meta, items }))?;
     Ok(input)
 }
@@ -236,7 +238,7 @@ fn parse_str_column<'a>(
     }
     for slot in str_streams.iter_mut().take(stream_count) {
         let stream;
-        (input, stream) = header01::parse_stream(input, parser)?;
+        (input, stream) = header01::parse_stream(input, ValueKind::Int, parser)?;
         *slot = Some(stream);
     }
     let encoding = match str_streams {
@@ -276,7 +278,7 @@ fn parse_shared_dict_column<'a>(
     let mut streams_taken = 0_usize;
     while streams_taken < stream_count.into_usize() {
         let stream;
-        (input, stream) = header01::parse_stream(input, parser)?;
+        (input, stream) = header01::parse_stream(input, ValueKind::Int, parser)?;
         let is_last = matches!(
             stream.meta.stream_type,
             StreamType::Data(DictionaryType::Single | DictionaryType::Shared)

--- a/rust/mlt-core/src/decoder/stream/decode.rs
+++ b/rust/mlt-core/src/decoder/stream/decode.rs
@@ -9,8 +9,12 @@ use crate::codecs::bytes::{PhysicalWord, debug_assert_length, decode_bytes_to_wo
 use crate::codecs::rle::decode_byte_rle;
 use crate::codecs::varint::{parse_varint_vec, parse_varint_vec_all};
 #[cfg(feature = "unstable-v2")]
+use crate::decoder::IntLogical;
+#[cfg(feature = "unstable-v2")]
 use crate::decoder::RleMeta;
-use crate::decoder::{LogicalEncoding, LogicalValue, PhysicalEncoding, RawStream};
+use crate::decoder::{
+    BoolLogical, FloatLogical, LogicalEncoding, LogicalValue, PhysicalEncoding, RawStream,
+};
 use crate::errors::{AsMltError as _, fail_if_invalid_stream_size};
 use crate::{Decoder, MltError, MltResult};
 
@@ -30,24 +34,23 @@ impl<'a> RawStream<'a> {
         let num_values = self.meta.num_values.into_usize();
         let num_bytes = num_values.div_ceil(8);
         match self.meta.encoding.logical {
-            LogicalEncoding::Rle(_) => {
+            LogicalEncoding::Bool(BoolLogical::ByteRle(_)) => {
                 let bytes = decode_byte_rle(self.data, num_bytes, dec)?;
                 fail_if_invalid_stream_size(bytes.len(), num_bytes)?;
                 let mut bits = BitVec::<u8, Lsb0>::from_vec(bytes);
                 bits.truncate(num_values);
                 Ok(Cow::Owned(bits))
             }
-            LogicalEncoding::None if self.meta.encoding.physical == PhysicalEncoding::None => {
+            LogicalEncoding::Bool(BoolLogical::None)
+                if self.meta.encoding.physical == PhysicalEncoding::None =>
+            {
                 fail_if_invalid_stream_size(self.data.len(), num_bytes)?;
                 Ok(Cow::Borrowed(&self.data.view_bits::<Lsb0>()[..num_values]))
             }
-            LogicalEncoding::None
-            | LogicalEncoding::Delta
-            | LogicalEncoding::DeltaRle(_)
-            | LogicalEncoding::ComponentwiseDelta
-            | LogicalEncoding::Morton(_)
-            | LogicalEncoding::MortonDelta(_)
-            | LogicalEncoding::MortonRle(_) => {
+            LogicalEncoding::Bool(BoolLogical::None)
+            | LogicalEncoding::Int(_)
+            | LogicalEncoding::Float(_)
+            | LogicalEncoding::Vertex(_) => {
                 Err(MltError::NotImplemented("unsupported bool stream encoding"))
             }
         }
@@ -86,7 +89,7 @@ impl<'a> RawStream<'a> {
     /// types always need at least a zigzag transform.
     pub fn decode_ints<T: DecodeInt>(self, dec: &mut Decoder) -> MltResult<Vec<T>> {
         let meta = self.meta;
-        if meta.encoding.logical == LogicalEncoding::None
+        if meta.encoding.logical.is_identity()
             && let Some(out) = T::decode_none_passthrough(&self, dec)?
         {
             return Ok(out);
@@ -111,14 +114,8 @@ impl<'a> RawStream<'a> {
         for<'b> <T as num_traits::FromBytes>::Bytes: TryFrom<&'b [u8]>,
     {
         match self.meta.encoding.logical {
-            LogicalEncoding::None => {}
-            LogicalEncoding::Delta
-            | LogicalEncoding::DeltaRle(_)
-            | LogicalEncoding::ComponentwiseDelta
-            | LogicalEncoding::Rle(_)
-            | LogicalEncoding::Morton(_)
-            | LogicalEncoding::MortonDelta(_)
-            | LogicalEncoding::MortonRle(_) => {
+            LogicalEncoding::Float(FloatLogical::None) => {}
+            LogicalEncoding::Int(_) | LogicalEncoding::Bool(_) | LogicalEncoding::Vertex(_) => {
                 return Err(MltError::UnsupportedLogicalEncoding(
                     self.meta.encoding.logical,
                     "float streams, which are stored raw",
@@ -203,7 +200,7 @@ pub trait DecodeInt: Sized {
         dec: &mut Decoder,
     ) -> MltResult<Vec<Self>>;
 
-    /// Fast path for [`LogicalEncoding::None`]:
+    /// Fast path for [`IntLogical::None`]:
     /// for unsigned types the physical words are already the output, so decode straight into a fresh `Vec`.
     /// Signed types return `None` (zigzag transform always required), so they fall through to the general path.
     fn decode_none_passthrough(
@@ -288,7 +285,10 @@ impl LogicalEncoding {
     fn scans_to_end(self) -> bool {
         matches!(
             self,
-            Self::Rle(RleMeta::Interleaved { .. }) | Self::DeltaRle(RleMeta::Interleaved { .. })
+            Self::Int(
+                IntLogical::Rle(RleMeta::Interleaved { .. })
+                    | IntLogical::DeltaRle(RleMeta::Interleaved { .. })
+            )
         )
     }
 
@@ -309,7 +309,7 @@ mod tests {
     use super::*;
     use crate::codecs::bytes::encode_bools_to_bytes;
     use crate::codecs::rle::encode_byte_rle;
-    use crate::decoder::{DictionaryType, IntEncoding, RleMeta, StreamMeta, StreamType};
+    use crate::decoder::{DictionaryType, IntEncoding, RleMeta, StreamMeta, StreamType, ValueKind};
     use crate::test_helpers::dec;
 
     fn packed(bools: &[bool]) -> Vec<u8> {
@@ -318,15 +318,15 @@ mod tests {
     }
 
     fn raw_bitmap(data: &[u8], num_values: usize) -> RawStream<'_> {
-        let meta = StreamMeta::new_none(StreamType::Present, num_values).unwrap();
+        let meta = StreamMeta::new_none(StreamType::Present, ValueKind::Bool, num_values).unwrap();
         RawStream::new(meta, data)
     }
 
     fn byte_rle(data: &[u8], num_values: usize) -> RawStream<'_> {
-        let logical = LogicalEncoding::Rle(RleMeta::Split {
+        let logical = LogicalEncoding::Bool(BoolLogical::ByteRle(RleMeta::Split {
             runs: u32::try_from(num_values.div_ceil(8)).unwrap(),
             num_rle_values: u32::try_from(data.len()).unwrap(),
-        });
+        }));
         let meta = StreamMeta::new2(
             StreamType::Present,
             logical,
@@ -396,7 +396,7 @@ mod tests {
     fn decode_bitvec_rejects_varint_physical_encoding() {
         let meta = StreamMeta::new2(
             StreamType::Present,
-            LogicalEncoding::None,
+            LogicalEncoding::Bool(BoolLogical::None),
             PhysicalEncoding::VarInt,
             8,
         )
@@ -419,19 +419,10 @@ mod tests {
     }
 
     #[rstest]
-    #[case::delta(LogicalEncoding::Delta)]
-    #[case::componentwise_delta(LogicalEncoding::ComponentwiseDelta)]
-    fn decode_floats_rejects_non_raw_logical(#[case] logical: LogicalEncoding) {
-        let stream = float_stream(logical, PhysicalEncoding::None);
-        let err = stream.decode_floats::<f32>(&mut dec()).unwrap_err();
-        assert!(matches!(err, MltError::UnsupportedLogicalEncoding(_, _)));
-    }
-
-    #[rstest]
     #[case::varint(PhysicalEncoding::VarInt)]
     #[case::fastpfor(PhysicalEncoding::FastPFor256)]
     fn decode_floats_rejects_non_raw_physical(#[case] physical: PhysicalEncoding) {
-        let stream = float_stream(LogicalEncoding::None, physical);
+        let stream = float_stream(LogicalEncoding::Float(FloatLogical::None), physical);
         let err = stream.decode_floats::<f32>(&mut dec()).unwrap_err();
         assert!(matches!(err, MltError::UnsupportedPhysicalEncoding(_)));
     }
@@ -439,7 +430,7 @@ mod tests {
     #[test]
     fn decode_floats_reads_raw_little_endian() {
         let bytes = 1.5_f32.to_le_bytes();
-        let meta = StreamMeta::new(DATA, IntEncoding::none(), 1);
+        let meta = StreamMeta::new(DATA, IntEncoding::none(ValueKind::Float), 1);
         let stream = RawStream::new(meta, &bytes);
         assert_eq!(stream.decode_floats::<f32>(&mut dec()).unwrap(), vec![1.5]);
     }

--- a/rust/mlt-core/src/decoder/stream/header01.rs
+++ b/rust/mlt-core/src/decoder/stream/header01.rs
@@ -27,8 +27,9 @@ use crate::MltError::ParsingStreamType;
 use crate::MltError::UnsupportedLogicalEncoding;
 use crate::codecs::varint::parse_varint;
 use crate::decoder::{
-    DictionaryType, IntEncoding, LengthType, LogicalCombination, LogicalEncoding, LogicalTechnique,
-    Morton, OffsetType, PhysicalEncoding, RawStream, RleMeta, StreamMeta, StreamType,
+    BoolLogical, DictionaryType, FloatLogical, IntEncoding, IntLogical, LengthType,
+    LogicalCombination, LogicalEncoding, LogicalTechnique, Morton, OffsetType, PhysicalEncoding,
+    RawStream, RleMeta, StreamMeta, StreamType, ValueKind, VertexLogical,
 };
 use crate::errors::{AsMltError as _, fail_if_invalid_stream_size};
 use crate::utils::{BinarySerializer as _, parse_u8, take};
@@ -114,6 +115,17 @@ fn stream_type_to_byte(stream_type: StreamType) -> u8 {
     category as u8 | subtype
 }
 
+/// The kind of values a v1 stream holds.
+/// The stream type byte fixes it for everything but a column's data stream, where the caller's column type decides.
+fn kind_of(stream_type: StreamType, hint: ValueKind) -> ValueKind {
+    match stream_type {
+        StreamType::Present => ValueKind::Bool,
+        StreamType::Data(DictionaryType::Vertex | DictionaryType::Morton) => ValueKind::Vertex,
+        StreamType::Offset(_) | StreamType::Length(_) => ValueKind::Int,
+        StreamType::Data(_) => hint,
+    }
+}
+
 /// Parse the metadata portion of a v1 stream header (everything before the payload).
 ///
 /// If `is_bool` is true, compute RLE parameters for boolean streams automatically
@@ -124,6 +136,7 @@ fn stream_type_to_byte(stream_type: StreamType) -> u8 {
 /// stream types. RLE uses `num_rle_values * 8` since that is the actual expanded count.
 pub(crate) fn parse_stream_meta<'a>(
     input: &'a [u8],
+    hint: ValueKind,
     is_bool: bool,
     parser: &mut Parser,
 ) -> MltRefResult<'a, (StreamMeta, u32)> {
@@ -131,6 +144,7 @@ pub(crate) fn parse_stream_meta<'a>(
 
     let (input, st_byte) = parse_u8(input)?;
     let stream_type = stream_type_from_byte(st_byte).ok_or(ParsingStreamType(st_byte))?;
+    let kind = kind_of(stream_type, hint);
 
     let (input, val) = parse_u8(input)?;
     let logical = parse_logical(val)?;
@@ -140,17 +154,23 @@ pub(crate) fn parse_stream_meta<'a>(
     let (input, byte_length) = parse_varint::<u32>(input)?;
 
     let mut input = input;
+    let not_in_kind = || MltError::LogicalEncodingNotInKind(logical, kind);
     let logical_encoding = match logical {
         LC::None | LC::Delta | LC::ComponentwiseDelta => {
             // Reserve decoded memory upper bound: worst case u64 = 8 bytes per value
             let decoded_bytes = num_values.saturating_mul(8);
             parser.reserve(decoded_bytes)?;
-            if logical == LC::None {
-                LogicalEncoding::None
-            } else if logical == LC::Delta {
-                LogicalEncoding::Delta
-            } else {
-                LogicalEncoding::ComponentwiseDelta
+            match (kind, logical) {
+                (ValueKind::Int, LC::None) => LogicalEncoding::Int(IntLogical::None),
+                (ValueKind::Int, LC::Delta) => LogicalEncoding::Int(IntLogical::Delta),
+                (ValueKind::Bool, LC::None) => LogicalEncoding::Bool(BoolLogical::None),
+                (ValueKind::Float, LC::None) => LogicalEncoding::Float(FloatLogical::None),
+                (ValueKind::Vertex, LC::None) => LogicalEncoding::Vertex(VertexLogical::None),
+                (ValueKind::Vertex, LC::Delta) => LogicalEncoding::Vertex(VertexLogical::Delta),
+                (ValueKind::Vertex, LC::ComponentwiseDelta) => {
+                    LogicalEncoding::Vertex(VertexLogical::ComponentwiseDelta)
+                }
+                _ => return Err(not_in_kind()),
             }
         }
         LC::Rle | LC::DeltaRle => {
@@ -170,10 +190,11 @@ pub(crate) fn parse_stream_meta<'a>(
                 runs,
                 num_rle_values,
             };
-            if logical == LC::Rle {
-                LogicalEncoding::Rle(rle)
-            } else {
-                LogicalEncoding::DeltaRle(rle)
+            match (kind, logical) {
+                (ValueKind::Int, LC::Rle) => LogicalEncoding::Int(IntLogical::Rle(rle)),
+                (ValueKind::Int, LC::DeltaRle) => LogicalEncoding::Int(IntLogical::DeltaRle(rle)),
+                (ValueKind::Bool, LC::Rle) => LogicalEncoding::Bool(BoolLogical::ByteRle(rle)),
+                _ => return Err(not_in_kind()),
             }
         }
         LC::Morton | LC::MortonRle | LC::MortonDelta => {
@@ -185,12 +206,15 @@ pub(crate) fn parse_stream_meta<'a>(
             (input, bits) = parse_varint::<u32>(input)?;
             (input, shift) = parse_varint::<u32>(input)?;
             let morton = Morton::new(bits, shift)?;
+            if kind != ValueKind::Vertex {
+                return Err(not_in_kind());
+            }
             if logical == LC::MortonRle {
-                LogicalEncoding::MortonRle(morton)
+                LogicalEncoding::Vertex(VertexLogical::MortonRle(morton))
             } else if logical == LC::MortonDelta {
-                LogicalEncoding::MortonDelta(morton)
+                LogicalEncoding::Vertex(VertexLogical::MortonDelta(morton))
             } else {
-                LogicalEncoding::Morton(morton)
+                LogicalEncoding::Vertex(VertexLogical::Morton(morton))
             }
         }
     };
@@ -213,19 +237,25 @@ pub(crate) fn write_stream_meta<W: io::Write>(
     is_bool: bool,
     byte_length: u32,
 ) -> MltResult<()> {
+    use BoolLogical as BL;
+    use FloatLogical as FL;
+    use IntLogical as IL;
     use LogicalCombination as LC;
     use LogicalEncoding as LE;
+    use VertexLogical as VL;
 
     writer.write_u8(stream_type_to_byte(meta.stream_type))?;
     let logical = match meta.encoding.logical {
-        LE::None => LC::None,
-        LE::Delta => LC::Delta,
-        LE::DeltaRle(_) => LC::DeltaRle,
-        LE::ComponentwiseDelta => LC::ComponentwiseDelta,
-        LE::Rle(_) => LC::Rle,
-        LE::Morton(_) => LC::Morton,
-        LE::MortonRle(_) => LC::MortonRle,
-        LE::MortonDelta(_) => LC::MortonDelta,
+        LE::Int(IL::None) | LE::Bool(BL::None) | LE::Float(FL::None) | LE::Vertex(VL::None) => {
+            LC::None
+        }
+        LE::Int(IL::Delta) | LE::Vertex(VL::Delta) => LC::Delta,
+        LE::Int(IL::Rle(_)) | LE::Bool(BL::ByteRle(_)) => LC::Rle,
+        LE::Int(IL::DeltaRle(_)) => LC::DeltaRle,
+        LE::Vertex(VL::ComponentwiseDelta) => LC::ComponentwiseDelta,
+        LE::Vertex(VL::Morton(_)) => LC::Morton,
+        LE::Vertex(VL::MortonDelta(_)) => LC::MortonDelta,
+        LE::Vertex(VL::MortonRle(_)) => LC::MortonRle,
     };
     writer.write_u8(encoding_byte(logical, meta.encoding.physical))?;
     writer.write_varint(meta.num_values)?;
@@ -234,53 +264,67 @@ pub(crate) fn write_stream_meta<W: io::Write>(
     // some encoding have settings inside them
     match meta.encoding.logical {
         // v1 always uses the Split layout; interleaved is a v2-only concern.
-        LE::DeltaRle(RleMeta::Split {
+        LE::Int(
+            IL::Rle(RleMeta::Split {
+                runs,
+                num_rle_values,
+            })
+            | IL::DeltaRle(RleMeta::Split {
+                runs,
+                num_rle_values,
+            }),
+        )
+        | LE::Bool(BL::ByteRle(RleMeta::Split {
             runs,
             num_rle_values,
-        })
-        | LE::Rle(RleMeta::Split {
-            runs,
-            num_rle_values,
-        }) => {
+        })) => {
             if !is_bool {
                 writer.write_varint(runs)?;
                 writer.write_varint(num_rle_values)?;
             }
         }
         #[cfg(feature = "unstable-v2")]
-        LE::DeltaRle(RleMeta::Interleaved { .. }) | LE::Rle(RleMeta::Interleaved { .. }) => {
+        LE::Int(
+            IL::Rle(RleMeta::Interleaved { .. }) | IL::DeltaRle(RleMeta::Interleaved { .. }),
+        )
+        | LE::Bool(BL::ByteRle(RleMeta::Interleaved { .. })) => {
             return Err(UnsupportedLogicalEncoding(
                 meta.encoding.logical,
                 "v1 stream header codec requires the Split RLE layout",
             ));
         }
-        LE::Morton(m) | LE::MortonDelta(m) | LE::MortonRle(m) => {
+        LE::Vertex(VL::Morton(m) | VL::MortonDelta(m) | VL::MortonRle(m)) => {
             writer.write_varint(m.bits)?;
             writer.write_varint(m.shift)?;
         }
-        LE::None | LE::Delta | LE::ComponentwiseDelta => {}
+        LE::Int(IL::None | IL::Delta)
+        | LE::Bool(BL::None)
+        | LE::Float(_)
+        | LE::Vertex(VL::None | VL::Delta | VL::ComponentwiseDelta) => {}
     }
     Ok(())
 }
 
-/// Parse one v1 stream (header + data).
+/// Parse one v1 stream (header + data), whose data stream holds `hint` values.
 pub(crate) fn parse_stream<'a>(
     input: &'a [u8],
+    hint: ValueKind,
     parser: &mut Parser,
 ) -> MltRefResult<'a, RawStream<'a>> {
-    parse_stream_internal(input, false, parser)
+    parse_stream_internal(input, hint, false, parser)
 }
 
-/// Parse `count` consecutive v1 streams.
+/// Parse `count` consecutive v1 streams, whose data streams hold `hint` values.
 pub(crate) fn parse_multiple_streams<'a>(
     mut input: &'a [u8],
     count: usize,
+    hint: ValueKind,
     parser: &mut Parser,
 ) -> MltRefResult<'a, Vec<RawStream<'a>>> {
     let mut result = Vec::with_capacity(count);
     for _ in 0..count {
         let stream;
-        (input, stream) = parse_stream_internal(input, false, parser)?;
+        (input, stream) = parse_stream_internal(input, hint, false, parser)?;
         result.push(stream);
     }
     Ok((input, result))
@@ -291,7 +335,7 @@ pub(crate) fn parse_bool_stream<'a>(
     input: &'a [u8],
     parser: &mut Parser,
 ) -> MltRefResult<'a, RawStream<'a>> {
-    parse_stream_internal(input, true, parser)
+    parse_stream_internal(input, ValueKind::Bool, true, parser)
 }
 
 /// Parse stream from the input.
@@ -300,25 +344,29 @@ pub(crate) fn parse_bool_stream<'a>(
 /// For RLE streams with `VarInt` data, validates that run lengths sum to `num_rle_values`.
 fn parse_stream_internal<'a>(
     input: &'a [u8],
+    hint: ValueKind,
     is_bool: bool,
     parser: &mut Parser,
 ) -> MltRefResult<'a, RawStream<'a>> {
+    use IntLogical as IL;
     use LogicalEncoding as LE;
     use PhysicalEncoding as PD;
 
-    let (input, (meta, byte_length)) = parse_stream_meta(input, is_bool, parser)?;
+    let (input, (meta, byte_length)) = parse_stream_meta(input, hint, is_bool, parser)?;
     let (input, data) = take(input, byte_length)?;
 
     // For RLE with VarInt physical encoding, validate stream: run lengths must sum to num_rle_values.
     // v1 parsing only ever produces the Split layout.
-    if let LE::Rle(RleMeta::Split {
-        runs,
-        num_rle_values,
-    })
-    | LE::DeltaRle(RleMeta::Split {
-        runs,
-        num_rle_values,
-    }) = meta.encoding.logical
+    if let LE::Int(
+        IL::Rle(RleMeta::Split {
+            runs,
+            num_rle_values,
+        })
+        | IL::DeltaRle(RleMeta::Split {
+            runs,
+            num_rle_values,
+        }),
+    ) = meta.encoding.logical
         && matches!(meta.encoding.physical, PD::VarInt)
         && !is_bool
     {
@@ -352,22 +400,37 @@ mod tests {
     use crate::test_helpers::parser;
 
     const DATA: StreamType = StreamType::Data(DictionaryType::None);
+    const VERTEX: StreamType = StreamType::Data(DictionaryType::Vertex);
 
     /// Place two techniques into the logical fields of the encoding byte.
     fn logical_bits(primary: LogicalTechnique, secondary: LogicalTechnique) -> u8 {
         primary as u8 | ((secondary as u8) >> LOGICAL2_SHIFT)
     }
 
-    fn meta(logical: LogicalEncoding, physical: PhysicalEncoding, num: u32) -> StreamMeta {
-        StreamMeta::new(DATA, IntEncoding::new(logical, physical), num)
+    fn meta(
+        stream_type: StreamType,
+        logical: LogicalEncoding,
+        physical: PhysicalEncoding,
+        num: u32,
+    ) -> StreamMeta {
+        StreamMeta::new(stream_type, IntEncoding::new(logical, physical), num)
+    }
+
+    fn int(physical: PhysicalEncoding, logical: IntLogical) -> StreamMeta {
+        meta(DATA, LogicalEncoding::Int(logical), physical, 5)
     }
 
     #[rstest]
-    #[case::none_varint(meta(LogicalEncoding::None, PhysicalEncoding::VarInt, 5), 0x02)]
-    #[case::none_raw(meta(LogicalEncoding::None, PhysicalEncoding::None, 5), 0x00)]
-    #[case::delta(meta(LogicalEncoding::Delta, PhysicalEncoding::VarInt, 5), 0x22)]
+    #[case::none_varint(int(PhysicalEncoding::VarInt, IntLogical::None), 0x02)]
+    #[case::none_raw(int(PhysicalEncoding::None, IntLogical::None), 0x00)]
+    #[case::delta(int(PhysicalEncoding::VarInt, IntLogical::Delta), 0x22)]
     #[case::cw_delta(
-        meta(LogicalEncoding::ComponentwiseDelta, PhysicalEncoding::VarInt, 5),
+        meta(
+            VERTEX,
+            LogicalEncoding::Vertex(VertexLogical::ComponentwiseDelta),
+            PhysicalEncoding::VarInt,
+            5
+        ),
         0x42
     )]
     fn encoding_byte_values(#[case] meta: StreamMeta, #[case] expected: u8) {
@@ -377,10 +440,15 @@ mod tests {
     }
 
     #[rstest]
-    #[case::none_varint(meta(LogicalEncoding::None, PhysicalEncoding::VarInt, 5))]
-    #[case::none_raw(meta(LogicalEncoding::None, PhysicalEncoding::None, 5))]
-    #[case::delta(meta(LogicalEncoding::Delta, PhysicalEncoding::VarInt, 5))]
-    #[case::cw_delta(meta(LogicalEncoding::ComponentwiseDelta, PhysicalEncoding::VarInt, 5))]
+    #[case::none_varint(int(PhysicalEncoding::VarInt, IntLogical::None))]
+    #[case::none_raw(int(PhysicalEncoding::None, IntLogical::None))]
+    #[case::delta(int(PhysicalEncoding::VarInt, IntLogical::Delta))]
+    #[case::cw_delta(meta(
+        VERTEX,
+        LogicalEncoding::Vertex(VertexLogical::ComponentwiseDelta),
+        PhysicalEncoding::VarInt,
+        5
+    ))]
     fn header_roundtrip(#[case] meta: StreamMeta) {
         let payload = [1_u8, 2, 3];
         let mut buf = Vec::new();
@@ -388,10 +456,24 @@ mod tests {
         write_stream_meta(&meta, &mut buf, false, byte_length).unwrap();
         buf.extend_from_slice(&payload);
 
-        let (rest, stream) = parse_stream(&buf, &mut parser()).unwrap();
+        let hint = meta.encoding.logical.kind();
+        let (rest, stream) = parse_stream(&buf, hint, &mut parser()).unwrap();
         assert!(rest.is_empty());
         assert_eq!(stream.meta, meta);
         assert_eq!(stream.data, payload);
+    }
+
+    #[rstest]
+    #[case::cw_delta_on_an_int_column(LogicalCombination::ComponentwiseDelta, ValueKind::Int)]
+    #[case::delta_on_a_float_column(LogicalCombination::Delta, ValueKind::Float)]
+    #[case::morton_on_an_int_column(LogicalCombination::Morton, ValueKind::Int)]
+    fn rejects_an_encoding_the_kind_does_not_have(
+        #[case] logical: LogicalCombination,
+        #[case] hint: ValueKind,
+    ) {
+        let buf = [stream_type_to_byte(DATA), logical as u8, 0, 0, 0, 0];
+        let err = parse_stream(&buf, hint, &mut parser()).unwrap_err();
+        assert!(matches!(err, MltError::LogicalEncodingNotInKind(_, _)));
     }
 
     #[rstest]
@@ -405,11 +487,12 @@ mod tests {
             num_rle_values: u32::from(run_lengths.iter().sum::<u8>()),
         };
         let logical = if plain_rle {
-            LogicalEncoding::Rle(rle)
+            LogicalEncoding::Int(IntLogical::Rle(rle))
         } else {
-            LogicalEncoding::DeltaRle(rle)
+            LogicalEncoding::Int(IntLogical::DeltaRle(rle))
         };
         let meta = meta(
+            DATA,
             logical,
             PhysicalEncoding::VarInt,
             u32::try_from(run_lengths.len() + values.len()).unwrap(),
@@ -420,7 +503,7 @@ mod tests {
         write_stream_meta(&meta, &mut buf, false, byte_length).unwrap();
         buf.extend_from_slice(&payload);
 
-        let (rest, stream) = parse_stream(&buf, &mut parser()).unwrap();
+        let (rest, stream) = parse_stream(&buf, ValueKind::Int, &mut parser()).unwrap();
         assert!(rest.is_empty());
         assert_eq!(stream.meta, meta);
         assert_eq!(stream.data, payload);
@@ -478,11 +561,11 @@ mod tests {
     fn write_rejects_interleaved_rle(#[case] plain_rle: bool) {
         let rle = RleMeta::Interleaved { num_rle_values: 5 };
         let logical = if plain_rle {
-            LogicalEncoding::Rle(rle)
+            LogicalEncoding::Int(IntLogical::Rle(rle))
         } else {
-            LogicalEncoding::DeltaRle(rle)
+            LogicalEncoding::Int(IntLogical::DeltaRle(rle))
         };
-        let meta = meta(logical, PhysicalEncoding::VarInt, 4);
+        let meta = meta(DATA, logical, PhysicalEncoding::VarInt, 4);
         let mut buf = Vec::new();
         let err = write_stream_meta(&meta, &mut buf, false, 4).unwrap_err();
         assert!(matches!(err, UnsupportedLogicalEncoding(_, _)));
@@ -492,7 +575,7 @@ mod tests {
     fn rejects_invalid_logical_combination() {
         let enc_byte = logical_bits(LogicalTechnique::ComponentwiseDelta, LogicalTechnique::Rle);
         let buf = [0u8, enc_byte, 0, 0];
-        let err = parse_stream(&buf, &mut parser()).unwrap_err();
+        let err = parse_stream(&buf, ValueKind::Int, &mut parser()).unwrap_err();
         assert!(matches!(err, MltError::InvalidLogicalEncodings(_, _)));
     }
 }

--- a/rust/mlt-core/src/decoder/stream/header02.rs
+++ b/rust/mlt-core/src/decoder/stream/header02.rs
@@ -24,8 +24,8 @@
 //! from the count context.
 //!
 //! Not yet implemented (rejected with [`MltError::NotImplemented`]):
-//! `None-noLen` (requires element-width context), `FastPFor128`, `Morton`, and
-//! RLE over a bool or float column.
+//! `None-noLen` (requires element-width context), `FastPFor128`, `Morton`,
+//! and RLE over a bool or float column.
 
 use std::io;
 
@@ -34,8 +34,8 @@ use num_enum::TryFromPrimitive;
 
 use crate::codecs::varint::parse_varint;
 use crate::decoder::{
-    DataType02, DictionaryType, IntEncoding, LengthType, LogicalEncoding, PhysicalEncoding,
-    RawStream, RleMeta, StreamMeta, StreamType,
+    BoolLogical, DataType02, DictionaryType, FloatLogical, IntEncoding, IntLogical, LengthType,
+    LogicalEncoding, PhysicalEncoding, RawStream, RleMeta, StreamMeta, StreamType, VertexLogical,
 };
 use crate::utils::{BinarySerializer as _, parse_u8, take};
 use crate::{MltError, MltRefResult, MltResult, Parser};
@@ -331,28 +331,40 @@ impl Encoding02 {
 
     /// Map down to the flat encoding the rest of the decoder shares with v1.
     /// `num_values` is the expanded element count, which the RLE members need.
-    fn to_flat(self, num_values: u32) -> MltResult<IntEncoding> {
+    fn to_model(self, num_values: u32) -> MltResult<IntEncoding> {
         let rle = || RleMeta::Interleaved {
             num_rle_values: num_values,
         };
         Ok(match self {
-            Self::Int(LogicalInt::None(p)) | Self::Vertex(LogicalVertex::None(p)) => {
-                IntEncoding::new(LogicalEncoding::None, flat_int(p)?)
+            Self::Int(LogicalInt::None(p)) => {
+                IntEncoding::new(LogicalEncoding::Int(IntLogical::None), flat_int(p)?)
             }
-            Self::Int(LogicalInt::Delta(p)) | Self::Vertex(LogicalVertex::Delta(p)) => {
-                IntEncoding::new(LogicalEncoding::Delta, flat_int(p)?)
+            Self::Vertex(LogicalVertex::None(p)) => {
+                IntEncoding::new(LogicalEncoding::Vertex(VertexLogical::None), flat_int(p)?)
             }
-            Self::Vertex(LogicalVertex::CwDelta(p)) => {
-                IntEncoding::new(LogicalEncoding::ComponentwiseDelta, flat_int(p)?)
+            Self::Int(LogicalInt::Delta(p)) => {
+                IntEncoding::new(LogicalEncoding::Int(IntLogical::Delta), flat_int(p)?)
             }
-            Self::Int(LogicalInt::Rle) => {
-                IntEncoding::new(LogicalEncoding::Rle(rle()), PhysicalEncoding::VarInt)
+            Self::Vertex(LogicalVertex::Delta(p)) => {
+                IntEncoding::new(LogicalEncoding::Vertex(VertexLogical::Delta), flat_int(p)?)
             }
-            Self::Int(LogicalInt::DeltaRle) => {
-                IntEncoding::new(LogicalEncoding::DeltaRle(rle()), PhysicalEncoding::VarInt)
+            Self::Vertex(LogicalVertex::CwDelta(p)) => IntEncoding::new(
+                LogicalEncoding::Vertex(VertexLogical::ComponentwiseDelta),
+                flat_int(p)?,
+            ),
+            Self::Int(LogicalInt::Rle) => IntEncoding::new(
+                LogicalEncoding::Int(IntLogical::Rle(rle())),
+                PhysicalEncoding::VarInt,
+            ),
+            Self::Int(LogicalInt::DeltaRle) => IntEncoding::new(
+                LogicalEncoding::Int(IntLogical::DeltaRle(rle())),
+                PhysicalEncoding::VarInt,
+            ),
+            Self::Bool(LogicalBool::None(p)) => {
+                IntEncoding::new(LogicalEncoding::Bool(BoolLogical::None), flat_bits(p)?)
             }
-            Self::Bool(LogicalBool::None(p)) | Self::Float(LogicalFloat::None(p)) => {
-                IntEncoding::new(LogicalEncoding::None, flat_bits(p)?)
+            Self::Float(LogicalFloat::None(p)) => {
+                IntEncoding::new(LogicalEncoding::Float(FloatLogical::None), flat_bits(p)?)
             }
             Self::Bool(LogicalBool::Rle) => {
                 return Err(MltError::NotImplemented("v2 RLE over a bool column"));
@@ -392,10 +404,14 @@ fn flat_bits(physical: PhysicalBits) -> MltResult<PhysicalEncoding> {
     }
 }
 
-/// The logical encoding and physical field bits `encoding` is written as, the reverse of [`Encoding02::to_flat`].
+/// The logical encoding and physical field bits `encoding` is written as, the reverse of [`Encoding02::to_model`].
 /// The caller checks the result against the stream's family, which is where an illegal pairing is caught.
 fn wire_fields(encoding: IntEncoding, family: Family) -> MltResult<(Logical, u8)> {
+    use BoolLogical as BL;
+    use FloatLogical as FL;
+    use IntLogical as IL;
     use LogicalEncoding as LE;
+    use VertexLogical as VL;
 
     let physical = |encoding: IntEncoding| -> MltResult<u8> {
         Ok(match (family, encoding.physical) {
@@ -416,10 +432,12 @@ fn wire_fields(encoding: IntEncoding, family: Family) -> MltResult<(Logical, u8)
     };
 
     Ok(match encoding.logical {
-        LE::None => (Logical::None, physical(encoding)?),
-        LE::Delta => (Logical::Delta, physical(encoding)?),
-        LE::ComponentwiseDelta => (Logical::CwDelta, physical(encoding)?),
-        LE::Rle(rle) | LE::DeltaRle(rle) => {
+        LE::Int(IL::None) | LE::Bool(BL::None) | LE::Float(FL::None) | LE::Vertex(VL::None) => {
+            (Logical::None, physical(encoding)?)
+        }
+        LE::Int(IL::Delta) | LE::Vertex(VL::Delta) => (Logical::Delta, physical(encoding)?),
+        LE::Vertex(VL::ComponentwiseDelta) => (Logical::CwDelta, physical(encoding)?),
+        LE::Int(IL::Rle(rle) | IL::DeltaRle(rle)) => {
             if !matches!(rle, RleMeta::Interleaved { .. }) {
                 return Err(MltError::UnsupportedLogicalEncoding(
                     encoding.logical,
@@ -431,7 +449,7 @@ fn wire_fields(encoding: IntEncoding, family: Family) -> MltResult<(Logical, u8)
                     "v2 RLE requires VarInt",
                 ));
             }
-            let logical = if matches!(encoding.logical, LE::Rle(_)) {
+            let logical = if matches!(encoding.logical, LE::Int(IL::Rle(_))) {
                 Logical::Rle
             } else {
                 Logical::DeltaRle
@@ -439,7 +457,13 @@ fn wire_fields(encoding: IntEncoding, family: Family) -> MltResult<(Logical, u8)
             // The physical encoding is implied, so the field stays zero.
             (logical, 0)
         }
-        LE::Morton(_) | LE::MortonDelta(_) | LE::MortonRle(_) => {
+        LE::Bool(BL::ByteRle(_)) => {
+            return Err(MltError::UnsupportedLogicalEncoding(
+                encoding.logical,
+                "v2, whose bool columns have no byte-RLE",
+            ));
+        }
+        LE::Vertex(VL::Morton(_) | VL::MortonDelta(_) | VL::MortonRle(_)) => {
             return Err(MltError::NotImplemented("v2 Morton streams"));
         }
     })
@@ -472,7 +496,7 @@ pub(crate) fn parse_stream<'a>(
     // Reserve decoded memory upper bound: worst case u64 = 8 bytes per value.
     parser.reserve(num_values.saturating_mul(8))?;
 
-    let encoding = encoding.to_flat(num_values)?;
+    let encoding = encoding.to_model(num_values)?;
     let (input, byte_length) = parse_varint::<u32>(input)?;
     let (input, data) = take(input, byte_length)?;
     let meta = StreamMeta::new(ctx.stream_type(), encoding, num_values);
@@ -507,13 +531,11 @@ pub(crate) fn write_stream_meta<W: io::Write>(
     // in-memory `num_values` holds the encoded word count, which a v2 decoder
     // derives by scanning the pairs to `byte_length`).
     let num_values = match meta.encoding.logical {
-        LE::Rle(rle) | LE::DeltaRle(rle) => rle.num_rle_values(),
-        LE::None
-        | LE::Delta
-        | LE::ComponentwiseDelta
-        | LE::Morton(_)
-        | LE::MortonDelta(_)
-        | LE::MortonRle(_) => meta.num_values,
+        LE::Int(IntLogical::Rle(rle) | IntLogical::DeltaRle(rle)) => rle.num_rle_values(),
+        LE::Int(IntLogical::None | IntLogical::Delta)
+        | LE::Bool(_)
+        | LE::Float(_)
+        | LE::Vertex(_) => meta.num_values,
     };
     let explicit = num_values != implicit_count;
     let enc_byte =
@@ -551,6 +573,7 @@ mod tests {
     use strum::{EnumCount as _, IntoEnumIterator as _};
 
     use super::*;
+    use crate::decoder::Morton;
     use crate::test_helpers::parser;
 
     const INT: StreamCtx02 = StreamCtx02::Property(DataType02::U32);
@@ -558,9 +581,27 @@ mod tests {
     const FLOAT: StreamCtx02 = StreamCtx02::Property(DataType02::F64);
     const VERTEX: StreamCtx02 = StreamCtx02::GeomVertices;
 
+    use PhysicalEncoding as PE;
+
     fn meta(logical: LogicalEncoding, physical: PhysicalEncoding, num: u32) -> StreamMeta {
         let stream_type = StreamType::Data(DictionaryType::None);
         StreamMeta::new(stream_type, IntEncoding::new(logical, physical), num)
+    }
+
+    fn int(logical: IntLogical, physical: PhysicalEncoding, num: u32) -> StreamMeta {
+        meta(LogicalEncoding::Int(logical), physical, num)
+    }
+
+    fn boolean(logical: BoolLogical, physical: PhysicalEncoding, num: u32) -> StreamMeta {
+        meta(LogicalEncoding::Bool(logical), physical, num)
+    }
+
+    fn float(logical: FloatLogical, physical: PhysicalEncoding, num: u32) -> StreamMeta {
+        meta(LogicalEncoding::Float(logical), physical, num)
+    }
+
+    fn vertex(logical: VertexLogical, physical: PhysicalEncoding, num: u32) -> StreamMeta {
+        meta(LogicalEncoding::Vertex(logical), physical, num)
     }
 
     fn rle(num: u32) -> RleMeta {
@@ -646,56 +687,26 @@ mod tests {
     }
 
     #[rstest]
-    #[case::varint_implicit(
-        meta(LogicalEncoding::None, PhysicalEncoding::VarInt, 5),
-        5,
-        Family::Int,
-        0b0000_1000
-    )]
-    #[case::varint_explicit(
-        meta(LogicalEncoding::None, PhysicalEncoding::VarInt, 5),
-        9,
-        Family::Int,
-        0b1000_1000
-    )]
-    #[case::raw_implicit(
-        meta(LogicalEncoding::None, PhysicalEncoding::None, 5),
-        5,
-        Family::Int,
-        0b0000_0100
-    )]
-    #[case::delta_varint(
-        meta(LogicalEncoding::Delta, PhysicalEncoding::VarInt, 5),
-        5,
-        Family::Int,
-        0b0001_1000
-    )]
+    #[case::varint_implicit(int(IntLogical::None, PE::VarInt, 5), 5, Family::Int, 0b0000_1000)]
+    #[case::varint_explicit(int(IntLogical::None, PE::VarInt, 5), 9, Family::Int, 0b1000_1000)]
+    #[case::raw_implicit(int(IntLogical::None, PE::None, 5), 5, Family::Int, 0b0000_0100)]
+    #[case::delta_varint(int(IntLogical::Delta, PE::VarInt, 5), 5, Family::Int, 0b0001_1000)]
     #[case::rle_implicit(
-        meta(LogicalEncoding::Rle(rle(5)), PhysicalEncoding::VarInt, 5),
+        int(IntLogical::Rle(rle(5)), PE::VarInt, 5),
         5,
         Family::Int,
         0b0010_0000
     )]
     #[case::delta_rle(
-        meta(LogicalEncoding::DeltaRle(rle(5)), PhysicalEncoding::VarInt, 5),
+        int(IntLogical::DeltaRle(rle(5)), PE::VarInt, 5),
         5,
         Family::Int,
         0b0011_0000
     )]
-    #[case::raw_float(
-        meta(LogicalEncoding::None, PhysicalEncoding::None, 5),
-        5,
-        Family::Float,
-        0b0000_0100
-    )]
-    #[case::raw_bool(
-        meta(LogicalEncoding::None, PhysicalEncoding::None, 5),
-        5,
-        Family::Bool,
-        0b0000_0100
-    )]
+    #[case::raw_float(float(FloatLogical::None, PE::None, 5), 5, Family::Float, 0b0000_0100)]
+    #[case::raw_bool(boolean(BoolLogical::None, PE::None, 5), 5, Family::Bool, 0b0000_0100)]
     #[case::cw_delta_vertices_explicit(
-        meta(LogicalEncoding::ComponentwiseDelta, PhysicalEncoding::VarInt, 8),
+        vertex(VertexLogical::ComponentwiseDelta, PE::VarInt, 8),
         5,
         Family::Vertex,
         0b1010_1000
@@ -712,27 +723,15 @@ mod tests {
     }
 
     #[rstest]
-    #[case::varint(meta(LogicalEncoding::None, PhysicalEncoding::VarInt, 5), 5, INT)]
-    #[case::varint_explicit(meta(LogicalEncoding::None, PhysicalEncoding::VarInt, 7), 5, INT)]
-    #[case::raw(meta(LogicalEncoding::None, PhysicalEncoding::None, 5), 5, INT)]
-    #[case::delta(meta(LogicalEncoding::Delta, PhysicalEncoding::VarInt, 5), 5, INT)]
-    #[case::rle(
-        meta(LogicalEncoding::Rle(rle(5)), PhysicalEncoding::VarInt, 5),
-        5,
-        INT
-    )]
-    #[case::delta_rle(
-        meta(LogicalEncoding::DeltaRle(rle(9)), PhysicalEncoding::VarInt, 9),
-        5,
-        INT
-    )]
-    #[case::raw_float(meta(LogicalEncoding::None, PhysicalEncoding::None, 5), 5, FLOAT)]
-    #[case::raw_bool(meta(LogicalEncoding::None, PhysicalEncoding::None, 5), 5, BOOL)]
-    #[case::cw_delta_vertices(
-        meta(LogicalEncoding::ComponentwiseDelta, PhysicalEncoding::VarInt, 10),
-        5,
-        VERTEX
-    )]
+    #[case::varint(int(IntLogical::None, PE::VarInt, 5), 5, INT)]
+    #[case::varint_explicit(int(IntLogical::None, PE::VarInt, 7), 5, INT)]
+    #[case::raw(int(IntLogical::None, PE::None, 5), 5, INT)]
+    #[case::delta(int(IntLogical::Delta, PE::VarInt, 5), 5, INT)]
+    #[case::rle(int(IntLogical::Rle(rle(5)), PE::VarInt, 5), 5, INT)]
+    #[case::delta_rle(int(IntLogical::DeltaRle(rle(9)), PE::VarInt, 9), 5, INT)]
+    #[case::raw_float(float(FloatLogical::None, PE::None, 5), 5, FLOAT)]
+    #[case::raw_bool(boolean(BoolLogical::None, PE::None, 5), 5, BOOL)]
+    #[case::cw_delta_vertices(vertex(VertexLogical::ComponentwiseDelta, PE::VarInt, 10), 5, VERTEX)]
     fn header_roundtrip(
         #[case] meta: StreamMeta,
         #[case] implicit_count: u32,
@@ -790,9 +789,17 @@ mod tests {
     }
 
     #[rstest]
-    #[case::delta(0b0001_1000, LogicalEncoding::Delta, "encoding byte")]
-    #[case::rle(0b0010_0000, LogicalEncoding::Rle(rle(1)), "encoding byte")]
-    #[case::delta_rle(0b0011_0000, LogicalEncoding::DeltaRle(rle(1)), "encoding byte")]
+    #[case::delta(0b0001_1000, LogicalEncoding::Int(IntLogical::Delta), "encoding byte")]
+    #[case::rle(
+        0b0010_0000,
+        LogicalEncoding::Int(IntLogical::Rle(rle(1))),
+        "encoding byte"
+    )]
+    #[case::delta_rle(
+        0b0011_0000,
+        LogicalEncoding::Int(IntLogical::DeltaRle(rle(1))),
+        "encoding byte"
+    )]
     fn an_int_bit_pattern_never_means_the_same_on_a_float_column(
         #[case] enc_byte: u8,
         #[case] as_int: LogicalEncoding,
@@ -827,9 +834,9 @@ mod tests {
             num_rle_values: 5,
         };
         let logical = if plain_rle {
-            LogicalEncoding::Rle(rle)
+            LogicalEncoding::Int(IntLogical::Rle(rle))
         } else {
-            LogicalEncoding::DeltaRle(rle)
+            LogicalEncoding::Int(IntLogical::DeltaRle(rle))
         };
         let meta = meta(logical, PhysicalEncoding::VarInt, 5);
         let mut buf = Vec::new();
@@ -838,9 +845,21 @@ mod tests {
     }
 
     #[rstest]
-    #[case::delta_on_a_float_column(LogicalEncoding::Delta, Family::Float)]
-    #[case::delta_on_a_bool_column(LogicalEncoding::Delta, Family::Bool)]
-    #[case::cw_delta_on_a_property_column(LogicalEncoding::ComponentwiseDelta, Family::Int)]
+    #[case::cw_delta_on_a_property_column(
+        LogicalEncoding::Vertex(VertexLogical::ComponentwiseDelta),
+        Family::Int
+    )]
+    #[case::morton_on_a_property_column(
+        LogicalEncoding::Vertex(VertexLogical::Morton(Morton::new(4, 0).unwrap())),
+        Family::Int
+    )]
+    #[case::byte_rle_on_a_bool_column(
+        LogicalEncoding::Bool(BoolLogical::ByteRle(RleMeta::Split {
+            runs: 1,
+            num_rle_values: 1
+        })),
+        Family::Bool
+    )]
     fn write_rejects_a_logical_the_family_does_not_list(
         #[case] logical: LogicalEncoding,
         #[case] family: Family,
@@ -849,7 +868,10 @@ mod tests {
         let mut buf = Vec::new();
         let err = write_stream_meta(&meta, &mut buf, 0, 5, family).unwrap_err();
         assert!(
-            matches!(err, MltError::UnsupportedLogicalEncoding(_, _)),
+            matches!(
+                err,
+                MltError::UnsupportedLogicalEncoding(_, _) | MltError::NotImplemented(_)
+            ),
             "{err:?}"
         );
     }

--- a/rust/mlt-core/src/decoder/stream/logical.rs
+++ b/rust/mlt-core/src/decoder/stream/logical.rs
@@ -6,7 +6,9 @@ use usize_cast::IntoUsize as _;
 
 use crate::MltError::{ParsingLogicalTechnique, RleRunLenInvalid, UnsupportedLogicalEncoding};
 use crate::codecs::zigzag::{decode_componentwise_delta_vec2s, decode_zigzag, decode_zigzag_delta};
-use crate::decoder::{LogicalEncoding, LogicalTechnique, LogicalValue, RleMeta, StreamMeta};
+use crate::decoder::{
+    IntLogical, LogicalEncoding, LogicalTechnique, LogicalValue, RleMeta, StreamMeta, VertexLogical,
+};
 use crate::errors::{AsMltError as _, fail_if_invalid_stream_size};
 use crate::{Decoder, MltResult};
 
@@ -121,20 +123,28 @@ impl LogicalValue {
     /// Never called for `LogicalEncoding::None` - that case is handled directly
     /// in the bridge (physical buffer decoded into a fresh output Vec).
     pub fn decode_i32(self, data: &[u32], dec: &mut Decoder) -> MltResult<Vec<i32>> {
+        use IntLogical as IL;
+        use LogicalEncoding as LE;
+        use VertexLogical as VL;
+
         match self.meta.encoding.logical {
-            LogicalEncoding::None => decode_zigzag(data, dec),
-            LogicalEncoding::Rle(v) => decode_zigzag(&v.decode(data, dec)?, dec),
-            LogicalEncoding::ComponentwiseDelta => decode_componentwise_delta_vec2s(data, dec),
-            LogicalEncoding::Delta => decode_zigzag_delta::<i32, _>(data, dec),
-            LogicalEncoding::DeltaRle(v) => {
+            LE::Int(IL::None) | LE::Vertex(VL::None) => decode_zigzag(data, dec),
+            LE::Int(IL::Rle(v)) => decode_zigzag(&v.decode(data, dec)?, dec),
+            LE::Vertex(VL::ComponentwiseDelta) => decode_componentwise_delta_vec2s(data, dec),
+            LE::Int(IL::Delta) | LE::Vertex(VL::Delta) => decode_zigzag_delta::<i32, _>(data, dec),
+            LE::Int(IL::DeltaRle(v)) => {
                 let expanded = v.decode(data, dec)?;
                 decode_zigzag_delta::<i32, _>(&expanded, dec)
             }
-            LogicalEncoding::Morton(v) => v.decode_codes(data, dec),
-            LogicalEncoding::MortonDelta(v) => v.decode_delta(data, dec),
-            LogicalEncoding::MortonRle(_) => Err(UnsupportedLogicalEncoding(
+            LE::Vertex(VL::Morton(v)) => v.decode_codes(data, dec),
+            LE::Vertex(VL::MortonDelta(v)) => v.decode_delta(data, dec),
+            LE::Vertex(VL::MortonRle(_)) => Err(UnsupportedLogicalEncoding(
                 self.meta.encoding.logical,
                 "i32 (MortonRle)",
+            )),
+            LE::Bool(_) | LE::Float(_) => Err(UnsupportedLogicalEncoding(
+                self.meta.encoding.logical,
+                "i32",
             )),
         }
     }
@@ -146,23 +156,22 @@ impl LogicalValue {
     pub fn decode_u32(self, data: &[u32], dec: &mut Decoder) -> MltResult<Vec<u32>> {
         let num = self.meta.num_values.into_usize();
         match self.meta.encoding.logical {
-            LogicalEncoding::None => {
+            LogicalEncoding::Int(IntLogical::None) => {
                 // Caller should have used the direct-output path; this is a fallback.
                 dec.consume_items::<u32>(num)?;
                 Ok(data.to_vec())
             }
-            LogicalEncoding::Rle(rle) => rle.decode(data, dec),
-            LogicalEncoding::Delta => decode_zigzag_delta::<i32, _>(data, dec),
-            LogicalEncoding::DeltaRle(rle) => {
+            LogicalEncoding::Int(IntLogical::Rle(rle)) => rle.decode(data, dec),
+            LogicalEncoding::Int(IntLogical::Delta) => decode_zigzag_delta::<i32, _>(data, dec),
+            LogicalEncoding::Int(IntLogical::DeltaRle(rle)) => {
                 decode_zigzag_delta::<i32, _>(&rle.decode(data, dec)?, dec)
             }
-            LogicalEncoding::ComponentwiseDelta
-            | LogicalEncoding::Morton(_)
-            | LogicalEncoding::MortonDelta(_)
-            | LogicalEncoding::MortonRle(_) => Err(UnsupportedLogicalEncoding(
-                self.meta.encoding.logical,
-                "u32",
-            )),
+            LogicalEncoding::Bool(_) | LogicalEncoding::Float(_) | LogicalEncoding::Vertex(_) => {
+                Err(UnsupportedLogicalEncoding(
+                    self.meta.encoding.logical,
+                    "u32",
+                ))
+            }
         }
     }
 
@@ -172,24 +181,23 @@ impl LogicalValue {
     /// in the bridge (physical buffer decoded into a fresh output Vec).
     pub fn decode_i64(self, data: &[u64], dec: &mut Decoder) -> MltResult<Vec<i64>> {
         match self.meta.encoding.logical {
-            LogicalEncoding::None => decode_zigzag(data, dec),
-            LogicalEncoding::Delta => decode_zigzag_delta::<i64, _>(data, dec),
-            LogicalEncoding::DeltaRle(rle) => {
+            LogicalEncoding::Int(IntLogical::None) => decode_zigzag(data, dec),
+            LogicalEncoding::Int(IntLogical::Delta) => decode_zigzag_delta::<i64, _>(data, dec),
+            LogicalEncoding::Int(IntLogical::DeltaRle(rle)) => {
                 let expanded = rle.decode(data, dec)?;
                 decode_zigzag_delta::<i64, _>(&expanded, dec)
             }
-            LogicalEncoding::Rle(rle) => {
+            LogicalEncoding::Int(IntLogical::Rle(rle)) => {
                 // rle.decode() charges for expanded u64 vec; decode_zigzag charges for i64 vec
                 let expanded = rle.decode(data, dec)?;
                 decode_zigzag(&expanded, dec)
             }
-            LogicalEncoding::ComponentwiseDelta
-            | LogicalEncoding::Morton(_)
-            | LogicalEncoding::MortonDelta(_)
-            | LogicalEncoding::MortonRle(_) => Err(UnsupportedLogicalEncoding(
-                self.meta.encoding.logical,
-                "i64",
-            )),
+            LogicalEncoding::Bool(_) | LogicalEncoding::Float(_) | LogicalEncoding::Vertex(_) => {
+                Err(UnsupportedLogicalEncoding(
+                    self.meta.encoding.logical,
+                    "i64",
+                ))
+            }
         }
     }
 
@@ -200,24 +208,23 @@ impl LogicalValue {
     pub fn decode_u64(self, data: &[u64], dec: &mut Decoder) -> MltResult<Vec<u64>> {
         let num = self.meta.num_values.into_usize();
         match self.meta.encoding.logical {
-            LogicalEncoding::None => {
+            LogicalEncoding::Int(IntLogical::None) => {
                 // Caller should have used the direct-output path; this is a fallback.
                 dec.consume_items::<u64>(num)?;
                 Ok(data.to_vec())
             }
-            LogicalEncoding::Rle(rle) => rle.decode(data, dec),
-            LogicalEncoding::Delta => decode_zigzag_delta::<i64, _>(data, dec),
-            LogicalEncoding::DeltaRle(rle) => {
+            LogicalEncoding::Int(IntLogical::Rle(rle)) => rle.decode(data, dec),
+            LogicalEncoding::Int(IntLogical::Delta) => decode_zigzag_delta::<i64, _>(data, dec),
+            LogicalEncoding::Int(IntLogical::DeltaRle(rle)) => {
                 let expanded = rle.decode(data, dec)?;
                 decode_zigzag_delta::<i64, _>(&expanded, dec)
             }
-            LogicalEncoding::ComponentwiseDelta
-            | LogicalEncoding::Morton(_)
-            | LogicalEncoding::MortonDelta(_)
-            | LogicalEncoding::MortonRle(_) => Err(UnsupportedLogicalEncoding(
-                self.meta.encoding.logical,
-                "u64",
-            )),
+            LogicalEncoding::Bool(_) | LogicalEncoding::Float(_) | LogicalEncoding::Vertex(_) => {
+                Err(UnsupportedLogicalEncoding(
+                    self.meta.encoding.logical,
+                    "u64",
+                ))
+            }
         }
     }
 }

--- a/rust/mlt-core/src/decoder/stream/model.rs
+++ b/rust/mlt-core/src/decoder/stream/model.rs
@@ -97,17 +97,99 @@ impl Morton {
     }
 }
 
-/// How should the stream be interpreted at the logical level (second pass of decoding)
+/// What kind of values a stream holds, which fixes the encodings it can name.
+/// Neither wire format stores it: v1 reads it from the column type, v2 from the stream's context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValueKind {
+    Int,
+    Bool,
+    Float,
+    Vertex,
+}
+
+/// Logical encoding of a stream of integer values.
+/// Covers the id columns, the integer property columns, and the geometry length and offset streams.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum LogicalEncoding {
+pub enum IntLogical {
     None,
     Delta,
-    DeltaRle(RleMeta),
-    ComponentwiseDelta,
     Rle(RleMeta),
+    DeltaRle(RleMeta),
+}
+
+/// Logical encoding of a bool column's data stream or a presence bitfield.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum BoolLogical {
+    /// A raw packed bitmap, one bit per value.
+    None,
+    /// A byte-RLE compressed bitmap.
+    /// Its run parameters come from the stream's context rather than from its header.
+    ByteRle(RleMeta),
+}
+
+/// Logical encoding of a float column's data stream.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum FloatLogical {
+    /// Fixed-width little-endian values, one per element.
+    None,
+}
+
+/// Logical encoding of a geometry vertex stream, whose values are interleaved coordinate pairs.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum VertexLogical {
+    None,
+    Delta,
+    ComponentwiseDelta,
     Morton(Morton),
     MortonDelta(Morton),
     MortonRle(Morton),
+}
+
+/// How should the stream be interpreted at the logical level (second pass of decoding)
+///
+/// Split per [`ValueKind`] so a stream can name only the encodings its values can have.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LogicalEncoding {
+    Int(IntLogical),
+    Bool(BoolLogical),
+    Float(FloatLogical),
+    Vertex(VertexLogical),
+}
+
+impl LogicalEncoding {
+    /// The kind of values this encoding belongs to.
+    #[must_use]
+    pub fn kind(self) -> ValueKind {
+        match self {
+            Self::Int(_) => ValueKind::Int,
+            Self::Bool(_) => ValueKind::Bool,
+            Self::Float(_) => ValueKind::Float,
+            Self::Vertex(_) => ValueKind::Vertex,
+        }
+    }
+
+    /// The identity encoding for `kind`, i.e. values stored as they are.
+    #[must_use]
+    pub(crate) fn none(kind: ValueKind) -> Self {
+        match kind {
+            ValueKind::Int => Self::Int(IntLogical::None),
+            ValueKind::Bool => Self::Bool(BoolLogical::None),
+            ValueKind::Float => Self::Float(FloatLogical::None),
+            ValueKind::Vertex => Self::Vertex(VertexLogical::None),
+        }
+    }
+
+    /// Whether the stream's own logical pass is a no-op, so the physical words are already the output.
+    #[must_use]
+    pub(crate) fn is_identity(self) -> bool {
+        matches!(
+            self,
+            Self::Int(IntLogical::None)
+                | Self::Bool(BoolLogical::None)
+                | Self::Float(FloatLogical::None)
+                | Self::Vertex(VertexLogical::None)
+        )
+    }
 }
 
 /// Carries the stream metadata needed to perform the logical decode pass.
@@ -194,8 +276,8 @@ impl IntEncoding {
     }
 
     #[must_use]
-    pub(crate) const fn none() -> Self {
-        Self::new(LogicalEncoding::None, PhysicalEncoding::None)
+    pub(crate) fn none(kind: ValueKind) -> Self {
+        Self::new(LogicalEncoding::none(kind), PhysicalEncoding::None)
     }
 }
 
@@ -231,8 +313,12 @@ impl StreamMeta {
     }
 
     #[inline]
-    pub(crate) fn new_none(stream_type: StreamType, num_values: usize) -> MltResult<Self> {
-        let enc = IntEncoding::none();
+    pub(crate) fn new_none(
+        stream_type: StreamType,
+        kind: ValueKind,
+        num_values: usize,
+    ) -> MltResult<Self> {
+        let enc = IntEncoding::none(kind);
         Ok(Self::new(stream_type, enc, u32::try_from(num_values)?))
     }
 }

--- a/rust/mlt-core/src/dump/walker01.rs
+++ b/rust/mlt-core/src/dump/walker01.rs
@@ -8,7 +8,10 @@ use crate::codecs::varint::parse_varint;
 use crate::decoder::stream::header01::parse_stream_meta;
 use crate::decoder::{Column, ColumnType, DictionaryType, StreamType};
 use crate::utils::{parse_string, take};
-use crate::wire::{LogicalEncoding, LogicalTechnique, PhysicalEncoding, StreamMeta};
+use crate::wire::{
+    BoolLogical, IntLogical, LogicalEncoding, LogicalTechnique, PhysicalEncoding, StreamMeta,
+    ValueKind, VertexLogical,
+};
 use crate::{MltError, MltResult};
 
 impl<'a> Walker<'a> {
@@ -152,11 +155,15 @@ impl<'a> Walker<'a> {
         match typ {
             C::Id | C::OptId => {
                 input = self.walk_optional(input, typ)?;
-                input = self.walk_stream(input, false, "id", |_| DecodeHint::U32)?.0;
+                input = self
+                    .walk_stream(input, ValueKind::Int, "id", |_| DecodeHint::U32)?
+                    .0;
             }
             C::LongId | C::OptLongId => {
                 input = self.walk_optional(input, typ)?;
-                input = self.walk_stream(input, false, "id", |_| DecodeHint::U64)?.0;
+                input = self
+                    .walk_stream(input, ValueKind::Int, "id", |_| DecodeHint::U64)?
+                    .0;
             }
             C::Geometry => {
                 input = self.walk_geometry(input)?;
@@ -164,43 +171,43 @@ impl<'a> Walker<'a> {
             C::Bool | C::OptBool => {
                 input = self.walk_optional(input, typ)?;
                 input = self
-                    .walk_stream(input, true, "data", |_| DecodeHint::Bool)?
+                    .walk_stream(input, ValueKind::Bool, "data", |_| DecodeHint::Bool)?
                     .0;
             }
             C::I8 | C::OptI8 | C::I32 | C::OptI32 => {
                 input = self.walk_optional(input, typ)?;
                 input = self
-                    .walk_stream(input, false, "data", |_| DecodeHint::I32)?
+                    .walk_stream(input, ValueKind::Int, "data", |_| DecodeHint::I32)?
                     .0;
             }
             C::U8 | C::OptU8 | C::U32 | C::OptU32 => {
                 input = self.walk_optional(input, typ)?;
                 input = self
-                    .walk_stream(input, false, "data", |_| DecodeHint::U32)?
+                    .walk_stream(input, ValueKind::Int, "data", |_| DecodeHint::U32)?
                     .0;
             }
             C::I64 | C::OptI64 => {
                 input = self.walk_optional(input, typ)?;
                 input = self
-                    .walk_stream(input, false, "data", |_| DecodeHint::I64)?
+                    .walk_stream(input, ValueKind::Int, "data", |_| DecodeHint::I64)?
                     .0;
             }
             C::U64 | C::OptU64 => {
                 input = self.walk_optional(input, typ)?;
                 input = self
-                    .walk_stream(input, false, "data", |_| DecodeHint::U64)?
+                    .walk_stream(input, ValueKind::Int, "data", |_| DecodeHint::U64)?
                     .0;
             }
             C::F32 | C::OptF32 => {
                 input = self.walk_optional(input, typ)?;
                 input = self
-                    .walk_stream(input, false, "data", |_| DecodeHint::F32)?
+                    .walk_stream(input, ValueKind::Float, "data", |_| DecodeHint::F32)?
                     .0;
             }
             C::F64 | C::OptF64 => {
                 input = self.walk_optional(input, typ)?;
                 input = self
-                    .walk_stream(input, false, "data", |_| DecodeHint::F64)?
+                    .walk_stream(input, ValueKind::Float, "data", |_| DecodeHint::F64)?
                     .0;
             }
             C::Str | C::OptStr => {
@@ -219,7 +226,7 @@ impl<'a> Walker<'a> {
     fn walk_optional(&mut self, input: &'a [u8], typ: ColumnType) -> MltResult<&'a [u8]> {
         if typ.is_optional() {
             Ok(self
-                .walk_stream(input, true, "present", |_| DecodeHint::Presence)?
+                .walk_stream(input, ValueKind::Bool, "present", |_| DecodeHint::Presence)?
                 .0)
         } else {
             Ok(input)
@@ -237,10 +244,12 @@ impl<'a> Walker<'a> {
         if stream_count == 0 {
             return Err(MltError::GeometryWithoutStreams);
         }
-        input = self.walk_stream(input, false, "meta", geom_hint)?.0;
+        input = self
+            .walk_stream(input, ValueKind::Int, "meta", geom_hint)?
+            .0;
         for j in 0..stream_count - 1 {
             input = self
-                .walk_stream(input, false, &format!("stream[{j}]"), geom_hint)?
+                .walk_stream(input, ValueKind::Int, &format!("stream[{j}]"), geom_hint)?
                 .0;
         }
         Ok(input)
@@ -261,13 +270,13 @@ impl<'a> Walker<'a> {
                 return Err(MltError::UnsupportedStringStreamCount(remaining));
             }
             input = self
-                .walk_stream(input, true, "present", |_| DecodeHint::Presence)?
+                .walk_stream(input, ValueKind::Bool, "present", |_| DecodeHint::Presence)?
                 .0;
             remaining -= 1;
         }
         for j in 0..remaining {
             input = self
-                .walk_stream(input, false, &format!("stream[{j}]"), auto_hint)?
+                .walk_stream(input, ValueKind::Int, &format!("stream[{j}]"), auto_hint)?
                 .0;
         }
         Ok(input)
@@ -285,8 +294,12 @@ impl<'a> Walker<'a> {
         // Dictionary streams: read until the DATA(Single|Shared) stream.
         let mut taken = 0usize;
         loop {
-            let (rest, meta) =
-                self.walk_stream(input, false, &format!("dict_stream[{taken}]"), auto_hint)?;
+            let (rest, meta) = self.walk_stream(
+                input,
+                ValueKind::Int,
+                &format!("dict_stream[{taken}]"),
+                auto_hint,
+            )?;
             input = rest;
             taken += 1;
             if matches!(
@@ -312,10 +325,12 @@ impl<'a> Walker<'a> {
             input = rest;
             if child.typ.is_optional() {
                 input = self
-                    .walk_stream(input, true, "present", |_| DecodeHint::Presence)?
+                    .walk_stream(input, ValueKind::Bool, "present", |_| DecodeHint::Presence)?
                     .0;
             }
-            input = self.walk_stream(input, false, "data", auto_hint)?.0;
+            input = self
+                .walk_stream(input, ValueKind::Int, "data", auto_hint)?
+                .0;
             self.close(cci, input);
         }
         Ok(input)
@@ -326,14 +341,16 @@ impl<'a> Walker<'a> {
     fn walk_stream(
         &mut self,
         input: &'a [u8],
-        is_bool: bool,
+        kind: ValueKind,
         label: &str,
         hint: impl FnOnce(StreamType) -> DecodeHint,
     ) -> MltResult<(&'a [u8], StreamMeta)> {
         let si = self.open(input, label);
+        let is_bool = kind == ValueKind::Bool;
 
         // Authoritative parse - drives advancement and gives us `meta`/`byte_length`.
-        let (after_hdr, (meta, byte_length)) = parse_stream_meta(input, is_bool, &mut self.parser)?;
+        let (after_hdr, (meta, byte_length)) =
+            parse_stream_meta(input, kind, is_bool, &mut self.parser)?;
 
         // Re-walk the consumed header bytes to annotate each field.
         let hi = self.open(input, "header");
@@ -371,7 +388,10 @@ impl<'a> Walker<'a> {
         )?;
 
         match meta.encoding.logical {
-            LogicalEncoding::Rle(_) | LogicalEncoding::DeltaRle(_) if !is_bool => {
+            LogicalEncoding::Int(IntLogical::Rle(_) | IntLogical::DeltaRle(_))
+            | LogicalEncoding::Bool(BoolLogical::ByteRle(_))
+                if !is_bool =>
+            {
                 (c, _) = self.field(
                     c,
                     "runs",
@@ -385,9 +405,11 @@ impl<'a> Walker<'a> {
                     |v| Some(v.to_string()),
                 )?;
             }
-            LogicalEncoding::Morton(_)
-            | LogicalEncoding::MortonDelta(_)
-            | LogicalEncoding::MortonRle(_) => {
+            LogicalEncoding::Vertex(
+                VertexLogical::Morton(_)
+                | VertexLogical::MortonDelta(_)
+                | VertexLogical::MortonRle(_),
+            ) => {
                 (c, _) = self.field(
                     c,
                     "bits",
@@ -401,11 +423,12 @@ impl<'a> Walker<'a> {
                     |v| Some(v.to_string()),
                 )?;
             }
-            LogicalEncoding::None
-            | LogicalEncoding::Delta
-            | LogicalEncoding::DeltaRle(_)
-            | LogicalEncoding::ComponentwiseDelta
-            | LogicalEncoding::Rle(_) => {}
+            LogicalEncoding::Int(_)
+            | LogicalEncoding::Bool(_)
+            | LogicalEncoding::Float(_)
+            | LogicalEncoding::Vertex(
+                VertexLogical::None | VertexLogical::Delta | VertexLogical::ComponentwiseDelta,
+            ) => {}
         }
         self.close(hi, c);
 

--- a/rust/mlt-core/src/dump/walker02.rs
+++ b/rust/mlt-core/src/dump/walker02.rs
@@ -20,7 +20,7 @@ use crate::decoder::{
 };
 use crate::tile::Extent;
 use crate::utils::{parse_string, parse_u8, take};
-use crate::wire::{IntEncoding, StreamMeta};
+use crate::wire::{IntEncoding, StreamMeta, ValueKind};
 use crate::{MltError, MltResult};
 
 impl<'a> Walker<'a> {
@@ -218,7 +218,11 @@ impl<'a> Walker<'a> {
             bytes.len(),
             label.to_string(),
             BlobInfo {
-                meta: StreamMeta::new(StreamType::Present, IntEncoding::none(), feature_count),
+                meta: StreamMeta::new(
+                    StreamType::Present,
+                    IntEncoding::none(ValueKind::Bool),
+                    feature_count,
+                ),
                 hint: DecodeHint::PackedBits,
             },
         );

--- a/rust/mlt-core/src/encoder/encode02.rs
+++ b/rust/mlt-core/src/encoder/encode02.rs
@@ -22,8 +22,8 @@ use integer_encoding::VarIntWriter as _;
 
 use crate::decoder::stream::header02::StreamCtx02;
 use crate::decoder::{
-    ColumnType02, DataType02, DictionaryType, LayerLayout, LogicalEncoding, PhysicalEncoding,
-    Presence02, StreamMeta, StreamType,
+    BoolLogical, ColumnType02, DataType02, DictionaryType, LayerLayout, LogicalEncoding,
+    PhysicalEncoding, Presence02, StreamMeta, StreamType,
 };
 use crate::encoder::geometry::encode02::encode_geometry02;
 use crate::encoder::model::{StagedLayer, StreamCtx};
@@ -272,7 +272,7 @@ fn write_bool_bitfield(enc: &mut Encoder, values: &[bool]) -> MltResult<()> {
     write_presence_bits(&mut packed, values);
     let meta = StreamMeta::new2(
         StreamType::Data(DictionaryType::None),
-        LogicalEncoding::None,
+        LogicalEncoding::Bool(BoolLogical::None),
         PhysicalEncoding::None,
         values.len(),
     )?;

--- a/rust/mlt-core/src/encoder/geometry/geotype.rs
+++ b/rust/mlt-core/src/encoder/geometry/geotype.rs
@@ -285,7 +285,7 @@ mod tests {
     use crate::LazyParsed;
     use crate::decoder::{
         DictionaryType, IntEncoding, LengthType, LogicalEncoding, Morton, OffsetType, RawGeometry,
-        StreamMeta, StreamType,
+        StreamMeta, StreamType, VertexLogical,
     };
     use crate::encoder::model::StreamCtx;
     use crate::encoder::{
@@ -579,7 +579,10 @@ mod tests {
             meta: StreamMeta::new(
                 StreamType::Data(DictionaryType::Morton),
                 IntEncoding::new(
-                    LogicalEncoding::MortonDelta(Morton { bits: 3, shift: 0 }),
+                    LogicalEncoding::Vertex(VertexLogical::MortonDelta(Morton {
+                        bits: 3,
+                        shift: 0,
+                    })),
                     PhysicalEncoding::VarInt,
                 ),
                 3, // 3 dictionary entries -> 3 physical u32 values

--- a/rust/mlt-core/src/encoder/geometry/streams.rs
+++ b/rust/mlt-core/src/encoder/geometry/streams.rs
@@ -14,7 +14,7 @@ use crate::codecs::zigzag::encode_componentwise_delta_vec2s;
 use crate::decoder::GeometryType::Point;
 use crate::decoder::{
     DictionaryType, GeometryType, LogicalEncoding, Morton, OffsetType, PhysicalEncoding,
-    StreamMeta, StreamType,
+    StreamMeta, StreamType, VertexLogical,
 };
 use crate::encoder::model::{CurveParams, StreamCtx};
 use crate::encoder::{Codecs, Encoder, PhysicalCodecs, write_stream_payload};
@@ -399,7 +399,7 @@ pub(super) fn encode_vec2_vertex_stream(
 ) -> MltResult<u8> {
     let delta = encode_componentwise_delta_vec2s(vertices, &mut codecs.logical.u32_tmp);
     let ctx = StreamCtx::geom(StreamType::Data(DictionaryType::Vertex), "vertex");
-    let logical = LogicalEncoding::ComponentwiseDelta;
+    let logical = LogicalEncoding::Vertex(VertexLogical::ComponentwiseDelta);
     write_geo_precomputed_stream(delta, ctx, logical, enc, &mut codecs.physical)
 }
 
@@ -419,7 +419,7 @@ pub(super) fn encode_morton_vertex_streams(
 
     let delta = encode_morton_deltas(&dict, &mut codecs.logical.u32_tmp);
     let ctx = StreamCtx::geom(StreamType::Data(DictionaryType::Morton), "vertex");
-    let logical = LogicalEncoding::MortonDelta(morton);
+    let logical = LogicalEncoding::Vertex(VertexLogical::MortonDelta(morton));
     n += write_geo_precomputed_stream(delta, ctx, logical, enc, &mut codecs.physical)?;
     Ok(n)
 }
@@ -462,7 +462,7 @@ pub(super) fn encode_hilbert_vertex_streams(
     // also keeps `codecs.logical.u32_values` free for the inner race.
     encode_componentwise_delta_vec2s(&dict_xy, &mut offsets);
     let ctx = StreamCtx::geom(StreamType::Data(DictionaryType::Vertex), "vertex");
-    let logical = LogicalEncoding::ComponentwiseDelta;
+    let logical = LogicalEncoding::Vertex(VertexLogical::ComponentwiseDelta);
     n += write_geo_precomputed_stream(&offsets, ctx, logical, enc, &mut codecs.physical)?;
 
     codecs.logical.hilbert_offsets = offsets;

--- a/rust/mlt-core/src/encoder/property/strings.rs
+++ b/rust/mlt-core/src/encoder/property/strings.rs
@@ -7,7 +7,7 @@ use crate::MltResult;
 use crate::codecs::fsst::{FsstRawData, compress_fsst, compress_fsst_with};
 use crate::decoder::stream::header01;
 use crate::decoder::strings::{checked_string_end, encode_null_end};
-use crate::decoder::{DictionaryType, LengthType, OffsetType, StreamMeta, StreamType};
+use crate::decoder::{DictionaryType, LengthType, OffsetType, StreamMeta, StreamType, ValueKind};
 use crate::encoder::model::{StrEncoding, StreamCtx};
 use crate::encoder::stream::{dedup_strings, write_stream_payload};
 use crate::encoder::{Codecs, Encoder};
@@ -279,11 +279,15 @@ pub fn write_fsst_data(
     let ctx = StreamCtx::prop(StreamType::Length(LengthType::Symbol), name);
     codecs.write_int_stream(&raw.symbol_lengths, &ctx, enc)?;
     let typ = StreamType::Data(DictionaryType::Fsst);
-    let meta = StreamMeta::new_none(typ, raw.symbol_lengths.len())?;
+    let meta = StreamMeta::new_none(typ, ValueKind::Int, raw.symbol_lengths.len())?;
     write_stream_payload(enc, meta, false, &raw.symbol_bytes)?;
     let ctx = StreamCtx::prop(StreamType::Length(LengthType::Dictionary), name);
     codecs.write_int_stream(&raw.value_lengths, &ctx, enc)?;
-    let meta = StreamMeta::new_none(StreamType::Data(dict_type), raw.value_lengths.len())?;
+    let meta = StreamMeta::new_none(
+        StreamType::Data(dict_type),
+        ValueKind::Int,
+        raw.value_lengths.len(),
+    )?;
     write_stream_payload(enc, meta, false, &raw.corpus)?;
     Ok(())
 }
@@ -297,7 +301,7 @@ pub fn write_raw_str_data(
 ) -> MltResult<()> {
     let total_len: usize = strings.iter().map(|s| s.len()).sum();
     let typ = StreamType::Data(dict_type);
-    let meta = StreamMeta::new_none(typ, strings.len())?;
+    let meta = StreamMeta::new_none(typ, ValueKind::Int, strings.len())?;
     header01::write_stream_meta(&meta, enc, false, u32::try_from(total_len)?)?;
     enc.data_mut().reserve(total_len);
     for s in strings {

--- a/rust/mlt-core/src/encoder/stream/codecs.rs
+++ b/rust/mlt-core/src/encoder/stream/codecs.rs
@@ -7,7 +7,10 @@ use crate::codecs::bytes::encode_bools_to_bytes;
 use crate::codecs::rle::encode_byte_rle;
 #[cfg(not(feature = "unstable-v2"))]
 use crate::decoder::RleLayout;
-use crate::decoder::{LogicalEncoding, PhysicalEncoding, RleMeta, StreamMeta, StreamType};
+use crate::decoder::{
+    BoolLogical, IntLogical, LogicalEncoding, PhysicalEncoding, RleMeta, StreamMeta, StreamType,
+    ValueKind,
+};
 use crate::encoder;
 use crate::encoder::Encoder;
 use crate::encoder::model::StreamCtx;
@@ -57,10 +60,10 @@ impl LogicalCodecs {
         let num_values = u32::try_from(values.len())?;
         let data = encode_bools_to_bytes(values, &mut self.u8_tmp);
         let encoded = encode_byte_rle(data, &mut self.u8_tmp2);
-        let meta = LogicalEncoding::Rle(RleMeta::Split {
+        let meta = LogicalEncoding::Bool(BoolLogical::ByteRle(RleMeta::Split {
             runs: num_values.div_ceil(8),
             num_rle_values: u32::try_from(encoded.len())?,
-        });
+        }));
         Ok((meta, encoded))
     }
 }
@@ -99,7 +102,7 @@ impl Codecs {
         #[cfg(not(target_endian = "little"))]
         compile_error!("not implemented for non-little-endian targets");
 
-        let meta = StreamMeta::new_none(stream_type, values.len())?;
+        let meta = StreamMeta::new_none(stream_type, ValueKind::Float, values.len())?;
         encoder::write_stream_payload(enc, meta, false, cast_slice(values))
     }
 
@@ -126,8 +129,8 @@ impl Codecs {
         // FIXME: does StreamMeta encode values.len() or vals1.len()?
         if let Some(int_enc) = enc.override_int_enc(ctx) {
             let (le, vals) = match int_enc.logical {
-                LogicalEncoder::None => (LE::None, self.logical.none(values)),
-                LogicalEncoder::Delta => (LE::Delta, self.logical.delta(values)),
+                LogicalEncoder::None => (LE::Int(IntLogical::None), self.logical.none(values)),
+                LogicalEncoder::Delta => (LE::Int(IntLogical::Delta), self.logical.delta(values)),
                 LogicalEncoder::Rle => self.logical.rle(values, rle_layout)?,
                 LogicalEncoder::DeltaRle => self.logical.delta_rle(values, rle_layout)?,
             };
@@ -140,7 +143,12 @@ impl Codecs {
         if values.is_empty() {
             let vals1 = self.logical.none(values);
             let vals2 = Output::<T>::none(&mut self.physical, vals1);
-            let meta = StreamMeta::new2(ctx.stream_type, LE::None, PE::None, vals1.len())?;
+            let meta = StreamMeta::new2(
+                ctx.stream_type,
+                LE::Int(IntLogical::None),
+                PE::None,
+                vals1.len(),
+            )?;
             return encoder::write_stream_payload(enc, meta, false, vals2);
         }
 
@@ -158,7 +166,7 @@ impl Codecs {
             } else {
                 (PE::None, cast_slice(encoded))
             };
-            let meta = StreamMeta::new2(ctx.stream_type, LE::None, pe, 1)?;
+            let meta = StreamMeta::new2(ctx.stream_type, LE::Int(IntLogical::None), pe, 1)?;
             return encoder::write_stream_payload(enc, meta, false, payload);
         }
 
@@ -185,7 +193,7 @@ impl Codecs {
             physical.write_alternatives::<Output<T>>(
                 &mut alt,
                 values,
-                LE::Delta,
+                LE::Int(IntLogical::Delta),
                 ctx.stream_type,
                 allow_fastpfor,
             )?;
@@ -204,7 +212,7 @@ impl Codecs {
         physical.write_alternatives::<Output<T>>(
             &mut alt,
             values,
-            LE::None,
+            LE::Int(IntLogical::None),
             ctx.stream_type,
             allow_fastpfor,
         )

--- a/rust/mlt-core/src/encoder/stream/encode_stream.rs
+++ b/rust/mlt-core/src/encoder/stream/encode_stream.rs
@@ -3,7 +3,7 @@ use std::collections::hash_map::Entry;
 
 use crate::MltResult;
 #[cfg(any(test, feature = "__private"))]
-use crate::decoder::{DictionaryType, StreamMeta, StreamType};
+use crate::decoder::{DictionaryType, StreamMeta, StreamType, ValueKind};
 #[cfg(any(test, feature = "__private"))]
 use crate::encoder::EncodedStream;
 use crate::errors::AsMltError as _;
@@ -39,7 +39,11 @@ impl EncodedStream {
         for v in values {
             data.extend_from_slice(v.to_le_bytes().as_ref());
         }
-        let meta = StreamMeta::new_none(StreamType::Data(DictionaryType::None), values.len())?;
+        let meta = StreamMeta::new_none(
+            StreamType::Data(DictionaryType::None),
+            ValueKind::Float,
+            values.len(),
+        )?;
         Ok(Self { meta, data })
     }
 }

--- a/rust/mlt-core/src/encoder/stream/logical.rs
+++ b/rust/mlt-core/src/encoder/stream/logical.rs
@@ -61,6 +61,7 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
+    use crate::decoder::ValueKind;
     use crate::decoder::stream::header01;
     use crate::encoder::model::StreamCtx;
     use crate::encoder::{Codecs, Encoder, EncoderConfig, ExplicitEncoder, IntEncoder};
@@ -79,7 +80,7 @@ mod tests {
             let mut codecs = Codecs::default();
             let ctx = StreamCtx::prop_data("test");
             codecs.write_int_stream(&values, &ctx, &mut enc).unwrap();
-            let parsed = assert_empty(header01::parse_stream(enc.data(), &mut parser()));
+            let parsed = assert_empty(header01::parse_stream(enc.data(), ValueKind::Int, &mut parser()));
             let decoded = parsed.decode_ints::<u32>(&mut dec()).unwrap();
             prop_assert_eq!(decoded, values);
         }
@@ -96,7 +97,7 @@ mod tests {
             let mut codecs = Codecs::default();
             let ctx = StreamCtx::prop_data("test");
             codecs.write_int_stream(&values, &ctx, &mut enc).unwrap();
-            let parsed = assert_empty(header01::parse_stream(enc.data(), &mut parser()));
+            let parsed = assert_empty(header01::parse_stream(enc.data(), ValueKind::Int, &mut parser()));
             let decoded = parsed.decode_ints::<i32>(&mut dec()).unwrap();
             prop_assert_eq!(decoded, values);
         }
@@ -113,7 +114,7 @@ mod tests {
             let mut codecs = Codecs::default();
             let ctx = StreamCtx::prop_data("test");
             codecs.write_int_stream(&values, &ctx, &mut enc).unwrap();
-            let parsed = assert_empty(header01::parse_stream(enc.data(), &mut parser()));
+            let parsed = assert_empty(header01::parse_stream(enc.data(), ValueKind::Int, &mut parser()));
             let decoded = parsed.decode_ints::<u64>(&mut dec()).unwrap();
             prop_assert_eq!(decoded, values);
         }
@@ -130,7 +131,7 @@ mod tests {
             let mut codecs = Codecs::default();
             let ctx = StreamCtx::prop_data("test");
             codecs.write_int_stream(&values, &ctx, &mut enc).unwrap();
-            let parsed = assert_empty(header01::parse_stream(enc.data(), &mut parser()));
+            let parsed = assert_empty(header01::parse_stream(enc.data(), ValueKind::Int, &mut parser()));
             let decoded = parsed.decode_ints::<i64>(&mut dec()).unwrap();
             prop_assert_eq!(decoded, values);
         }

--- a/rust/mlt-core/src/encoder/stream/tests.rs
+++ b/rust/mlt-core/src/encoder/stream/tests.rs
@@ -4,8 +4,9 @@ use rstest::rstest;
 use crate::MltError;
 use crate::decoder::stream::header01;
 use crate::decoder::{
-    DictionaryType, IntEncoding, LengthType, LogicalEncoding, LogicalValue, Morton, OffsetType,
-    PhysicalEncoding, RawStream, RleMeta, StreamMeta, StreamType,
+    BoolLogical, DictionaryType, IntEncoding, IntLogical, LengthType, LogicalEncoding,
+    LogicalValue, Morton, OffsetType, PhysicalEncoding, RawStream, RleMeta, StreamMeta, StreamType,
+    ValueKind, VertexLogical,
 };
 use crate::encoder::model::StreamCtx;
 use crate::encoder::{
@@ -17,11 +18,12 @@ use crate::utils::BinarySerializer as _;
 fn roundtrip_stream<'a>(buffer: &'a mut Vec<u8>, stream: &EncodedStream) -> RawStream<'a> {
     buffer.clear();
     buffer.write_stream(stream).unwrap();
-    assert_empty(header01::parse_stream(buffer, &mut parser()))
+    let hint = stream.meta.encoding.logical.kind();
+    assert_empty(header01::parse_stream(buffer, hint, &mut parser()))
 }
 
 fn roundtrip_stream_u32s(wire: &[u8]) -> Vec<u32> {
-    let parsed_stream = assert_empty(header01::parse_stream(wire, &mut parser()));
+    let parsed_stream = assert_empty(header01::parse_stream(wire, ValueKind::Int, &mut parser()));
 
     let mut decoder = dec();
     let values = parsed_stream.decode_ints::<u32>(&mut decoder).unwrap();
@@ -35,9 +37,15 @@ fn roundtrip_stream_u32s(wire: &[u8]) -> Vec<u32> {
 }
 
 fn make_logical_val(logical_encoding: LogicalEncoding, num_values: usize) -> LogicalValue {
+    let stream_type = match logical_encoding.kind() {
+        ValueKind::Vertex => StreamType::Data(DictionaryType::Vertex),
+        ValueKind::Int | ValueKind::Bool | ValueKind::Float => {
+            StreamType::Data(DictionaryType::None)
+        }
+    };
     LogicalValue::new(
         StreamMeta::new2(
-            StreamType::Data(DictionaryType::None),
+            stream_type,
             logical_encoding,
             PhysicalEncoding::VarInt,
             num_values,
@@ -62,7 +70,10 @@ fn generate_stream_test_cases() -> Vec<StreamTestCase> {
         StreamTestCase {
             meta: StreamMeta::new(
                 StreamType::Data(DictionaryType::None),
-                IntEncoding::new(LogicalEncoding::None, PhysicalEncoding::VarInt),
+                IntEncoding::new(
+                    LogicalEncoding::Int(IntLogical::None),
+                    PhysicalEncoding::VarInt,
+                ),
                 4,
             ),
             data: &[0x04, 0x03, 0x02, 0x01],
@@ -72,7 +83,7 @@ fn generate_stream_test_cases() -> Vec<StreamTestCase> {
         StreamTestCase {
             meta: StreamMeta::new(
                 StreamType::Data(DictionaryType::None),
-                IntEncoding::none(),
+                IntEncoding::none(ValueKind::Int),
                 1,
             ),
             data: &[0x04, 0x03, 0x02, 0x01],
@@ -107,17 +118,17 @@ fn test_decode_bits_u32() {
 #[rstest]
 // ZigZag pairs: [(0,0),(2,4),(2,4)] -> [(0,0),(1,2),(1,2)]
 // Delta: [(0,0),(1,2),(1,2)] -> [(0,0),(1,2),(2,4)]
-#[case::componentwise_delta(LogicalEncoding::ComponentwiseDelta, vec![0u32, 0, 2, 4, 2, 4], vec![0i32, 0, 1, 2, 2, 4]
+#[case::componentwise_delta(LogicalEncoding::Vertex(VertexLogical::ComponentwiseDelta), vec![0u32, 0, 2, 4, 2, 4], vec![0i32, 0, 1, 2, 2, 4]
 )]
 // ZigZag: [0,1,2,1,2] -> [0,-1,1,-1,1]
 // Delta: [0,-1,1,-1,1] -> [0,-1,0,-1,0]
-#[case::delta(LogicalEncoding::Delta, vec![0u32, 1, 2, 1, 2], vec![0i32, -1, 0, -1, 0])]
+#[case::delta(LogicalEncoding::Int(IntLogical::Delta), vec![0u32, 1, 2, 1, 2], vec![0i32, -1, 0, -1, 0])]
 // RLE: [3,2] [0,2] -> [0,0,0,2,2]
 // ZigZag: [0,0,0,2,2] -> [0,0,0,1,1]
 // Delta: [0,0,0,1,1] -> [0,0,0,1,2]
-#[case::delta_rle(LogicalEncoding::DeltaRle(RleMeta::Split { runs: 2, num_rle_values: 5 }), vec![3u32, 2, 0, 2], vec![0i32, 0, 0, 1, 2]
+#[case::delta_rle(LogicalEncoding::Int(IntLogical::DeltaRle(RleMeta::Split { runs: 2, num_rle_values: 5 })), vec![3u32, 2, 0, 2], vec![0i32, 0, 0, 1, 2]
 )]
-#[case::delta_empty(LogicalEncoding::Delta, vec![], vec![])]
+#[case::delta_empty(LogicalEncoding::Int(IntLogical::Delta), vec![], vec![])]
 fn test_decode_i32(
     #[case] logical_encoding: LogicalEncoding,
     #[case] input_data: Vec<u32>,
@@ -130,13 +141,13 @@ fn test_decode_i32(
 }
 
 #[rstest]
-#[case::empty(LogicalEncoding::None, vec![], vec![])]
-#[case::new_encoded(LogicalEncoding::None, vec![10u32, 20, 30, 40], vec![10u32, 20, 30, 40])]
-#[case::rle(LogicalEncoding::Rle(RleMeta::Split { runs: 3, num_rle_values: 6 }), vec![3u32, 2, 1, 10, 20, 30], vec![10u32, 10, 10, 20, 20, 30]
+#[case::empty(LogicalEncoding::Int(IntLogical::None), vec![], vec![])]
+#[case::new_encoded(LogicalEncoding::Int(IntLogical::None), vec![10u32, 20, 30, 40], vec![10u32, 20, 30, 40])]
+#[case::rle(LogicalEncoding::Int(IntLogical::Rle(RleMeta::Split { runs: 3, num_rle_values: 6 })), vec![3u32, 2, 1, 10, 20, 30], vec![10u32, 10, 10, 20, 20, 30]
 )]
 // ZigZag: [0,2,2,2,2] -> [0,1,1,1,1]
 // Delta: [0,1,1,1,1] -> [0,1,2,3,4]
-#[case::delta(LogicalEncoding::Delta, vec![0u32, 2, 2, 2, 2], vec![0u32, 1, 2, 3, 4])]
+#[case::delta(LogicalEncoding::Int(IntLogical::Delta), vec![0u32, 2, 2, 2, 2], vec![0u32, 1, 2, 3, 4])]
 fn test_decode_u32(
     #[case] logical_encoding: LogicalEncoding,
     #[case] input_data: Vec<u32>,
@@ -172,7 +183,11 @@ fn auto_physical(values: &[u32], cfg: EncoderConfig) -> PhysicalEncoding {
     let codecs = &mut Codecs::default();
     let ctx = StreamCtx::prop_data("test");
     codecs.write_int_stream(values, &ctx, &mut enc).unwrap();
-    let parsed = assert_empty(header01::parse_stream(enc.data(), &mut parser()));
+    let parsed = assert_empty(header01::parse_stream(
+        enc.data(),
+        ValueKind::Int,
+        &mut parser(),
+    ));
     parsed.meta.encoding.physical
 }
 
@@ -192,8 +207,15 @@ fn single_value_u32_picks_smaller_physical(
     let ctx = StreamCtx::prop_data("test");
     codecs.write_int_stream(&[v], &ctx, &mut enc).unwrap();
 
-    let parsed = assert_empty(header01::parse_stream(enc.data(), &mut parser()));
-    assert_eq!(parsed.meta.encoding.logical, LogicalEncoding::None);
+    let parsed = assert_empty(header01::parse_stream(
+        enc.data(),
+        ValueKind::Int,
+        &mut parser(),
+    ));
+    assert_eq!(
+        parsed.meta.encoding.logical,
+        LogicalEncoding::Int(IntLogical::None)
+    );
     assert_eq!(parsed.meta.encoding.physical, expected_physical);
     assert_eq!(parsed.meta.num_values, 1);
     assert_eq!(roundtrip_stream_u32s(enc.data()), vec![v]);
@@ -214,8 +236,15 @@ fn single_value_i32_picks_smaller_physical(
     let ctx = StreamCtx::prop_data("test");
     codecs.write_int_stream(&[v], &ctx, &mut enc).unwrap();
 
-    let parsed = assert_empty(header01::parse_stream(enc.data(), &mut parser()));
-    assert_eq!(parsed.meta.encoding.logical, LogicalEncoding::None);
+    let parsed = assert_empty(header01::parse_stream(
+        enc.data(),
+        ValueKind::Int,
+        &mut parser(),
+    ));
+    assert_eq!(
+        parsed.meta.encoding.logical,
+        LogicalEncoding::Int(IntLogical::None)
+    );
     assert_eq!(parsed.meta.encoding.physical, expected_physical);
 }
 
@@ -246,25 +275,25 @@ fn allow_fastpfor_gates_fastpfor_selection() {
 
 /// Test roundtrip: write -> parse -> equality for stream serialization
 #[rstest]
-#[case::new_encoded(StreamType::Data(DictionaryType::None), 2, LogicalEncoding::None, PhysicalEncoding::None, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08], false
+#[case::new_encoded(StreamType::Data(DictionaryType::None), 2, LogicalEncoding::Int(IntLogical::None), PhysicalEncoding::None, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08], false
 )]
-#[case::new_encoded(StreamType::Data(DictionaryType::None), 2, LogicalEncoding::ComponentwiseDelta, PhysicalEncoding::None, vec![0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00], false
+#[case::new_encoded(StreamType::Data(DictionaryType::Vertex), 2, LogicalEncoding::Vertex(VertexLogical::ComponentwiseDelta), PhysicalEncoding::None, vec![0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00], false
 )]
-#[case::new_encoded(StreamType::Offset(OffsetType::Vertex), 3, LogicalEncoding::None, PhysicalEncoding::None, vec![0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00], false
+#[case::new_encoded(StreamType::Offset(OffsetType::Vertex), 3, LogicalEncoding::Int(IntLogical::None), PhysicalEncoding::None, vec![0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00], false
 )]
-#[case::varint(StreamType::Data(DictionaryType::None), 4, LogicalEncoding::None, PhysicalEncoding::VarInt, vec![0x0A, 0x14, 0x1E, 0x28], false
+#[case::varint(StreamType::Data(DictionaryType::None), 4, LogicalEncoding::Int(IntLogical::None), PhysicalEncoding::VarInt, vec![0x0A, 0x14, 0x1E, 0x28], false
 )]
-#[case::varint(StreamType::Data(DictionaryType::None), 5, LogicalEncoding::Delta, PhysicalEncoding::VarInt, vec![0x00, 0x02, 0x02, 0x02, 0x02], false
+#[case::varint(StreamType::Data(DictionaryType::None), 5, LogicalEncoding::Int(IntLogical::Delta), PhysicalEncoding::VarInt, vec![0x00, 0x02, 0x02, 0x02, 0x02], false
 )]
-#[case::varint(StreamType::Length(LengthType::VarBinary), 3, LogicalEncoding::Delta, PhysicalEncoding::VarInt, vec![0x00, 0x02, 0x02], false
+#[case::varint(StreamType::Length(LengthType::VarBinary), 3, LogicalEncoding::Int(IntLogical::Delta), PhysicalEncoding::VarInt, vec![0x00, 0x02, 0x02], false
 )]
-#[case::rle(StreamType::Data(DictionaryType::None), 6, LogicalEncoding::Rle(RleMeta::Split { runs: 3, num_rle_values: 6 }), PhysicalEncoding::VarInt, vec![0x03, 0x02, 0x01, 0x0A, 0x14, 0x1E], false
+#[case::rle(StreamType::Data(DictionaryType::None), 6, LogicalEncoding::Int(IntLogical::Rle(RleMeta::Split { runs: 3, num_rle_values: 6 })), PhysicalEncoding::VarInt, vec![0x03, 0x02, 0x01, 0x0A, 0x14, 0x1E], false
 )]
-#[case::rle(StreamType::Data(DictionaryType::None), 5, LogicalEncoding::DeltaRle(RleMeta::Split { runs: 2, num_rle_values: 5 }), PhysicalEncoding::VarInt, vec![0x03, 0x02, 0x00, 0x02], false
+#[case::rle(StreamType::Data(DictionaryType::None), 5, LogicalEncoding::Int(IntLogical::DeltaRle(RleMeta::Split { runs: 2, num_rle_values: 5 })), PhysicalEncoding::VarInt, vec![0x03, 0x02, 0x00, 0x02], false
 )]
-#[case::morton(StreamType::Data(DictionaryType::Morton), 4, LogicalEncoding::Morton(Morton { bits: 16, shift: 0 }), PhysicalEncoding::VarInt, vec![0x01, 0x02, 0x03, 0x04], false
+#[case::morton(StreamType::Data(DictionaryType::Morton), 4, LogicalEncoding::Vertex(VertexLogical::Morton(Morton { bits: 16, shift: 0 })), PhysicalEncoding::VarInt, vec![0x01, 0x02, 0x03, 0x04], false
 )]
-#[case::boolean(StreamType::Present, 16, LogicalEncoding::Rle(RleMeta::Split { runs: 2, num_rle_values: 2 }), PhysicalEncoding::VarInt, vec![0xFF, 0x00], true
+#[case::boolean(StreamType::Present, 16, LogicalEncoding::Bool(BoolLogical::ByteRle(RleMeta::Split { runs: 2, num_rle_values: 2 })), PhysicalEncoding::VarInt, vec![0xFF, 0x00], true
 )]
 fn test_stream_roundtrip(
     #[case] stream_type: StreamType,
@@ -292,10 +321,11 @@ fn test_stream_roundtrip(
     }
 
     // Parse back
+    let hint = stream.meta.encoding.logical.kind();
     let parsed = assert_empty(if is_bool {
         header01::parse_bool_stream(&buffer, &mut parser())
     } else {
-        header01::parse_stream(&buffer, &mut parser())
+        header01::parse_stream(&buffer, hint, &mut parser())
     });
 
     assert_eq!(parsed.meta, stream.meta, "metadata mismatch");
@@ -308,7 +338,7 @@ fn test_morton_parse_rejects_too_many_bits() {
         meta: StreamMeta::new(
             StreamType::Data(DictionaryType::Morton),
             IntEncoding::new(
-                LogicalEncoding::Morton(Morton { bits: 17, shift: 0 }),
+                LogicalEncoding::Vertex(VertexLogical::Morton(Morton { bits: 17, shift: 0 })),
                 PhysicalEncoding::VarInt,
             ),
             1,
@@ -318,7 +348,7 @@ fn test_morton_parse_rejects_too_many_bits() {
     let mut buffer = Vec::new();
     buffer.write_stream(&stream).unwrap();
 
-    let err = header01::parse_stream(&buffer, &mut parser()).unwrap_err();
+    let err = header01::parse_stream(&buffer, ValueKind::Int, &mut parser()).unwrap_err();
     assert!(matches!(err, MltError::InvalidMortonBits(17)));
 }
 
@@ -334,7 +364,7 @@ fn test_varint_stream_huge_num_values_empty_data() {
     // byte_length = 0x00 -> 0 bytes of data
     let wire: &[u8] = &[0x00, 0x02, 0xd5, 0xff, 0xd5, 0xff, 0x03, 0x00];
     // Parsing must fail: budget reserves num_values * 8 ≈ 8 GB which exceeds the 10 MB limit.
-    let result = header01::parse_stream(wire, &mut parser());
+    let result = header01::parse_stream(wire, ValueKind::Int, &mut parser());
     assert!(
         result.is_err(),
         "parse must fail when num_values * 8 exceeds the memory budget"
@@ -400,7 +430,7 @@ proptest! {
         let mut enc = Encoder::with_explicit(EncoderConfig::default(), ExplicitEncoder::all(encoding));
         let mut codecs = Codecs::default();
         codecs.write_int_stream(&widened, &StreamCtx::prop_data("test"), &mut enc).unwrap();
-        let parsed_stream = assert_empty(header01::parse_stream(enc.data(), &mut parser()));
+        let parsed_stream = assert_empty(header01::parse_stream(enc.data(), ValueKind::Int, &mut parser()));
         let decoded_values = parsed_stream.decode_narrow::<i8, i32>(&mut dec()).unwrap();
 
         assert_eq!(decoded_values, values);
@@ -415,7 +445,7 @@ proptest! {
         let mut enc = Encoder::with_explicit(EncoderConfig::default(), ExplicitEncoder::all(encoding));
         let mut codecs = Codecs::default();
         codecs.write_int_stream(&widened, &StreamCtx::prop_data("test"), &mut enc).unwrap();
-        let parsed_stream = assert_empty(header01::parse_stream(enc.data(), &mut parser()));
+        let parsed_stream = assert_empty(header01::parse_stream(enc.data(), ValueKind::Int, &mut parser()));
         let decoded_values = parsed_stream.decode_narrow::<u8, u32>(&mut dec()).unwrap();
 
         assert_eq!(decoded_values, values);
@@ -441,7 +471,7 @@ proptest! {
         let mut enc = Encoder::with_explicit(EncoderConfig::default(), ExplicitEncoder::all(encoding));
         let mut codecs = Codecs::default();
         codecs.write_int_stream(&values, &StreamCtx::prop_data("test"), &mut enc).unwrap();
-        let parsed_stream = assert_empty(header01::parse_stream(enc.data(), &mut parser()));
+        let parsed_stream = assert_empty(header01::parse_stream(enc.data(), ValueKind::Int, &mut parser()));
         let decoded_values = parsed_stream.decode_ints::<i32>(&mut dec()).unwrap();
 
         assert_eq!(decoded_values, values);
@@ -455,7 +485,7 @@ proptest! {
         let mut enc = Encoder::with_explicit(EncoderConfig::default(), ExplicitEncoder::all(encoding));
         let mut codecs = Codecs::default();
         codecs.write_int_stream(&values, &StreamCtx::prop_data("test"), &mut enc).unwrap();
-        let parsed_stream = assert_empty(header01::parse_stream(enc.data(), &mut parser()));
+        let parsed_stream = assert_empty(header01::parse_stream(enc.data(), ValueKind::Int, &mut parser()));
         let decoded_values = parsed_stream.decode_ints::<u64>(&mut dec()).unwrap();
 
         assert_eq!(decoded_values, values);
@@ -469,7 +499,7 @@ proptest! {
         let mut enc = Encoder::with_explicit(EncoderConfig::default(), ExplicitEncoder::all(encoding));
         let mut codecs = Codecs::default();
         codecs.write_int_stream(&values, &StreamCtx::prop_data("test"), &mut enc).unwrap();
-        let parsed_stream = assert_empty(header01::parse_stream(enc.data(), &mut parser()));
+        let parsed_stream = assert_empty(header01::parse_stream(enc.data(), ValueKind::Int, &mut parser()));
         let decoded_values = parsed_stream.decode_ints::<i64>(&mut dec()).unwrap();
 
         assert_eq!(decoded_values, values);

--- a/rust/mlt-core/src/encoder/stream/write.rs
+++ b/rust/mlt-core/src/encoder/stream/write.rs
@@ -10,7 +10,9 @@ use crate::codecs::zigzag::{encode_zigzag, encode_zigzag_delta};
 use crate::decoder::stream::header01;
 #[cfg(feature = "unstable-v2")]
 use crate::decoder::stream::header02;
-use crate::decoder::{LogicalEncoding, PhysicalEncoding, RleLayout, StreamMeta, StreamType};
+use crate::decoder::{
+    IntLogical, LogicalEncoding, PhysicalEncoding, RleLayout, StreamMeta, StreamType,
+};
 use crate::encoder::Encoder;
 use crate::encoder::model::StreamCtx;
 #[cfg(feature = "unstable-v2")]
@@ -249,7 +251,7 @@ impl LogicalIntCodec<[u8]> for LogicalCodecs {
     ) -> MltResult<(LogicalEncoding, &'a [u32])> {
         let data = encode_u8_as_u32(values, &mut self.u32_tmp);
         let meta = apply_rle(data, values.len(), layout, &mut self.u32_tmp2)?;
-        Ok((LogicalEncoding::Rle(meta), &self.u32_tmp2))
+        Ok((LogicalEncoding::Int(IntLogical::Rle(meta)), &self.u32_tmp2))
     }
 
     fn delta_rle<'a>(
@@ -259,7 +261,10 @@ impl LogicalIntCodec<[u8]> for LogicalCodecs {
     ) -> MltResult<(LogicalEncoding, &'a [u32])> {
         let data = encode_narrow_delta(values, &mut self.u32_tmp);
         let meta = apply_rle(data, values.len(), layout, &mut self.u32_tmp2)?;
-        Ok((LogicalEncoding::DeltaRle(meta), &self.u32_tmp2))
+        Ok((
+            LogicalEncoding::Int(IntLogical::DeltaRle(meta)),
+            &self.u32_tmp2,
+        ))
     }
 }
 
@@ -285,7 +290,7 @@ impl LogicalIntCodec<[i8]> for LogicalCodecs {
     ) -> MltResult<(LogicalEncoding, &'a [u32])> {
         let data = encode_i8_zigzag(values, &mut self.u32_tmp);
         let meta = apply_rle(data, values.len(), layout, &mut self.u32_tmp2)?;
-        Ok((LogicalEncoding::Rle(meta), &self.u32_tmp2))
+        Ok((LogicalEncoding::Int(IntLogical::Rle(meta)), &self.u32_tmp2))
     }
 
     fn delta_rle<'a>(
@@ -295,7 +300,10 @@ impl LogicalIntCodec<[i8]> for LogicalCodecs {
     ) -> MltResult<(LogicalEncoding, &'a [u32])> {
         let data = encode_narrow_delta(values, &mut self.u32_tmp);
         let meta = apply_rle(data, values.len(), layout, &mut self.u32_tmp2)?;
-        Ok((LogicalEncoding::DeltaRle(meta), &self.u32_tmp2))
+        Ok((
+            LogicalEncoding::Int(IntLogical::DeltaRle(meta)),
+            &self.u32_tmp2,
+        ))
     }
 }
 
@@ -320,7 +328,7 @@ impl LogicalIntCodec<[u32]> for LogicalCodecs {
         layout: RleLayout,
     ) -> MltResult<(LogicalEncoding, &'a [u32])> {
         let meta = apply_rle(values, values.len(), layout, &mut self.u32_tmp)?;
-        Ok((LogicalEncoding::Rle(meta), &self.u32_tmp))
+        Ok((LogicalEncoding::Int(IntLogical::Rle(meta)), &self.u32_tmp))
     }
 
     fn delta_rle<'a>(
@@ -330,7 +338,10 @@ impl LogicalIntCodec<[u32]> for LogicalCodecs {
     ) -> MltResult<(LogicalEncoding, &'a [u32])> {
         let data = encode_zigzag_delta(cast_slice::<u32, i32>(values), &mut self.u32_tmp);
         let meta = apply_rle(data, values.len(), layout, &mut self.u32_tmp2)?;
-        Ok((LogicalEncoding::DeltaRle(meta), &self.u32_tmp2))
+        Ok((
+            LogicalEncoding::Int(IntLogical::DeltaRle(meta)),
+            &self.u32_tmp2,
+        ))
     }
 }
 
@@ -356,7 +367,7 @@ impl LogicalIntCodec<[i32]> for LogicalCodecs {
     ) -> MltResult<(LogicalEncoding, &'a [u32])> {
         let data = encode_zigzag(values, &mut self.u32_tmp);
         let meta = apply_rle(data, values.len(), layout, &mut self.u32_tmp2)?;
-        Ok((LogicalEncoding::Rle(meta), &self.u32_tmp2))
+        Ok((LogicalEncoding::Int(IntLogical::Rle(meta)), &self.u32_tmp2))
     }
 
     fn delta_rle<'a>(
@@ -366,7 +377,10 @@ impl LogicalIntCodec<[i32]> for LogicalCodecs {
     ) -> MltResult<(LogicalEncoding, &'a [u32])> {
         let data = encode_zigzag_delta(values, &mut self.u32_tmp);
         let meta = apply_rle(data, values.len(), layout, &mut self.u32_tmp2)?;
-        Ok((LogicalEncoding::DeltaRle(meta), &self.u32_tmp2))
+        Ok((
+            LogicalEncoding::Int(IntLogical::DeltaRle(meta)),
+            &self.u32_tmp2,
+        ))
     }
 }
 
@@ -391,7 +405,7 @@ impl LogicalIntCodec<[u64]> for LogicalCodecs {
         layout: RleLayout,
     ) -> MltResult<(LogicalEncoding, &'a [u64])> {
         let meta = apply_rle(values, values.len(), layout, &mut self.u64_tmp)?;
-        Ok((LogicalEncoding::Rle(meta), &self.u64_tmp))
+        Ok((LogicalEncoding::Int(IntLogical::Rle(meta)), &self.u64_tmp))
     }
 
     fn delta_rle<'a>(
@@ -401,7 +415,10 @@ impl LogicalIntCodec<[u64]> for LogicalCodecs {
     ) -> MltResult<(LogicalEncoding, &'a [u64])> {
         let data = encode_zigzag_delta(cast_slice::<u64, i64>(values), &mut self.u64_tmp);
         let meta = apply_rle(data, values.len(), layout, &mut self.u64_tmp2)?;
-        Ok((LogicalEncoding::DeltaRle(meta), &self.u64_tmp2))
+        Ok((
+            LogicalEncoding::Int(IntLogical::DeltaRle(meta)),
+            &self.u64_tmp2,
+        ))
     }
 }
 
@@ -427,7 +444,7 @@ impl LogicalIntCodec<[i64]> for LogicalCodecs {
     ) -> MltResult<(LogicalEncoding, &'a [u64])> {
         let data = encode_zigzag(values, &mut self.u64_tmp);
         let meta = apply_rle(data, values.len(), layout, &mut self.u64_tmp2)?;
-        Ok((LogicalEncoding::Rle(meta), &self.u64_tmp2))
+        Ok((LogicalEncoding::Int(IntLogical::Rle(meta)), &self.u64_tmp2))
     }
 
     fn delta_rle<'a>(
@@ -437,6 +454,9 @@ impl LogicalIntCodec<[i64]> for LogicalCodecs {
     ) -> MltResult<(LogicalEncoding, &'a [u64])> {
         let data = encode_zigzag_delta(values, &mut self.u64_tmp);
         let meta = apply_rle(data, values.len(), layout, &mut self.u64_tmp2)?;
-        Ok((LogicalEncoding::DeltaRle(meta), &self.u64_tmp2))
+        Ok((
+            LogicalEncoding::Int(IntLogical::DeltaRle(meta)),
+            &self.u64_tmp2,
+        ))
     }
 }

--- a/rust/mlt-core/src/errors.rs
+++ b/rust/mlt-core/src/errors.rs
@@ -3,7 +3,8 @@ use std::num::TryFromIntError;
 use num_enum::TryFromPrimitiveError;
 
 use crate::decoder::{
-    GeometryType, LogicalEncoding, LogicalTechnique, PhysicalEncoding, StreamType,
+    GeometryType, LogicalCombination, LogicalEncoding, LogicalTechnique, PhysicalEncoding,
+    StreamType, ValueKind,
 };
 
 pub type MltResult<T> = Result<T, MltError>;
@@ -84,6 +85,8 @@ pub enum MltError {
     UnsupportedLogicalEncoding(LogicalEncoding, &'static str),
     #[error("invalid combination of logical encodings: {0:?} + {1:?}")]
     InvalidLogicalEncodings(LogicalTechnique, LogicalTechnique),
+    #[error("logical encoding {0:?} is not one a {1:?} stream has")]
+    LogicalEncodingNotInKind(LogicalCombination, ValueKind),
     #[error("layer has zero size")]
     ZeroLayerSize,
     #[error("The encoder used to optimise data is incompatible")]

--- a/rust/mlt-core/src/lib.rs
+++ b/rust/mlt-core/src/lib.rs
@@ -55,8 +55,9 @@ pub(crate) use utils::lazy_state::{Decode, DecodeState, Lazy, LazyParsed, Parsed
 pub mod wire {
     pub use crate::decoder::ColumnType;
     pub use crate::decoder::stream::model::{
-        DictionaryType, IntEncoding, LengthType, LogicalEncoding, LogicalTechnique, Morton,
-        OffsetType, PhysicalEncoding, RleLayout, RleMeta, StreamMeta, StreamType,
+        BoolLogical, DictionaryType, FloatLogical, IntEncoding, IntLogical, LengthType,
+        LogicalEncoding, LogicalTechnique, Morton, OffsetType, PhysicalEncoding, RleLayout,
+        RleMeta, StreamMeta, StreamType, ValueKind, VertexLogical,
     };
     pub use crate::utils::analyze::{Analyze, StatType};
 }

--- a/rust/mlt-core/tests/tag02_fixtures.rs
+++ b/rust/mlt-core/tests/tag02_fixtures.rs
@@ -1,12 +1,13 @@
 //! Differential test of the v2 wire format over every MVT fixture v2 can encode.
 
+use std::fs;
+use std::path::Path;
+
 use mlt_core::dump::annotate_tile;
 use mlt_core::encoder::{EncoderConfig, WireVersion};
 use mlt_core::mvt::mvt_to_tile_layers;
 use mlt_core::{Decoder, Layer, MltError, Parser, TileLayer};
 use rstest::rstest;
-use std::fs;
-use std::path::Path;
 use test_each_file::test_each_path;
 
 test_each_path! { for ["mvt"] in "../test/fixtures" as tag02_fixtures => differential_fixture }

--- a/rust/mlt/src/ls.rs
+++ b/rust/mlt/src/ls.rs
@@ -15,8 +15,8 @@ use mlt_core::geojson::FeatureCollection;
 use mlt_core::mvt::mvt_to_feature_collection;
 use mlt_core::wire::StatType::{DecodedDataSize, DecodedMetaSize, FeatureCount};
 use mlt_core::wire::{
-    Analyze as _, DictionaryType, LengthType, LogicalEncoding, OffsetType, PhysicalEncoding,
-    StreamMeta, StreamType,
+    Analyze as _, BoolLogical, DictionaryType, FloatLogical, IntLogical, LengthType,
+    LogicalEncoding, OffsetType, PhysicalEncoding, StreamMeta, StreamType, VertexLogical,
 };
 use mlt_core::{Decoder, GeometryType, Parser};
 use rayon::iter::{IntoParallelRefIterator as _, ParallelIterator as _};
@@ -670,15 +670,19 @@ pub enum StatLogicalCodec {
 
 impl From<LogicalEncoding> for StatLogicalCodec {
     fn from(ld: LogicalEncoding) -> Self {
+        use LogicalEncoding as LE;
         match ld {
-            LogicalEncoding::None => Self::None,
-            LogicalEncoding::Delta => Self::Delta,
-            LogicalEncoding::DeltaRle(_) => Self::DeltaRle,
-            LogicalEncoding::ComponentwiseDelta => Self::ComponentwiseDelta,
-            LogicalEncoding::Rle(_) => Self::Rle,
-            LogicalEncoding::Morton(_) => Self::Morton,
-            LogicalEncoding::MortonDelta(_) => Self::MortonDelta,
-            LogicalEncoding::MortonRle(_) => Self::MortonRle,
+            LE::Int(IntLogical::None)
+            | LE::Bool(BoolLogical::None)
+            | LE::Float(FloatLogical::None)
+            | LE::Vertex(VertexLogical::None) => Self::None,
+            LE::Int(IntLogical::Delta) | LE::Vertex(VertexLogical::Delta) => Self::Delta,
+            LE::Int(IntLogical::DeltaRle(_)) => Self::DeltaRle,
+            LE::Vertex(VertexLogical::ComponentwiseDelta) => Self::ComponentwiseDelta,
+            LE::Int(IntLogical::Rle(_)) | LE::Bool(BoolLogical::ByteRle(_)) => Self::Rle,
+            LE::Vertex(VertexLogical::Morton(_)) => Self::Morton,
+            LE::Vertex(VertexLogical::MortonDelta(_)) => Self::MortonDelta,
+            LE::Vertex(VertexLogical::MortonRle(_)) => Self::MortonRle,
         }
     }
 }


### PR DESCRIPTION
`LogicalEncoding` was the union of every encoding any stream can name, so a float column could name `ComponentwiseDelta` and only a runtime check said otherwise; it is now an enum over the value kind, each listing only its own encodings. No wire change.
