### PR TITLE
feat(rust): encode v2 float columns as a dictionary, behind a flag

### DIFF
--- a/rust/mlt-core/src/encoder/fuzzing.rs
+++ b/rust/mlt-core/src/encoder/fuzzing.rs
@@ -18,7 +18,9 @@ impl Arbitrary<'_> for EncoderConfig {
             .with_fastpfor(u.arbitrary()?)
             .with_shared_dict(u.arbitrary()?);
         #[cfg(feature = "unstable-v2")]
-        let config = config.with_wire_version(u.arbitrary()?);
+        let config = config
+            .with_wire_version(u.arbitrary()?)
+            .with_float_dict(u.arbitrary()?);
         Ok(config)
     }
 }

--- a/rust/mlt-core/src/encoder/model.rs
+++ b/rust/mlt-core/src/encoder/model.rs
@@ -227,6 +227,9 @@ pub struct EncoderConfig {
     allow_fastpfor: bool,
     /// Allow string grouping into shared dictionaries
     allow_shared_dict: bool,
+    /// Allow the v2-only float dictionary encoding
+    #[cfg(feature = "unstable-v2")]
+    allow_float_dict: bool,
 }
 impl Default for EncoderConfig {
     fn default() -> Self {
@@ -240,6 +243,9 @@ impl Default for EncoderConfig {
             allow_fsst: true,
             allow_fastpfor: true,
             allow_shared_dict: true,
+            // Off by default while the encoding is still being measured.
+            #[cfg(feature = "unstable-v2")]
+            allow_float_dict: false,
         }
     }
 }
@@ -293,6 +299,13 @@ impl EncoderConfig {
         self.allow_shared_dict
     }
 
