### PR TITLE
feat(rust): decode dictionary-encoded v2 float columns

### DIFF
--- a/rust/mlt-core/src/decoder/analyze.rs
+++ b/rust/mlt-core/src/decoder/analyze.rs
@@ -143,6 +143,11 @@ impl Analyze for RawFloatsEncoding<'_> {
     fn for_each_stream(&self, cb: &mut dyn FnMut(StreamMeta)) {
         match self {
             Self::Single(data) => data.for_each_stream(cb),
+            #[cfg(feature = "unstable-v2")]
+            Self::Dictionary { codes, dictionary } => {
+                codes.for_each_stream(cb);
+                dictionary.for_each_stream(cb);
+            }
         }
     }
 }

--- a/rust/mlt-core/src/decoder/property/decode.rs
+++ b/rust/mlt-core/src/decoder/property/decode.rs
@@ -2,7 +2,11 @@ use std::borrow::Cow;
 
 use bitvec::order::Lsb0;
 use bitvec::slice::BitSlice;
+#[cfg(feature = "unstable-v2")]
+use usize_cast::IntoUsize as _;
 
+#[cfg(feature = "unstable-v2")]
+use crate::MltError;
 use crate::decoder::{
     ParsedProperty, ParsedScalar, RawFloats, RawFloatsEncoding, RawPresence, RawProperty,
 };
@@ -36,6 +40,21 @@ impl<'a> RawFloats<'a> {
     {
         let values = match self.encoding {
             RawFloatsEncoding::Single(data) => data.decode_floats::<T>(dec)?,
+            #[cfg(feature = "unstable-v2")]
+            RawFloatsEncoding::Dictionary { codes, dictionary } => {
+                let dictionary = dictionary.decode_floats::<T>(dec)?;
+                let codes = codes.decode_ints::<u32>(dec)?;
+                dec.consume_items::<T>(codes.len())?;
+                codes
+                    .into_iter()
+                    .map(|code| {
+                        dictionary
+                            .get(code.into_usize())
+                            .copied()
+                            .ok_or(MltError::DictionaryCodeOutOfRange(code, dictionary.len()))
+                    })
+                    .collect::<MltResult<Vec<T>>>()?
+            }
         };
         ParsedScalar::from_parts(self.name, self.presence, values, dec)
     }
@@ -98,5 +117,74 @@ impl<'a> Decode<ParsedProperty<'a>> for RawProperty<'a> {
             Self::Str(v) => P::Str(v.decode(dec)?),
             Self::SharedDict(v) => P::SharedDict(v.decode(dec)?),
         })
+    }
+}
+
+#[cfg(all(test, feature = "unstable-v2"))]
+mod tests {
+    use bytemuck::cast_slice;
+
+    use super::*;
+    use crate::decoder::{
+        DictionaryType, FloatLogical, IntEncoding, LogicalEncoding, PhysicalEncoding, RawStream,
+        StreamMeta, StreamType, ValueKind,
+    };
+    use crate::test_helpers::dec;
+
+    fn codes(values: &[u32]) -> RawStream<'_> {
+        let encoding = IntEncoding::new(
+            LogicalEncoding::Float(FloatLogical::Dict),
+            PhysicalEncoding::None,
+        );
+        let num = u32::try_from(values.len()).unwrap();
+        let meta = StreamMeta::new(StreamType::Data(DictionaryType::None), encoding, num);
+        RawStream::new(meta, cast_slice(values))
+    }
+
+    fn dictionary(values: &[f64]) -> RawStream<'_> {
+        let num = u32::try_from(values.len()).unwrap();
+        let meta = StreamMeta::new(
+            StreamType::Data(DictionaryType::Single),
+            IntEncoding::none(ValueKind::Float),
+            num,
+        );
+        RawStream::new(meta, cast_slice(values))
+    }
+
+    fn floats<'a>(codes: RawStream<'a>, dictionary: RawStream<'a>) -> RawFloats<'a> {
+        RawFloats {
+            name: "v",
+            presence: RawPresence::AllPresent,
+            encoding: RawFloatsEncoding::Dictionary { codes, dictionary },
+        }
+    }
+
+    #[test]
+    fn a_dictionary_column_expands_its_codes_bit_for_bit() {
+        let dict = [1.5_f64, -0.0, f64::NAN];
+        let column = floats(codes(&[2, 0, 1, 0]), dictionary(&dict));
+        let parsed = column.decode::<f64>(&mut dec()).unwrap();
+
+        let bits: Vec<u64> = parsed
+            .presence
+            .dense_values()
+            .iter()
+            .map(|v| v.to_bits())
+            .collect();
+        let expected: Vec<u64> = [dict[2], dict[0], dict[1], dict[0]]
+            .iter()
+            .map(|v| v.to_bits())
+            .collect();
+        assert_eq!(bits, expected);
+    }
+
+    #[test]
+    fn a_code_past_the_end_of_the_dictionary_is_rejected() {
+        let column = floats(codes(&[0, 3]), dictionary(&[1.0, 2.0, 3.0]));
+        let err = column.decode::<f64>(&mut dec()).unwrap_err();
+        assert!(
+            matches!(err, MltError::DictionaryCodeOutOfRange(3, 3)),
+            "{err:?}"
+        );
     }
 }