+    /// Whether float columns may use a dictionary, which only v2 can express.
+    #[cfg(feature = "unstable-v2")]
+    #[must_use]
+    pub fn allow_float_dict(self) -> bool {
+        self.allow_float_dict && self.wire_version != WireVersion::V01
+    }
+
     #[cfg(feature = "unstable-v2")]
     #[must_use]
     pub fn with_wire_version(mut self, version: WireVersion) -> Self {
@@ -339,6 +352,16 @@ impl EncoderConfig {
     #[must_use]
     pub fn with_shared_dict(mut self, enabled: bool) -> Self {
         self.allow_shared_dict = enabled;
+        self
+    }
+
+    /// Allow float columns to store one code per value into a dictionary of the distinct ones.
+    /// Off by default, and only v2 can express it.
+    /// A column takes it only when it comes out strictly smaller in stored bytes.
+    #[cfg(feature = "unstable-v2")]
+    #[must_use]
+    pub fn with_float_dict(mut self, enabled: bool) -> Self {
+        self.allow_float_dict = enabled;
         self
     }
 }

--- a/rust/mlt-core/src/encoder/stream/codecs.rs
+++ b/rust/mlt-core/src/encoder/stream/codecs.rs
@@ -5,6 +5,8 @@ use fastpfor::FastPFor256;
 
 use crate::codecs::bytes::encode_bools_to_bytes;
 use crate::codecs::rle::encode_byte_rle;
+#[cfg(feature = "unstable-v2")]
+use crate::decoder::FloatLogical;
 #[cfg(not(feature = "unstable-v2"))]
 use crate::decoder::RleLayout;
 use crate::decoder::{
@@ -14,6 +16,9 @@ use crate::decoder::{
 use crate::encoder;
 use crate::encoder::Encoder;
 use crate::encoder::model::StreamCtx;
+use crate::encoder::stream::float_dict::FloatBits;
+#[cfg(feature = "unstable-v2")]
+use crate::encoder::stream::float_dict::FloatDict;
 use crate::encoder::stream::logical::LogicalEncoder;
 use crate::encoder::stream::optimizer::DataProfile;
 use crate::encoder::write::{LogicalIntCodec, LogicalIntStreamKind, PhysicalIntStreamKind};
@@ -89,11 +94,14 @@ impl Codecs {
         self.write_bool_stream(values, StreamType::Present, enc)
     }
 
-    #[expect(
-        clippy::unused_self,
-        reason = "kept as a Codecs method to match the other stream writers"
+    #[cfg_attr(
+        not(feature = "unstable-v2"),
+        expect(
+            clippy::unused_self,
+            reason = "kept as a Codecs method to match the other stream writers"
+        )
     )]
-    pub(crate) fn write_float_stream<T: NoUninit>(
+    pub(crate) fn write_float_stream<T: NoUninit + FloatBits>(
         &mut self,
         values: &[T],
         stream_type: StreamType,
@@ -102,8 +110,44 @@ impl Codecs {
         #[cfg(not(target_endian = "little"))]
         compile_error!("not implemented for non-little-endian targets");
 
+        #[cfg(feature = "unstable-v2")]
+        if enc.config().allow_float_dict()
+            && let Some(dict) = FloatDict::worth_building(values)
+        {
+            return self.write_float_dict_streams(values, &dict, stream_type, enc);
+        }
+
         let meta = StreamMeta::new_none(stream_type, ValueKind::Float, values.len())?;
         encoder::write_stream_payload(enc, meta, false, cast_slice(values))
+    }
+
+    /// Write a float column as a codes stream followed by its dictionary.
+    /// Codes first, so only the dictionary needs a count in its header.
+    #[cfg(feature = "unstable-v2")]
+    fn write_float_dict_streams<T: NoUninit + FloatBits>(
+        &mut self,
+        values: &[T],
+        dict: &FloatDict<T>,
+        stream_type: StreamType,
+        enc: &mut Encoder,
+    ) -> MltResult<()> {
+        use crate::decoder::DictionaryType;
+
+        let codes_meta = StreamMeta::new2(
+            stream_type,
+            LogicalEncoding::Float(FloatLogical::Dict),
+            PhysicalEncoding::VarInt,
+            values.len(),
+        )?;
+        let codes = self.physical.varint(&dict.codes);
+        encoder::write_stream_payload(enc, codes_meta, false, codes)?;
+
+        let values_meta = StreamMeta::new_none(
+            StreamType::Data(DictionaryType::Single),
+            ValueKind::Float,
+            dict.values.len(),
+        )?;
+        encoder::write_stream_payload(enc, values_meta, false, cast_slice(&dict.values))
     }
 
     pub(crate) fn write_int_stream<T>(

--- a/rust/mlt-core/src/encoder/stream/float_dict.rs
+++ b/rust/mlt-core/src/encoder/stream/float_dict.rs
@@ -1,0 +1,95 @@
+//! Dictionary building for float columns.
+
+/// A float whose bit pattern is its dictionary key.
+/// `-0.0` must stay a distinct entry from `0.0`, and a NaN is equal to no float at all, itself included.
+pub(crate) trait FloatBits: Copy {
+    type Bits: Copy + Eq + std::hash::Hash;
+
+    #[cfg_attr(
+        not(feature = "unstable-v2"),
+        expect(dead_code, reason = "only the v2 float dictionary keys on bits")
+    )]
+    fn key(self) -> Self::Bits;
+}
+
+impl FloatBits for f32 {
+    type Bits = u32;
+
+    fn key(self) -> u32 {
+        self.to_bits()
+    }
+}
+
+impl FloatBits for f64 {
+    type Bits = u64;
+
+    fn key(self) -> u64 {
+        self.to_bits()
+    }
+}
+
+/// A float column's distinct values and one code per element.
+#[cfg(feature = "unstable-v2")]
+pub(crate) struct FloatDict<T> {
+    /// Distinct values in first-appearance order, so the result does not depend on hash iteration order.
+    pub(crate) values: Vec<T>,
+    /// One index into `values` per input element.
+    pub(crate) codes: Vec<u32>,
+}
+
+#[cfg(feature = "unstable-v2")]
+impl<T: FloatBits> FloatDict<T> {
+    /// Build a dictionary for `values`, or [`None`] when it would not be smaller.
+    /// Both layouts are costed as stored bytes, headers included, assuming nothing about transport compression.
+    pub(crate) fn worth_building(values: &[T]) -> Option<Self> {
+        let dict = Self::build(values)?;
+        (dict.stored_bytes() < raw_stored_bytes::<T>(values.len())).then_some(dict)
+    }
+
+    /// The dictionary, or [`None`] if every element is distinct.
+    fn build(values: &[T]) -> Option<Self> {
+        let mut seen = std::collections::HashMap::new();
+        let mut dict = Self {
+            values: Vec::new(),
+            codes: Vec::with_capacity(values.len()),
+        };
+        for &value in values {
+            let next = u32::try_from(dict.values.len()).ok()?;
+            let code = *seen.entry(value.key()).or_insert_with(|| {
+                dict.values.push(value);
+                next
+            });
+            dict.codes.push(code);
+        }
+        (dict.values.len() < values.len()).then_some(dict)
+    }
+
+    /// Bytes the codes and dictionary streams occupy, headers included.
+    /// The codes count is implied by context, while the dictionary's always needs its own varint.
+    fn stored_bytes(&self) -> usize {
+        let codes: usize = self.codes.iter().copied().map(varint_len).sum();
+        let values = size_of_val(self.values.as_slice());
+        let codes_stream = ENCODING_BYTE + varint_len(codes) + codes;
+        let dict_stream =
+            ENCODING_BYTE + varint_len(self.values.len()) + varint_len(values) + values;
+        codes_stream + dict_stream
+    }
+}
+
+/// The encoding byte every stream header starts with.
+#[cfg(feature = "unstable-v2")]
+const ENCODING_BYTE: usize = 1;
+
+/// Bytes a raw column of `count` elements occupies, header included.
+#[cfg(feature = "unstable-v2")]
+fn raw_stored_bytes<T>(count: usize) -> usize {
+    let values = count * size_of::<T>();
+    ENCODING_BYTE + varint_len(values) + values
+}
+
+/// Encoded length of a varint, for costing a header that is not written yet.
+#[cfg(feature = "unstable-v2")]
+fn varint_len(value: impl TryInto<u64>) -> usize {
+    let value: u64 = value.try_into().unwrap_or(u64::MAX);
+    integer_encoding::VarInt::required_space(value)
+}

--- a/rust/mlt-core/src/encoder/stream/mod.rs
+++ b/rust/mlt-core/src/encoder/stream/mod.rs
@@ -1,4 +1,5 @@
 mod codecs;
+mod float_dict;
 pub(crate) use codecs::LogicalCodecs;
 #[cfg(feature = "__private")]
 pub use codecs::{Codecs, PhysicalCodecs};

--- a/rust/mlt-core/tests/tag02_roundtrip.rs
+++ b/rust/mlt-core/tests/tag02_roundtrip.rs
@@ -607,3 +607,140 @@ fn tessellation_not_yet_supported() {
     let err = l.encode(cfg_v2().with_tessellation(true)).unwrap_err();
     assert!(err.to_string().contains("not"), "unexpected error: {err}");
 }
+
+/// Float columns encoded as a dictionary: off by default, so these opt in.
+mod float_dictionary {
+    use super::*;
+
+    fn cfg_dict() -> EncoderConfig {
+        cfg_v2().with_float_dict(true)
+    }
+
+    fn f64_col(values: &[f64]) -> Vec<PropValue> {
+        values.iter().map(|&v| PropValue::F64(Some(v))).collect()
+    }
+
+    fn f32_col(values: &[f32]) -> Vec<PropValue> {
+        values.iter().map(|&v| PropValue::F32(Some(v))).collect()
+    }
+
+    fn round_trip(l: &TileLayer, config: EncoderConfig) -> TileLayer {
+        let bytes = l.clone().encode(config).expect("encode");
+        let (tag, tile) = decode(&bytes);
+        assert_eq!(tag, 2);
+        assert_dump_covers(&bytes);
+        tile
+    }
+
+    fn column(values: &[f64]) -> TileLayer {
+        let mask = "1".repeat(values.len());
+        layer(points(&mask), None, &[("v", f64_col(values))])
+    }
+
+    #[test]
+    fn a_repetitive_column_round_trips_through_a_dictionary() {
+        const VALUES: &[f64] = &[1.5, 2.5, 1.5, 1.5, 2.5, 3.5, 1.5, 2.5, 1.5, 1.5, 2.5, 3.5];
+        let l = column(VALUES);
+        assert_eq!(round_trip(&l, cfg_dict()), round_trip(&l, cfg_v2()));
+    }
+
+    #[test]
+    fn the_dictionary_is_smaller_and_shows_in_the_dump() {
+        const VALUES: &[f64] = &[1.5, 2.5, 1.5, 1.5, 2.5, 3.5, 1.5, 2.5, 1.5, 1.5, 2.5, 3.5];
+        let l = column(VALUES);
+        let plain = l.clone().encode(cfg_v2()).unwrap();
+        let dict = l.clone().encode(cfg_dict()).unwrap();
+        assert!(
+            dict.len() < plain.len(),
+            "{} vs {}",
+            dict.len(),
+            plain.len()
+        );
+
+        let dump = dump_text(&dict);
+        assert!(
+            dump.contains("logical = Dict, numbered for a v2 float column"),
+            "{dump}"
+        );
+        assert!(dump.contains("dictionary"), "{dump}");
+    }
+
+    #[test]
+    #[expect(
+        clippy::wildcard_enum_match_arm,
+        reason = "only f64 values are expected"
+    )]
+    fn zero_and_negative_zero_stay_distinct_entries() {
+        const VALUES: &[f64] = &[0.0, -0.0, 0.0, -0.0, 0.0, -0.0];
+        let l = column(VALUES);
+        let tile = round_trip(&l, cfg_dict());
+        let signs: Vec<bool> = tile
+            .features()
+            .iter()
+            .map(|f| match f.properties()[0] {
+                PropValue::F64(Some(v)) => v.is_sign_negative(),
+                ref other => panic!("unexpected {other:?}"),
+            })
+            .collect();
+        assert_eq!(signs, [false, true, false, true, false, true]);
+    }
+
+    #[test]
+    #[expect(
+        clippy::wildcard_enum_match_arm,
+        reason = "only f64 values are expected"
+    )]
+    fn every_nan_with_the_same_bits_shares_one_entry() {
+        let values: Vec<f64> = (0..8)
+            .map(|i| if i % 2 == 0 { f64::NAN } else { 7.5 })
+            .collect();
+        let l = column(&values);
+        let tile = round_trip(&l, cfg_dict());
+        let nans: Vec<bool> = tile
+            .features()
+            .iter()
+            .map(|f| match f.properties()[0] {
+                PropValue::F64(Some(v)) => v.is_nan(),
+                ref other => panic!("unexpected {other:?}"),
+            })
+            .collect();
+        assert_eq!(nans, [true, false, true, false, true, false, true, false]);
+    }
+
+    #[test]
+    fn an_all_distinct_column_stays_raw() {
+        let values: Vec<f64> = (0..16).map(f64::from).collect();
+        let l = column(&values);
+        assert_eq!(
+            l.clone().encode(cfg_dict()).unwrap(),
+            l.encode(cfg_v2()).unwrap()
+        );
+    }
+
+    #[test]
+    fn f32_columns_round_trip_through_a_dictionary() {
+        const VALUES: &[f32] = &[1.5, 2.5, 1.5, 1.5, 2.5, 3.5, 1.5, 2.5, 1.5, 1.5, 2.5, 3.5];
+        let mask = "1".repeat(VALUES.len());
+        let l = layer(points(&mask), None, &[("v", f32_col(VALUES))]);
+        assert_eq!(round_trip(&l, cfg_dict()), round_trip(&l, cfg_v2()));
+    }
+
+    #[test]
+    fn an_optional_dictionary_column_round_trips() {
+        let values: Vec<PropValue> = (0..12)
+            .map(|i| PropValue::F64((i % 3 != 0).then(|| f64::from(i % 2) + 0.5)))
+            .collect();
+        let l = layer(points(&"1".repeat(12)), None, &[("v", values)]);
+        assert_eq!(round_trip(&l, cfg_dict()), round_trip(&l, cfg_v2()));
+    }
+
+    #[test]
+    fn v1_ignores_the_flag() {
+        const VALUES: &[f64] = &[1.5, 1.5, 1.5, 1.5];
+        let l = column(VALUES);
+        assert_eq!(
+            l.clone().encode(cfg_v1().with_float_dict(true)).unwrap(),
+            l.encode(cfg_v1()).unwrap()
+        );
+    }
+}


### PR DESCRIPTION
The float encoder can now emit a dictionary, chosen only when the column actually gets smaller once both layouts are costed in full with their headers. Off by default behind `with_float_codecs`, which is gated on `unstable-v2`.