--- a/rust/mlt-core/src/decoder/property/model.rs
+++ b/rust/mlt-core/src/decoder/property/model.rs
@@ -61,6 +61,14 @@ impl<'a> RawFloats<'a> {
 pub enum RawFloatsEncoding<'a> {
     /// One data stream, its own logical encoding saying how to read it.
     Single(RawStream<'a>),
+    /// Codes first, then the distinct values they index.
+    ///
+    /// Requires the `unstable-v2` feature.
+    #[cfg(feature = "unstable-v2")]
+    Dictionary {
+        codes: RawStream<'a>,
+        dictionary: RawStream<'a>,
+    },
 }
 
 /// Raw string column as read directly from the tile.

--- a/rust/mlt-core/src/decoder/root02.rs
+++ b/rust/mlt-core/src/decoder/root02.rs
@@ -41,8 +41,9 @@ use crate::codecs::varint::parse_varint;
 use crate::decoder::stream::header02;
 use crate::decoder::stream::header02::StreamCtx02;
 use crate::decoder::{
-    ColumnType02, DataType02, GeoLayout, Id, Layer01, LayerLayout, LengthType, Presence02,
-    RawFloats, RawGeometry, RawId, RawIdValue, RawPresence, RawScalar,
+    ColumnType02, DataType02, FloatLogical, GeoLayout, Id, Layer01, LayerLayout, LengthType,
+    LogicalEncoding, Presence02, RawFloats, RawFloatsEncoding, RawGeometry, RawId, RawIdValue,
+    RawPresence, RawScalar, RawStream,
 };
 use crate::tile::Extent;
 use crate::utils::{SetOptionOnce as _, parse_string, parse_u8, take};
@@ -134,8 +135,15 @@ pub(crate) fn parse_layer02<'a>(
             DataType02::U32 => RP::U32(RawScalar::new(name, presence, value)),
             DataType02::I64 => RP::I64(RawScalar::new(name, presence, value)),
             DataType02::U64 => RP::U64(RawScalar::new(name, presence, value)),
-            DataType02::F32 => RP::F32(RawFloats::single(name, presence, value)),
-            DataType02::F64 => RP::F64(RawFloats::single(name, presence, value)),
+            DataType02::F32 | DataType02::F64 => {
+                let floats;
+                (input, floats) = parse_floats(input, typ.data, name, presence, value, parser)?;
+                if typ.data == DataType02::F32 {
+                    RP::F32(floats)
+                } else {
+                    RP::F64(floats)
+                }
+            }
         };
         properties.push(Raw(prop));
     }
@@ -152,6 +160,35 @@ pub(crate) fn parse_layer02<'a>(
         #[cfg(fuzzing)]
         layer_order,
     })
+}
+
+/// Finish a float column, reading the dictionary stream when its data stream turned out to be one of codes.
+fn parse_floats<'a>(
+    input: &'a [u8],
+    typ: DataType02,
+    name: &'a str,
+    presence: RawPresence<'a>,
+    data: RawStream<'a>,
+    parser: &mut Parser,
+) -> MltRefResult<'a, RawFloats<'a>> {
+    if data.meta.encoding.logical != LogicalEncoding::Float(FloatLogical::Dict) {
+        return Ok((input, RawFloats::single(name, presence, data)));
+    }
+    // The dictionary's count is explicit in its header, so this fallback is never used.
+    let ctx = StreamCtx02::PropertyDictionary(typ);
+    let (input, dictionary) = header02::parse_stream(input, ctx, data.meta.num_values, parser)?;
+    let encoding = RawFloatsEncoding::Dictionary {
+        codes: data,
+        dictionary,
+    };
+    Ok((
+        input,
+        RawFloats {
+            name,
+            presence,
+            encoding,
+        },
+    ))
 }
 
 /// Parse the layer's shared presence bitfields: `shared_presence` back-to-back

--- a/rust/mlt-core/src/decoder/stream/decode.rs
+++ b/rust/mlt-core/src/decoder/stream/decode.rs
@@ -115,7 +115,10 @@ impl<'a> RawStream<'a> {
     {
         match self.meta.encoding.logical {
             LogicalEncoding::Float(FloatLogical::None) => {}
-            LogicalEncoding::Int(_) | LogicalEncoding::Bool(_) | LogicalEncoding::Vertex(_) => {
+            LogicalEncoding::Float(FloatLogical::Dict)
+            | LogicalEncoding::Int(_)
+            | LogicalEncoding::Bool(_)
+            | LogicalEncoding::Vertex(_) => {
                 return Err(MltError::UnsupportedLogicalEncoding(
                     self.meta.encoding.logical,
                     "float streams, which are stored raw",

--- a/rust/mlt-core/src/decoder/stream/header01.rs
+++ b/rust/mlt-core/src/decoder/stream/header01.rs
@@ -22,9 +22,7 @@ use integer_encoding::VarIntWriter as _;
 use num_enum::TryFromPrimitive;
 use usize_cast::IntoUsize as _;
 
-use crate::MltError::ParsingStreamType;
-#[cfg(feature = "unstable-v2")]
-use crate::MltError::UnsupportedLogicalEncoding;
+use crate::MltError::{ParsingStreamType, UnsupportedLogicalEncoding};
 use crate::codecs::varint::parse_varint;
 use crate::decoder::{
     BoolLogical, DictionaryType, FloatLogical, IntEncoding, IntLogical, LengthType,
@@ -256,6 +254,12 @@ pub(crate) fn write_stream_meta<W: io::Write>(
         LE::Vertex(VL::Morton(_)) => LC::Morton,
         LE::Vertex(VL::MortonDelta(_)) => LC::MortonDelta,
         LE::Vertex(VL::MortonRle(_)) => LC::MortonRle,
+        LE::Float(FL::Dict) => {
+            return Err(UnsupportedLogicalEncoding(
+                meta.encoding.logical,
+                "v1, whose dictionaries are named by the stream type",
+            ));
+        }
     };
     writer.write_u8(encoding_byte(logical, meta.encoding.physical))?;
     writer.write_varint(meta.num_values)?;

--- a/rust/mlt-core/src/decoder/stream/header02.rs
+++ b/rust/mlt-core/src/decoder/stream/header02.rs
@@ -68,6 +68,8 @@ pub(crate) enum Logical {
     Rle,
     DeltaRle,
     Morton,
+    Alp,
+    Dict,
 }
 
 /// Which logical encodings a stream's context admits, and how each reads the rest of the encoding byte.
@@ -86,17 +88,12 @@ pub(crate) enum Family {
 
 impl Family {
     /// The encodings this family has, in [`Logical`]'s canonical order, indexed by their wire code.
-    #[expect(
-        clippy::match_same_arms,
-        reason = "the families are separate tables that happen to agree today; \
-                  float gains Alp and Dict, bool does not"
-    )]
     const fn members(self) -> &'static [Logical] {
         use Logical as L;
         match self {
             Self::Int => &[L::None, L::Delta, L::Rle, L::DeltaRle],
             Self::Bool => &[L::None, L::Rle],
-            Self::Float => &[L::None, L::Rle],
+            Self::Float => &[L::None, L::Rle, L::Alp, L::Dict],
             Self::Vertex => &[L::None, L::Delta, L::CwDelta, L::Morton],
         }
     }
@@ -119,6 +116,8 @@ impl Family {
 pub(crate) enum StreamCtx02 {
     /// A counted column's data stream, typed by the column's data type.
     Property(DataType02),
+    /// The dictionary a column's codes index into, following its codes stream, of the column's own type.
+    PropertyDictionary(DataType02),
     GeomTypes,
     GeomVertices,
     GeomOffsets(LengthType),
@@ -128,9 +127,15 @@ impl StreamCtx02 {
     /// The family this stream's logical field is numbered in.
     pub(crate) fn family(self) -> Family {
         match self {
-            Self::Property(DataType02::Bool) => Family::Bool,
-            Self::Property(DataType02::F32 | DataType02::F64) => Family::Float,
-            Self::Property(_) | Self::GeomTypes | Self::GeomOffsets(_) => Family::Int,
+            Self::Property(DataType02::Bool) | Self::PropertyDictionary(DataType02::Bool) => {
+                Family::Bool
+            }
+            Self::Property(DataType02::F32 | DataType02::F64)
+            | Self::PropertyDictionary(DataType02::F32 | DataType02::F64) => Family::Float,
+            Self::Property(_)
+            | Self::PropertyDictionary(_)
+            | Self::GeomTypes
+            | Self::GeomOffsets(_) => Family::Int,
             Self::GeomVertices => Family::Vertex,
         }
     }
@@ -139,6 +144,7 @@ impl StreamCtx02 {
     fn stream_type(self) -> StreamType {
         match self {
             Self::Property(_) => StreamType::Data(DictionaryType::None),
+            Self::PropertyDictionary(_) => StreamType::Data(DictionaryType::Single),
             Self::GeomTypes => StreamType::Length(LengthType::VarBinary),
             Self::GeomVertices => StreamType::Data(DictionaryType::Vertex),
             Self::GeomOffsets(length_type) => StreamType::Length(length_type),
@@ -190,6 +196,11 @@ pub(crate) enum LogicalFloat {
     /// Fixed-width little-endian values, one per element.
     None(PhysicalBits),
     Rle,
+    /// Adaptive lossless floating-point compression.
+    Alp,
+    /// One code per element, then the dictionary of distinct values as a second stream.
+    /// The physical field codes the codes, not the values.
+    Dict(PhysicalInt),
 }
 
 /// Logical encoding of a geometry vertex stream.
@@ -260,7 +271,9 @@ impl Encoding02 {
                     no_physical(enc_byte)?;
                     LogicalInt::DeltaRle
                 }
-                Logical::CwDelta | Logical::Morton => unreachable_member(family, logical)?,
+                Logical::CwDelta | Logical::Morton | Logical::Alp | Logical::Dict => {
+                    unreachable_member(family, logical)?
+                }
             }),
             Family::Bool => Self::Bool(match logical {
                 Logical::None => LogicalBool::None(physical_bits(enc_byte)?),
@@ -268,9 +281,12 @@ impl Encoding02 {
                     no_physical(enc_byte)?;
                     LogicalBool::Rle
                 }
-                Logical::Delta | Logical::CwDelta | Logical::DeltaRle | Logical::Morton => {
-                    unreachable_member(family, logical)?
-                }
+                Logical::Delta
+                | Logical::CwDelta
+                | Logical::DeltaRle
+                | Logical::Morton
+                | Logical::Alp
+                | Logical::Dict => unreachable_member(family, logical)?,
             }),
             Family::Float => Self::Float(match logical {
                 Logical::None => LogicalFloat::None(physical_bits(enc_byte)?),
@@ -278,6 +294,11 @@ impl Encoding02 {
                     no_physical(enc_byte)?;
                     LogicalFloat::Rle
                 }
+                Logical::Alp => {
+                    no_physical(enc_byte)?;
+                    LogicalFloat::Alp
+                }
+                Logical::Dict => LogicalFloat::Dict(physical_int(enc_byte)?),
                 Logical::Delta | Logical::CwDelta | Logical::DeltaRle | Logical::Morton => {
                     unreachable_member(family, logical)?
                 }
@@ -290,7 +311,9 @@ impl Encoding02 {
                     no_physical(enc_byte)?;
                     LogicalVertex::Morton
                 }
-                Logical::Rle | Logical::DeltaRle => unreachable_member(family, logical)?,
+                Logical::Rle | Logical::DeltaRle | Logical::Alp | Logical::Dict => {
+                    unreachable_member(family, logical)?
+                }
             }),
         })
     }
@@ -311,6 +334,8 @@ impl Encoding02 {
             | Self::Float(LogicalFloat::Rle) => Logical::Rle,
             Self::Int(LogicalInt::DeltaRle) => Logical::DeltaRle,
             Self::Vertex(LogicalVertex::Morton) => Logical::Morton,
+            Self::Float(LogicalFloat::Alp) => Logical::Alp,
+            Self::Float(LogicalFloat::Dict(_)) => Logical::Dict,
         }
     }
 
@@ -318,13 +343,14 @@ impl Encoding02 {
     fn physical_label(self) -> &'static str {
         match self {
             Self::Int(LogicalInt::None(p) | LogicalInt::Delta(p))
+            | Self::Float(LogicalFloat::Dict(p))
             | Self::Vertex(
                 LogicalVertex::None(p) | LogicalVertex::Delta(p) | LogicalVertex::CwDelta(p),
             ) => p.into(),
             Self::Bool(LogicalBool::None(p)) | Self::Float(LogicalFloat::None(p)) => p.into(),
             Self::Int(LogicalInt::Rle | LogicalInt::DeltaRle)
             | Self::Bool(LogicalBool::Rle)
-            | Self::Float(LogicalFloat::Rle)
+            | Self::Float(LogicalFloat::Rle | LogicalFloat::Alp)
             | Self::Vertex(LogicalVertex::Morton) => "implied",
         }
     }
@@ -372,6 +398,12 @@ impl Encoding02 {
             Self::Float(LogicalFloat::Rle) => {
                 return Err(MltError::NotImplemented("v2 RLE over a float column"));
             }
+            Self::Float(LogicalFloat::Alp) => {
+                return Err(MltError::NotImplemented("v2 ALP float streams"));
+            }
+            Self::Float(LogicalFloat::Dict(p)) => {
+                IntEncoding::new(LogicalEncoding::Float(FloatLogical::Dict), flat_int(p)?)
+            }
             Self::Vertex(LogicalVertex::Morton) => {
                 return Err(MltError::NotImplemented("v2 Morton streams"));
             }
@@ -402,6 +434,19 @@ fn flat_bits(physical: PhysicalBits) -> MltResult<PhysicalEncoding> {
         PhysicalBits::WithLen => Ok(PhysicalEncoding::None),
         PhysicalBits::NoLen => Err(MltError::NotImplemented("v2 None-noLen physical encoding")),
     }
+}
+
+/// The physical field bits for a stream of integers, whatever the column's own type is.
+fn physical_int_field(physical: PhysicalEncoding) -> MltResult<u8> {
+    Ok(match physical {
+        PhysicalEncoding::None => PhysicalInt::NoneWithLen as u8,
+        PhysicalEncoding::VarInt => PhysicalInt::VarInt as u8,
+        PhysicalEncoding::FastPFor256 => {
+            return Err(MltError::NotImplemented(
+                "v2 FastPFor: requires the FastPFor128-LE codec",
+            ));
+        }
+    })
 }
 
 /// The logical encoding and physical field bits `encoding` is written as, the reverse of [`Encoding02::to_model`].
@@ -435,6 +480,8 @@ fn wire_fields(encoding: IntEncoding, family: Family) -> MltResult<(Logical, u8)
         LE::Int(IL::None) | LE::Bool(BL::None) | LE::Float(FL::None) | LE::Vertex(VL::None) => {
             (Logical::None, physical(encoding)?)
         }
+        // Codes are an integer stream, whatever the column's type is.
+        LE::Float(FL::Dict) => (Logical::Dict, physical_int_field(encoding.physical)?),
         LE::Int(IL::Delta) | LE::Vertex(VL::Delta) => (Logical::Delta, physical(encoding)?),
         LE::Vertex(VL::ComponentwiseDelta) => (Logical::CwDelta, physical(encoding)?),
         LE::Int(IL::Rle(rle) | IL::DeltaRle(rle)) => {
@@ -619,6 +666,8 @@ mod tests {
     #[case::bool_rle(Family::Bool, Logical::Rle, 0b001)]
     #[case::float_none(Family::Float, Logical::None, 0b000)]
     #[case::float_rle(Family::Float, Logical::Rle, 0b001)]
+    #[case::float_alp(Family::Float, Logical::Alp, 0b010)]
+    #[case::float_dict(Family::Float, Logical::Dict, 0b011)]
     #[case::vertex_none(Family::Vertex, Logical::None, 0b000)]
     #[case::vertex_delta(Family::Vertex, Logical::Delta, 0b001)]
     #[case::vertex_cw_delta(Family::Vertex, Logical::CwDelta, 0b010)]
@@ -705,6 +754,12 @@ mod tests {
     )]
     #[case::raw_float(float(FloatLogical::None, PE::None, 5), 5, Family::Float, 0b0000_0100)]
     #[case::raw_bool(boolean(BoolLogical::None, PE::None, 5), 5, Family::Bool, 0b0000_0100)]
+    #[case::float_dict_codes_varint(
+        float(FloatLogical::Dict, PE::VarInt, 5),
+        5,
+        Family::Float,
+        0b0011_1000
+    )]
     #[case::cw_delta_vertices_explicit(
         vertex(VertexLogical::ComponentwiseDelta, PE::VarInt, 8),
         5,
@@ -731,6 +786,8 @@ mod tests {
     #[case::delta_rle(int(IntLogical::DeltaRle(rle(9)), PE::VarInt, 9), 5, INT)]
     #[case::raw_float(float(FloatLogical::None, PE::None, 5), 5, FLOAT)]
     #[case::raw_bool(boolean(BoolLogical::None, PE::None, 5), 5, BOOL)]
+    #[case::float_dict_codes_varint(float(FloatLogical::Dict, PE::VarInt, 5), 5, FLOAT)]
+    #[case::float_dict_codes_raw(float(FloatLogical::Dict, PE::None, 5), 5, FLOAT)]
     #[case::cw_delta_vertices(vertex(VertexLogical::ComponentwiseDelta, PE::VarInt, 10), 5, VERTEX)]
     fn header_roundtrip(
         #[case] meta: StreamMeta,
@@ -761,7 +818,7 @@ mod tests {
     #[case::morton_with_physical(VERTEX, 0b0011_1000)]
     #[case::int_logical_past_table(INT, 0b0100_1000)]
     #[case::bool_logical_past_table(BOOL, 0b0010_0100)]
-    #[case::float_logical_past_table(FLOAT, 0b0011_0100)]
+    #[case::float_dict_with_extension(FLOAT, 0b0011_0101)]
     #[case::vertex_logical_past_table(VERTEX, 0b0100_1000)]
     #[case::float_physical_varint(FLOAT, 0b0000_1000)]
     #[case::float_physical_fastpfor(FLOAT, 0b0000_1100)]
@@ -780,6 +837,8 @@ mod tests {
     #[case::fastpfor128(INT, 0b0000_1100)]
     #[case::float_none_no_len(FLOAT, 0b0000_0000)]
     #[case::float_rle(FLOAT, 0b0001_0000)]
+    #[case::float_alp(FLOAT, 0b0010_0000)]
+    #[case::float_dict_no_len(FLOAT, 0b0011_0000)]
     #[case::bool_rle(BOOL, 0b0001_0000)]
     #[case::vertex_morton(VERTEX, 0b0011_0000)]
     fn parse_rejects_unimplemented_encoding(#[case] ctx: StreamCtx02, #[case] enc_byte: u8) {
@@ -790,15 +849,11 @@ mod tests {
 
     #[rstest]
     #[case::delta(0b0001_1000, LogicalEncoding::Int(IntLogical::Delta), "encoding byte")]
-    #[case::rle(
-        0b0010_0000,
-        LogicalEncoding::Int(IntLogical::Rle(rle(1))),
-        "encoding byte"
-    )]
+    #[case::rle(0b0010_0000, LogicalEncoding::Int(IntLogical::Rle(rle(1))), "ALP")]
     #[case::delta_rle(
         0b0011_0000,
         LogicalEncoding::Int(IntLogical::DeltaRle(rle(1))),
-        "encoding byte"
+        "None-noLen"
     )]
     fn an_int_bit_pattern_never_means_the_same_on_a_float_column(
         #[case] enc_byte: u8,
@@ -860,6 +915,8 @@ mod tests {
         })),
         Family::Bool
     )]
+    #[case::dict_on_an_int_column(LogicalEncoding::Float(FloatLogical::Dict), Family::Int)]
+    #[case::dict_on_a_vertex_stream(LogicalEncoding::Float(FloatLogical::Dict), Family::Vertex)]
     fn write_rejects_a_logical_the_family_does_not_list(
         #[case] logical: LogicalEncoding,
         #[case] family: Family,

--- a/rust/mlt-core/src/decoder/stream/model.rs
+++ b/rust/mlt-core/src/decoder/stream/model.rs
@@ -132,6 +132,10 @@ pub enum BoolLogical {
 pub enum FloatLogical {
     /// Fixed-width little-endian values, one per element.
     None,
+    /// A decimal split across two integer streams, which v1 can name but no decoder here implements.
+    /// One code per element, with the distinct values following as a second stream.
+    /// Only the tag `0x02` codec reads or writes it.
+    Dict,
 }
 
 /// Logical encoding of a geometry vertex stream, whose values are interleaved coordinate pairs.
@@ -180,13 +184,14 @@ impl LogicalEncoding {
     }
 
     /// Whether the stream's own logical pass is a no-op, so the physical words are already the output.
+    /// True for a float dictionary's codes, which the column turns back into floats.
     #[must_use]
     pub(crate) fn is_identity(self) -> bool {
         matches!(
             self,
             Self::Int(IntLogical::None)
                 | Self::Bool(BoolLogical::None)
-                | Self::Float(FloatLogical::None)
+                | Self::Float(FloatLogical::None | FloatLogical::Dict)
                 | Self::Vertex(VertexLogical::None)
         )
     }

--- a/rust/mlt-core/src/dump/walker02.rs
+++ b/rust/mlt-core/src/dump/walker02.rs
@@ -20,7 +20,7 @@ use crate::decoder::{
 };
 use crate::tile::Extent;
 use crate::utils::{parse_string, parse_u8, take};
-use crate::wire::{IntEncoding, StreamMeta, ValueKind};
+use crate::wire::{FloatLogical, IntEncoding, LogicalEncoding, StreamMeta, ValueKind};
 use crate::{MltError, MltResult};
 
 impl<'a> Walker<'a> {
@@ -110,7 +110,7 @@ impl<'a> Walker<'a> {
             return Err(MltError::NotImplemented("v2 tessellated geometry layouts"));
         }
 
-        let mut input = self.walk_stream02(
+        let (mut input, _) = self.walk_stream02(
             input,
             StreamCtx02::GeomTypes,
             feature_count,
@@ -130,17 +130,19 @@ impl<'a> Walker<'a> {
         for (present, length_type, label) in lengths {
             if present {
                 let ctx = StreamCtx02::GeomOffsets(length_type);
-                input = self.walk_stream02(input, ctx, feature_count, label, DecodeHint::U32)?;
+                (input, _) =
+                    self.walk_stream02(input, ctx, feature_count, label, DecodeHint::U32)?;
             }
         }
 
-        self.walk_stream02(
+        let (input, _) = self.walk_stream02(
             input,
             StreamCtx02::GeomVertices,
             feature_count,
             "vertices",
             DecodeHint::I32,
-        )
+        )?;
+        Ok(input)
     }
 
     /// `[u8 type][name?][presence bitfield?][data stream]`.
@@ -199,7 +201,20 @@ impl<'a> Walker<'a> {
         };
 
         let ctx = StreamCtx02::Property(typ.data);
-        input = self.walk_stream02(input, ctx, data_count, "data", hint_for(typ.data))?;
+        let meta;
+        (input, meta) = self.walk_stream02(input, ctx, data_count, "data", hint_for(typ.data))?;
+
+        // A dictionary column's data stream holds codes, and the values follow.
+        if meta.encoding.logical == LogicalEncoding::Float(FloatLogical::Dict) {
+            let ctx = StreamCtx02::PropertyDictionary(typ.data);
+            (input, _) = self.walk_stream02(
+                input,
+                ctx,
+                meta.num_values,
+                "dictionary",
+                hint_for(typ.data),
+            )?;
+        }
 
         self.close(ci, input);
         Ok(input)
@@ -244,7 +259,7 @@ impl<'a> Walker<'a> {
         implicit_count: u32,
         label: &str,
         hint: DecodeHint,
-    ) -> MltResult<&'a [u8]> {
+    ) -> MltResult<(&'a [u8], StreamMeta)> {
         let si = self.open(input, label.to_string());
 
         // parse -> synthesized meta.
@@ -297,7 +312,7 @@ impl<'a> Walker<'a> {
         );
 
         self.close(si, rest);
-        Ok(rest)
+        Ok((rest, stream.meta))
     }
 }
 

--- a/rust/mlt-core/src/errors.rs
+++ b/rust/mlt-core/src/errors.rs
@@ -119,6 +119,9 @@ pub enum MltError {
     PriorParseFailure,
     #[error("FSST-compressed data is malformed: {0}")]
     MalformedFsst(&'static str),
+    #[cfg(feature = "unstable-v2")]
+    #[error("dictionary code {0} is out of range for a dictionary of {1} values")]
+    DictionaryCodeOutOfRange(u32, usize),
     #[error("presence stream has {0} bits set but {1} values provided")]
     PresenceValueCountMismatch(usize, usize),
     #[error("need to encode before being able to write")]

--- a/rust/mlt/src/ls.rs
+++ b/rust/mlt/src/ls.rs
@@ -184,6 +184,7 @@ impl std::fmt::Display for FileAlgorithm {
                     StatLogicalCodec::Morton => "Morton",
                     StatLogicalCodec::MortonDelta => "MortonDelta",
                     StatLogicalCodec::MortonRle => "MortonRle",
+                    StatLogicalCodec::Dict => "Dict",
                 };
                 write!(f, "{phys_type}")?;
                 if !physical.is_empty() {
@@ -666,6 +667,7 @@ pub enum StatLogicalCodec {
     Morton,
     MortonDelta,
     MortonRle,
+    Dict,
 }
 
 impl From<LogicalEncoding> for StatLogicalCodec {
@@ -683,6 +685,7 @@ impl From<LogicalEncoding> for StatLogicalCodec {
             LE::Vertex(VertexLogical::Morton(_)) => Self::Morton,
             LE::Vertex(VertexLogical::MortonDelta(_)) => Self::MortonDelta,
             LE::Vertex(VertexLogical::MortonRle(_)) => Self::MortonRle,
+            LE::Float(FloatLogical::Dict) => Self::Dict,
         }
     }
 }


### PR DESCRIPTION
A float column whose encoding byte names `Dict` holds one code per element, followed by the distinct values those codes index. Codes come first because their count is implied by the presence popcount while the dictionary carries its own.
