### PR TITLE
feat(rust): encode and decode v2 float columns as ALP

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
       - id: mixed-line-ending
         args: [ --fix=lf ]
       - id: trailing-whitespace
+        exclude: '\.snap$' # insta snapshots assert trailing whitespace
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v23.1.0

--- a/rust/mlt-core/src/codecs/alp.rs
+++ b/rust/mlt-core/src/codecs/alp.rs
@@ -1,0 +1,110 @@
+//! Exception-free Adaptive Lossless floating-Point compression (ALP), storing `v` as the integer `i = round(v * 10^e / 10^f)`.
+
+use crate::codecs::float::FloatValue;
+use crate::decoder::Alp;
+
+/// Powers of ten that are exactly representable, indexed by exponent.
+/// Stopping at `10^18` keeps `v * 10^e` inside the `i64` range.
+const POW10: [f64; 19] = [
+    1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11, 1e12, 1e13, 1e14, 1e15, 1e16,
+    1e17, 1e18,
+];
+
+/// Encode one value, or [`None`] if it does not fit the integer range.
+fn encode_one<T: FloatValue>(value: T, params: Alp) -> Option<i64> {
+    let scaled = value.widen() * POW10[usize::from(params.e)] / POW10[usize::from(params.f)];
+    let rounded = scaled.round_ties_even();
+    // The bound below is `i64::MAX` as an f64, past which the cast would saturate.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "the bound above keeps the value inside the i64 range"
+    )]
+    let code = rounded as i64;
+    (rounded.is_finite() && rounded.abs() < 9.223_372_036_854_776e18).then_some(code)
+}
+
+/// Recover one value.
+#[must_use]
+pub fn decode_one<T: FloatValue>(code: i64, params: Alp) -> T {
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "exactness is verified on encode"
+    )]
+    let value = code as f64 * POW10[usize::from(params.f)] / POW10[usize::from(params.e)];
+    T::narrow(value)
+}
+
+/// Encode `values` with `params`, or [`None`] if any value would not return bit-for-bit.
+pub fn encode_exact<T: FloatValue>(values: &[T], params: Alp, out: &mut Vec<i64>) -> Option<()> {
+    out.clear();
+    out.reserve(values.len());
+    for &value in values {
+        let code = encode_one(value, params)?;
+        if !decode_one::<T>(code, params).same_bits(value) {
+            return None;
+        }
+        out.push(code);
+    }
+    Some(())
+}
+
+/// Decode a whole stream.
+#[must_use]
+pub fn decode<T: FloatValue>(codes: &[i64], params: Alp) -> Vec<T> {
+    codes.iter().map(|&c| decode_one(c, params)).collect()
+}
+
+/// Every `(e, f)` worth trying for `T`, in the order the search should walk them.
+/// `f` never exceeds `e`, since it only divides out trailing zeros that `e` introduced.
+pub fn candidates<T: FloatValue>() -> impl Iterator<Item = Alp> {
+    (0..=T::MAX_EXPONENT).flat_map(|e| (0..=e).map(move |f| Alp { e, f }))
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    fn best<T: FloatValue>(values: &[T]) -> Option<(Alp, Vec<i64>)> {
+        let mut out = Vec::new();
+        candidates::<T>().find_map(|params| {
+            encode_exact(values, params, &mut out).map(|()| (params, out.clone()))
+        })
+    }
+
+    #[rstest]
+    #[case::one_decimal(&[1.5, 2.5, -3.5])]
+    #[case::two_decimals(&[1.25, 100.75, -0.25])]
+    #[case::whole_numbers(&[1.0, 2.0, 1e15])]
+    #[case::coordinates(&[13.404_954, 52.520_008, -74.006])]
+    fn exception_free_parameters_round_trip_bit_for_bit(#[case] values: &[f64]) {
+        let (params, codes) = best(values).expect("some parameters fit");
+        let decoded: Vec<f64> = decode(&codes, params);
+        let bits: Vec<u64> = decoded.iter().map(|v| v.to_bits()).collect();
+        let expected: Vec<u64> = values.iter().map(|v| v.to_bits()).collect();
+        assert_eq!(bits, expected);
+    }
+
+    #[rstest]
+    #[case::nan(&[1.5, f64::NAN])]
+    #[case::infinity(&[1.5, f64::INFINITY])]
+    #[case::neg_infinity(&[1.5, f64::NEG_INFINITY])]
+    #[case::negative_zero(&[1.5, -0.0])]
+    #[case::too_many_digits(&[f64::MIN_POSITIVE])]
+    fn values_that_cannot_return_bit_for_bit_have_no_parameters(#[case] values: &[f64]) {
+        assert!(best(values).is_none(), "{values:?}");
+    }
+
+    #[test]
+    fn f32_values_round_trip_through_the_widened_arithmetic() {
+        let values: &[f32] = &[1.5, -2.25, 100.0, 0.125];
+        let (params, codes) = best(values).expect("some parameters fit");
+        assert_eq!(decode::<f32>(&codes, params), values);
+    }
+
+    #[test]
+    fn every_candidate_keeps_f_no_greater_than_e() {
+        assert!(candidates::<f64>().all(|p| p.f <= p.e && p.e <= f64::MAX_EXPONENT));
+    }
+}

--- a/rust/mlt-core/src/codecs/float.rs
+++ b/rust/mlt-core/src/codecs/float.rs
@@ -1,0 +1,72 @@
+//! What the encoder needs to know about a float type.
+
+/// A float the encoders understand, identified by its bit pattern rather than its value.
+/// `-0.0` must stay a distinct dictionary entry from `0.0`, and a NaN is equal to no float at all, itself included.
+#[cfg_attr(
+    not(feature = "unstable-v2"),
+    allow(dead_code, reason = "only the tag 0x02 float encodings use these")
+)]
+pub trait FloatValue: Copy {
+    /// Dictionary key type: this float's bits.
+    type Bits: Copy + Eq + std::hash::Hash;
+
+    /// Largest power of ten worth scaling by, past which the type has no more digits to recover.
+    const MAX_EXPONENT: u8;
+
+    fn key(self) -> Self::Bits;
+
+    /// Widen to `f64`, so scaling arithmetic happens at full precision.
+    fn widen(self) -> f64;
+
+    fn narrow(value: f64) -> Self;
+
+    fn same_bits(self, other: Self) -> bool;
+}
+
+impl FloatValue for f32 {
+    type Bits = u32;
+
+    const MAX_EXPONENT: u8 = 10;
+
+    fn key(self) -> u32 {
+        self.to_bits()
+    }
+
+    fn widen(self) -> f64 {
+        f64::from(self)
+    }
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "narrowing is the point; the caller verifies the value returns bit-for-bit"
+    )]
+    fn narrow(value: f64) -> Self {
+        value as Self
+    }
+
+    fn same_bits(self, other: Self) -> bool {
+        self.to_bits() == other.to_bits()
+    }
+}
+
+impl FloatValue for f64 {
+    type Bits = u64;
+
+    const MAX_EXPONENT: u8 = 18;
+
+    fn key(self) -> u64 {
+        self.to_bits()
+    }
+
+    fn widen(self) -> Self {
+        self
+    }
+
+    fn narrow(value: f64) -> Self {
+        value
+    }
+
+    fn same_bits(self, other: Self) -> bool {
+        self.to_bits() == other.to_bits()
+    }
+}

--- a/rust/mlt-core/src/codecs/mod.rs
+++ b/rust/mlt-core/src/codecs/mod.rs
@@ -1,5 +1,8 @@
+#[cfg(feature = "unstable-v2")]
+pub mod alp;
 pub mod bytes;
 pub mod fastpfor;
+pub mod float;
 pub mod fsst;
 pub mod hilbert;
 pub mod morton;

--- a/rust/mlt-core/src/decoder/analyze.rs
+++ b/rust/mlt-core/src/decoder/analyze.rs
@@ -148,6 +148,8 @@ impl Analyze for RawFloatsEncoding<'_> {
                 codes.for_each_stream(cb);
                 dictionary.for_each_stream(cb);
             }
+            #[cfg(feature = "unstable-v2")]
+            Self::Alp { data, .. } => data.for_each_stream(cb),
         }
     }
 }

--- a/rust/mlt-core/src/decoder/mod.rs
+++ b/rust/mlt-core/src/decoder/mod.rs
@@ -45,6 +45,8 @@ pub(crate) use property::{
     RawScalar, RawSharedDict, RawSharedDictEncoding, RawSharedDictItem, RawStrings,
     RawStringsEncoding,
 };
+#[cfg(feature = "unstable-v2")]
+pub(crate) use stream::model::Alp;
 pub(crate) use stream::model::{
     BoolLogical, DictionaryType, FloatLogical, IntEncoding, IntLogical, LengthType,
     LogicalCombination, LogicalEncoding, LogicalTechnique, LogicalValue, Morton, OffsetType,

--- a/rust/mlt-core/src/decoder/property/decode.rs
+++ b/rust/mlt-core/src/decoder/property/decode.rs
@@ -35,11 +35,17 @@ impl<'a> RawFloats<'a> {
     /// Decode the column, reading whichever stream set its encoding uses.
     fn decode<T>(self, dec: &mut Decoder) -> MltResult<ParsedScalar<'a, T>>
     where
-        T: Copy + PartialEq + num_traits::FromBytes,
+        T: Copy + PartialEq + num_traits::FromBytes + crate::codecs::float::FloatValue,
         for<'b> <T as num_traits::FromBytes>::Bytes: TryFrom<&'b [u8]>,
     {
         let values = match self.encoding {
             RawFloatsEncoding::Single(data) => data.decode_floats::<T>(dec)?,
+            #[cfg(feature = "unstable-v2")]
+            RawFloatsEncoding::Alp { params, data } => {
+                let codes = data.decode_ints::<i64>(dec)?;
+                dec.consume_items::<T>(codes.len())?;
+                crate::codecs::alp::decode::<T>(&codes, params)
+            }
             #[cfg(feature = "unstable-v2")]
             RawFloatsEncoding::Dictionary { codes, dictionary } => {
                 let dictionary = dictionary.decode_floats::<T>(dec)?;
@@ -126,14 +132,14 @@ mod tests {
 
     use super::*;
     use crate::decoder::{
-        DictionaryType, FloatLogical, IntEncoding, LogicalEncoding, PhysicalEncoding, RawStream,
+        DictionaryType, IntEncoding, IntLogical, LogicalEncoding, PhysicalEncoding, RawStream,
         StreamMeta, StreamType, ValueKind,
     };
     use crate::test_helpers::dec;
 
     fn codes(values: &[u32]) -> RawStream<'_> {
         let encoding = IntEncoding::new(
-            LogicalEncoding::Float(FloatLogical::Dict),
+            LogicalEncoding::Int(IntLogical::None),
             PhysicalEncoding::None,
         );
         let num = u32::try_from(values.len()).unwrap();

--- a/rust/mlt-core/src/decoder/property/model.rs
+++ b/rust/mlt-core/src/decoder/property/model.rs
@@ -7,6 +7,8 @@ use bitvec::order::Lsb0;
 use bitvec::slice::BitSlice;
 use enum_dispatch::enum_dispatch;
 
+#[cfg(feature = "unstable-v2")]
+use crate::decoder::Alp;
 use crate::decoder::RawStream;
 use crate::utils::Presence;
 use crate::{DecodeState, Lazy};
@@ -69,6 +71,11 @@ pub enum RawFloatsEncoding<'a> {
         codes: RawStream<'a>,
         dictionary: RawStream<'a>,
     },
+    /// Integers scaled by a power of ten, in one stream, with the parameters in its header.
+    ///
+    /// Requires the `unstable-v2` feature.
+    #[cfg(feature = "unstable-v2")]
+    Alp { params: Alp, data: RawStream<'a> },
 }
 
 /// Raw string column as read directly from the tile.

--- a/rust/mlt-core/src/decoder/root02.rs
+++ b/rust/mlt-core/src/decoder/root02.rs
@@ -171,15 +171,25 @@ fn parse_floats<'a>(
     data: RawStream<'a>,
     parser: &mut Parser,
 ) -> MltRefResult<'a, RawFloats<'a>> {
-    if data.meta.encoding.logical != LogicalEncoding::Float(FloatLogical::Dict) {
-        return Ok((input, RawFloats::single(name, presence, data)));
-    }
-    // The dictionary's count is explicit in its header, so this fallback is never used.
-    let ctx = StreamCtx02::PropertyDictionary(typ);
-    let (input, dictionary) = header02::parse_stream(input, ctx, data.meta.num_values, parser)?;
-    let encoding = RawFloatsEncoding::Dictionary {
-        codes: data,
-        dictionary,
+    let (input, encoding) = match data.meta.encoding.logical {
+        LogicalEncoding::Float(FloatLogical::Alp(params)) => {
+            (input, RawFloatsEncoding::Alp { params, data })
+        }
+        LogicalEncoding::Float(FloatLogical::Dict) => {
+            // The dictionary's count is explicit in its header, so this fallback is never used.
+            let ctx = StreamCtx02::PropertyDictionary(typ);
+            let (input, dictionary) =
+                header02::parse_stream(input, ctx, data.meta.num_values, parser)?;
+            let encoding = RawFloatsEncoding::Dictionary {
+                codes: data,
+                dictionary,
+            };
+            (input, encoding)
+        }
+        LogicalEncoding::Float(FloatLogical::None)
+        | LogicalEncoding::Int(_)
+        | LogicalEncoding::Bool(_)
+        | LogicalEncoding::Vertex(_) => (input, RawFloatsEncoding::Single(data)),
     };
     Ok((
         input,
@@ -274,9 +284,9 @@ fn parse_geometry<'a>(
     for (present, length_type) in lengths {
         if present {
             let ctx = StreamCtx02::GeomOffsets(length_type);
-            let stream;
-            (input, stream) = header02::parse_stream(input, ctx, feature_count, parser)?;
-            items.push(stream);
+            let parsed;
+            (input, parsed) = header02::parse_stream(input, ctx, feature_count, parser)?;
+            items.push(parsed);
         }
     }
 

--- a/rust/mlt-core/src/decoder/stream/decode.rs
+++ b/rust/mlt-core/src/decoder/stream/decode.rs
@@ -115,7 +115,7 @@ impl<'a> RawStream<'a> {
     {
         match self.meta.encoding.logical {
             LogicalEncoding::Float(FloatLogical::None) => {}
-            LogicalEncoding::Float(FloatLogical::Dict)
+            LogicalEncoding::Float(FloatLogical::Dict | FloatLogical::Alp(_))
             | LogicalEncoding::Int(_)
             | LogicalEncoding::Bool(_)
             | LogicalEncoding::Vertex(_) => {

--- a/rust/mlt-core/src/decoder/stream/header01.rs
+++ b/rust/mlt-core/src/decoder/stream/header01.rs
@@ -254,10 +254,10 @@ pub(crate) fn write_stream_meta<W: io::Write>(
         LE::Vertex(VL::Morton(_)) => LC::Morton,
         LE::Vertex(VL::MortonDelta(_)) => LC::MortonDelta,
         LE::Vertex(VL::MortonRle(_)) => LC::MortonRle,
-        LE::Float(FL::Dict) => {
+        LE::Float(FL::Dict | FL::Alp(_)) => {
             return Err(UnsupportedLogicalEncoding(
                 meta.encoding.logical,
-                "v1, whose dictionaries are named by the stream type",
+                "v1, whose float columns are stored raw",
             ));
         }
     };
@@ -420,14 +420,34 @@ mod tests {
         StreamMeta::new(stream_type, IntEncoding::new(logical, physical), num)
     }
 
-    fn int(physical: PhysicalEncoding, logical: IntLogical) -> StreamMeta {
-        meta(DATA, LogicalEncoding::Int(logical), physical, 5)
-    }
-
     #[rstest]
-    #[case::none_varint(int(PhysicalEncoding::VarInt, IntLogical::None), 0x02)]
-    #[case::none_raw(int(PhysicalEncoding::None, IntLogical::None), 0x00)]
-    #[case::delta(int(PhysicalEncoding::VarInt, IntLogical::Delta), 0x22)]
+    #[case::none_varint(
+        meta(
+            DATA,
+            LogicalEncoding::Int(IntLogical::None),
+            PhysicalEncoding::VarInt,
+            5
+        ),
+        0x02
+    )]
+    #[case::none_raw(
+        meta(
+            DATA,
+            LogicalEncoding::Int(IntLogical::None),
+            PhysicalEncoding::None,
+            5
+        ),
+        0x00
+    )]
+    #[case::delta(
+        meta(
+            DATA,
+            LogicalEncoding::Int(IntLogical::Delta),
+            PhysicalEncoding::VarInt,
+            5
+        ),
+        0x22
+    )]
     #[case::cw_delta(
         meta(
             VERTEX,
@@ -444,9 +464,24 @@ mod tests {
     }
 
     #[rstest]
-    #[case::none_varint(int(PhysicalEncoding::VarInt, IntLogical::None))]
-    #[case::none_raw(int(PhysicalEncoding::None, IntLogical::None))]
-    #[case::delta(int(PhysicalEncoding::VarInt, IntLogical::Delta))]
+    #[case::none_varint(meta(
+        DATA,
+        LogicalEncoding::Int(IntLogical::None),
+        PhysicalEncoding::VarInt,
+        5
+    ))]
+    #[case::none_raw(meta(
+        DATA,
+        LogicalEncoding::Int(IntLogical::None),
+        PhysicalEncoding::None,
+        5
+    ))]
+    #[case::delta(meta(
+        DATA,
+        LogicalEncoding::Int(IntLogical::Delta),
+        PhysicalEncoding::VarInt,
+        5
+    ))]
     #[case::cw_delta(meta(
         VERTEX,
         LogicalEncoding::Vertex(VertexLogical::ComponentwiseDelta),

--- a/rust/mlt-core/src/decoder/stream/header02.rs
+++ b/rust/mlt-core/src/decoder/stream/header02.rs
@@ -34,8 +34,9 @@ use num_enum::TryFromPrimitive;
 
 use crate::codecs::varint::parse_varint;
 use crate::decoder::{
-    BoolLogical, DataType02, DictionaryType, FloatLogical, IntEncoding, IntLogical, LengthType,
-    LogicalEncoding, PhysicalEncoding, RawStream, RleMeta, StreamMeta, StreamType, VertexLogical,
+    Alp, BoolLogical, DataType02, DictionaryType, FloatLogical, IntEncoding, IntLogical,
+    LengthType, LogicalEncoding, PhysicalEncoding, RawStream, RleMeta, StreamMeta, StreamType,
+    VertexLogical,
 };
 use crate::utils::{BinarySerializer as _, parse_u8, take};
 use crate::{MltError, MltRefResult, MltResult, Parser};
@@ -187,6 +188,9 @@ pub(crate) enum LogicalInt {
 pub(crate) enum LogicalBool {
     /// A raw packed bitmap, one bit per value.
     None(PhysicalBits),
+    /// Numbered so the family matches the format, but not yet readable.
+    // TODO(v2): decide what RLE over a bool column means - v1's is a byte-RLE compressed
+    //           bitmap, while every other v2 RLE is varint `(run, value)` pairs.
     Rle,
 }
 
@@ -197,7 +201,9 @@ pub(crate) enum LogicalFloat {
     None(PhysicalBits),
     Rle,
     /// Adaptive lossless floating-point compression.
-    Alp,
+    /// The physical field codes the scaled integers, not the column's element layout.
+    // TODO(v2): extension bit 1 = an exception count varint and exception stream follow.
+    Alp(PhysicalInt),
     /// One code per element, then the dictionary of distinct values as a second stream.
     /// The physical field codes the codes, not the values.
     Dict(PhysicalInt),
@@ -294,10 +300,7 @@ impl Encoding02 {
                     no_physical(enc_byte)?;
                     LogicalFloat::Rle
                 }
-                Logical::Alp => {
-                    no_physical(enc_byte)?;
-                    LogicalFloat::Alp
-                }
+                Logical::Alp => LogicalFloat::Alp(physical_int(enc_byte)?),
                 Logical::Dict => LogicalFloat::Dict(physical_int(enc_byte)?),
                 Logical::Delta | Logical::CwDelta | Logical::DeltaRle | Logical::Morton => {
                     unreachable_member(family, logical)?
@@ -334,7 +337,7 @@ impl Encoding02 {
             | Self::Float(LogicalFloat::Rle) => Logical::Rle,
             Self::Int(LogicalInt::DeltaRle) => Logical::DeltaRle,
             Self::Vertex(LogicalVertex::Morton) => Logical::Morton,
-            Self::Float(LogicalFloat::Alp) => Logical::Alp,
+            Self::Float(LogicalFloat::Alp(_)) => Logical::Alp,
             Self::Float(LogicalFloat::Dict(_)) => Logical::Dict,
         }
     }
@@ -343,25 +346,28 @@ impl Encoding02 {
     fn physical_label(self) -> &'static str {
         match self {
             Self::Int(LogicalInt::None(p) | LogicalInt::Delta(p))
-            | Self::Float(LogicalFloat::Dict(p))
+            | Self::Float(LogicalFloat::Dict(p) | LogicalFloat::Alp(p))
             | Self::Vertex(
                 LogicalVertex::None(p) | LogicalVertex::Delta(p) | LogicalVertex::CwDelta(p),
             ) => p.into(),
             Self::Bool(LogicalBool::None(p)) | Self::Float(LogicalFloat::None(p)) => p.into(),
             Self::Int(LogicalInt::Rle | LogicalInt::DeltaRle)
             | Self::Bool(LogicalBool::Rle)
-            | Self::Float(LogicalFloat::Rle | LogicalFloat::Alp)
+            | Self::Float(LogicalFloat::Rle)
             | Self::Vertex(LogicalVertex::Morton) => "implied",
         }
     }
 
-    /// Map down to the flat encoding the rest of the decoder shares with v1.
+    /// Map to the shared model, reading any parameter varints the encoding carries.
+    ///
     /// `num_values` is the expanded element count, which the RLE members need.
-    fn to_model(self, num_values: u32) -> MltResult<IntEncoding> {
+    /// Parameters follow the byte length, as v1 writes Morton's and RLE's.
+    fn to_model(self, input: &[u8], num_values: u32) -> MltRefResult<'_, IntEncoding> {
         let rle = || RleMeta::Interleaved {
             num_rle_values: num_values,
         };
-        Ok(match self {
+        let mut rest = input;
+        let encoding = match self {
             Self::Int(LogicalInt::None(p)) => {
                 IntEncoding::new(LogicalEncoding::Int(IntLogical::None), flat_int(p)?)
             }
@@ -398,8 +404,14 @@ impl Encoding02 {
             Self::Float(LogicalFloat::Rle) => {
                 return Err(MltError::NotImplemented("v2 RLE over a float column"));
             }
-            Self::Float(LogicalFloat::Alp) => {
-                return Err(MltError::NotImplemented("v2 ALP float streams"));
+            Self::Float(LogicalFloat::Alp(p)) => {
+                let (after, e) = parse_varint::<u8>(input)?;
+                let (after, f) = parse_varint::<u8>(after)?;
+                rest = after;
+                IntEncoding::new(
+                    LogicalEncoding::Float(FloatLogical::Alp(Alp::new(e, f)?)),
+                    flat_int(p)?,
+                )
             }
             Self::Float(LogicalFloat::Dict(p)) => {
                 IntEncoding::new(LogicalEncoding::Float(FloatLogical::Dict), flat_int(p)?)
@@ -407,7 +419,8 @@ impl Encoding02 {
             Self::Vertex(LogicalVertex::Morton) => {
                 return Err(MltError::NotImplemented("v2 Morton streams"));
             }
-        })
+        };
+        Ok((rest, encoding))
     }
 }
 
@@ -459,29 +472,21 @@ fn wire_fields(encoding: IntEncoding, family: Family) -> MltResult<(Logical, u8)
     use VertexLogical as VL;
 
     let physical = |encoding: IntEncoding| -> MltResult<u8> {
-        Ok(match (family, encoding.physical) {
-            (Family::Bool | Family::Float, PhysicalEncoding::None) => PhysicalBits::WithLen as u8,
-            (Family::Bool | Family::Float, _) => {
-                return Err(MltError::UnsupportedPhysicalEncoding(
-                    "v2 bool and float streams store fixed-width elements",
-                ));
+        match (family, encoding.physical) {
+            (Family::Bool | Family::Float, PhysicalEncoding::None) => {
+                Ok(PhysicalBits::WithLen as u8)
             }
-            (_, PhysicalEncoding::None) => PhysicalInt::NoneWithLen as u8,
-            (_, PhysicalEncoding::VarInt) => PhysicalInt::VarInt as u8,
-            (_, PhysicalEncoding::FastPFor256) => {
-                return Err(MltError::NotImplemented(
-                    "v2 FastPFor: requires the FastPFor128-LE codec",
-                ));
-            }
-        })
+            (Family::Bool | Family::Float, _) => Err(MltError::UnsupportedPhysicalEncoding(
+                "v2 bool and float streams store fixed-width elements",
+            )),
+            _ => physical_int_field(encoding.physical),
+        }
     };
 
     Ok(match encoding.logical {
         LE::Int(IL::None) | LE::Bool(BL::None) | LE::Float(FL::None) | LE::Vertex(VL::None) => {
             (Logical::None, physical(encoding)?)
         }
-        // Codes are an integer stream, whatever the column's type is.
-        LE::Float(FL::Dict) => (Logical::Dict, physical_int_field(encoding.physical)?),
         LE::Int(IL::Delta) | LE::Vertex(VL::Delta) => (Logical::Delta, physical(encoding)?),
         LE::Vertex(VL::ComponentwiseDelta) => (Logical::CwDelta, physical(encoding)?),
         LE::Int(IL::Rle(rle) | IL::DeltaRle(rle)) => {
@@ -504,6 +509,9 @@ fn wire_fields(encoding: IntEncoding, family: Family) -> MltResult<(Logical, u8)
             // The physical encoding is implied, so the field stays zero.
             (logical, 0)
         }
+        // Codes and scaled integers are integer streams, whatever the column's type is.
+        LE::Float(FL::Dict) => (Logical::Dict, physical_int_field(encoding.physical)?),
+        LE::Float(FL::Alp(_)) => (Logical::Alp, physical_int_field(encoding.physical)?),
         LE::Bool(BL::ByteRle(_)) => {
             return Err(MltError::UnsupportedLogicalEncoding(
                 encoding.logical,
@@ -543,8 +551,8 @@ pub(crate) fn parse_stream<'a>(
     // Reserve decoded memory upper bound: worst case u64 = 8 bytes per value.
     parser.reserve(num_values.saturating_mul(8))?;
 
-    let encoding = encoding.to_model(num_values)?;
     let (input, byte_length) = parse_varint::<u32>(input)?;
+    let (input, encoding) = encoding.to_model(input, num_values)?;
     let (input, data) = take(input, byte_length)?;
     let meta = StreamMeta::new(ctx.stream_type(), encoding, num_values);
     Ok((input, RawStream::new(meta, data)))
@@ -592,6 +600,10 @@ pub(crate) fn write_stream_meta<W: io::Write>(
         writer.write_varint(num_values)?;
     }
     writer.write_varint(byte_length)?;
+    if let LE::Float(FloatLogical::Alp(alp)) = meta.encoding.logical {
+        writer.write_varint(alp.e)?;
+        writer.write_varint(alp.f)?;
+    }
     Ok(())
 }
 
@@ -760,6 +772,12 @@ mod tests {
         Family::Float,
         0b0011_1000
     )]
+    #[case::float_alp_integers(
+        float(FloatLogical::Alp(Alp::new(3, 1).unwrap()), PE::VarInt, 5),
+        5,
+        Family::Float,
+        0b0010_1000
+    )]
     #[case::cw_delta_vertices_explicit(
         vertex(VertexLogical::ComponentwiseDelta, PE::VarInt, 8),
         5,
@@ -788,6 +806,16 @@ mod tests {
     #[case::raw_bool(boolean(BoolLogical::None, PE::None, 5), 5, BOOL)]
     #[case::float_dict_codes_varint(float(FloatLogical::Dict, PE::VarInt, 5), 5, FLOAT)]
     #[case::float_dict_codes_raw(float(FloatLogical::Dict, PE::None, 5), 5, FLOAT)]
+    #[case::float_alp(
+        float(FloatLogical::Alp(Alp::new(6, 2).unwrap()), PE::VarInt, 5),
+        5,
+        FLOAT
+    )]
+    #[case::float_alp_explicit_count(
+        float(FloatLogical::Alp(Alp::new(0, 0).unwrap()), PE::VarInt, 7),
+        5,
+        FLOAT
+    )]
     #[case::cw_delta_vertices(vertex(VertexLogical::ComponentwiseDelta, PE::VarInt, 10), 5, VERTEX)]
     fn header_roundtrip(
         #[case] meta: StreamMeta,
@@ -800,12 +828,12 @@ mod tests {
         write_stream_meta(&meta, &mut buf, byte_length, implicit_count, ctx.family()).unwrap();
         buf.extend_from_slice(&payload);
 
-        let (rest, stream) = parse_stream(&buf, ctx, implicit_count, &mut parser()).unwrap();
+        let (rest, parsed) = parse_stream(&buf, ctx, implicit_count, &mut parser()).unwrap();
         assert!(rest.is_empty());
-        assert_eq!(stream.meta.encoding, meta.encoding);
-        assert_eq!(stream.meta.num_values, meta.num_values);
-        assert_eq!(stream.meta.stream_type, ctx.stream_type());
-        assert_eq!(stream.data, payload);
+        assert_eq!(parsed.meta.encoding, meta.encoding);
+        assert_eq!(parsed.meta.num_values, meta.num_values);
+        assert_eq!(parsed.meta.stream_type, ctx.stream_type());
+        assert_eq!(parsed.data, payload);
     }
 
     #[rstest]
@@ -819,6 +847,7 @@ mod tests {
     #[case::int_logical_past_table(INT, 0b0100_1000)]
     #[case::bool_logical_past_table(BOOL, 0b0010_0100)]
     #[case::float_dict_with_extension(FLOAT, 0b0011_0101)]
+    #[case::float_alp_with_extension(FLOAT, 0b0010_1001)]
     #[case::vertex_logical_past_table(VERTEX, 0b0100_1000)]
     #[case::float_physical_varint(FLOAT, 0b0000_1000)]
     #[case::float_physical_fastpfor(FLOAT, 0b0000_1100)]
@@ -842,30 +871,27 @@ mod tests {
     #[case::bool_rle(BOOL, 0b0001_0000)]
     #[case::vertex_morton(VERTEX, 0b0011_0000)]
     fn parse_rejects_unimplemented_encoding(#[case] ctx: StreamCtx02, #[case] enc_byte: u8) {
-        let buf = [enc_byte, 0];
+        let buf = [enc_byte, 0, 0, 0];
         let err = parse_stream(&buf, ctx, 0, &mut parser()).unwrap_err();
         assert!(matches!(err, MltError::NotImplemented(_)), "{err:?}");
     }
 
     #[rstest]
-    #[case::delta(0b0001_1000, LogicalEncoding::Int(IntLogical::Delta), "encoding byte")]
-    #[case::rle(0b0010_0000, LogicalEncoding::Int(IntLogical::Rle(rle(1))), "ALP")]
-    #[case::delta_rle(
-        0b0011_0000,
-        LogicalEncoding::Int(IntLogical::DeltaRle(rle(1))),
-        "None-noLen"
-    )]
+    #[case::delta(0b0001_1000, LogicalEncoding::Int(IntLogical::Delta))]
+    #[case::rle(0b0010_0000, LogicalEncoding::Int(IntLogical::Rle(rle(1))))]
+    #[case::delta_rle(0b0011_0000, LogicalEncoding::Int(IntLogical::DeltaRle(rle(1))))]
     fn an_int_bit_pattern_never_means_the_same_on_a_float_column(
         #[case] enc_byte: u8,
         #[case] as_int: LogicalEncoding,
-        #[case] float_error: &str,
     ) {
-        let buf = [enc_byte, 0];
-        let (_, stream) = parse_stream(&buf, INT, 1, &mut parser()).unwrap();
-        assert_eq!(stream.meta.encoding.logical, as_int);
+        let buf = [enc_byte, 0, 0, 0];
+        let (_, parsed) = parse_stream(&buf, INT, 1, &mut parser()).unwrap();
+        assert_eq!(parsed.meta.encoding.logical, as_int);
 
-        let err = parse_stream(&buf, FLOAT, 1, &mut parser()).unwrap_err();
-        assert!(err.to_string().contains(float_error), "{err}");
+        let as_float = parse_stream(&buf, FLOAT, 1, &mut parser())
+            .ok()
+            .map(|(_, p)| p.meta.encoding.logical);
+        assert_ne!(as_float, Some(as_int));
     }
 
     #[test]
@@ -884,16 +910,16 @@ mod tests {
     #[case::rle(true)]
     #[case::delta_rle(false)]
     fn write_rejects_split_rle(#[case] plain_rle: bool) {
-        let rle = RleMeta::Split {
+        let split = RleMeta::Split {
             runs: 2,
             num_rle_values: 5,
         };
         let logical = if plain_rle {
-            LogicalEncoding::Int(IntLogical::Rle(rle))
+            IntLogical::Rle(split)
         } else {
-            LogicalEncoding::Int(IntLogical::DeltaRle(rle))
+            IntLogical::DeltaRle(split)
         };
-        let meta = meta(logical, PhysicalEncoding::VarInt, 5);
+        let meta = int(logical, PE::VarInt, 5);
         let mut buf = Vec::new();
         let err = write_stream_meta(&meta, &mut buf, 0, 5, Family::Int).unwrap_err();
         assert!(matches!(err, MltError::UnsupportedLogicalEncoding(_, _)));
@@ -917,11 +943,19 @@ mod tests {
     )]
     #[case::dict_on_an_int_column(LogicalEncoding::Float(FloatLogical::Dict), Family::Int)]
     #[case::dict_on_a_vertex_stream(LogicalEncoding::Float(FloatLogical::Dict), Family::Vertex)]
-    fn write_rejects_a_logical_the_family_does_not_list(
+    #[case::alp_on_an_int_column(
+        LogicalEncoding::Float(FloatLogical::Alp(Alp::new(1, 0).unwrap())),
+        Family::Int
+    )]
+    #[case::alp_on_a_bool_column(
+        LogicalEncoding::Float(FloatLogical::Alp(Alp::new(1, 0).unwrap())),
+        Family::Bool
+    )]
+    fn write_rejects_an_encoding_the_family_does_not_list(
         #[case] logical: LogicalEncoding,
         #[case] family: Family,
     ) {
-        let meta = meta(logical, PhysicalEncoding::None, 5);
+        let meta = meta(logical, PE::None, 5);
         let mut buf = Vec::new();
         let err = write_stream_meta(&meta, &mut buf, 0, 5, family).unwrap_err();
         assert!(

--- a/rust/mlt-core/src/decoder/stream/logical.rs
+++ b/rust/mlt-core/src/decoder/stream/logical.rs
@@ -7,7 +7,8 @@ use usize_cast::IntoUsize as _;
 use crate::MltError::{ParsingLogicalTechnique, RleRunLenInvalid, UnsupportedLogicalEncoding};
 use crate::codecs::zigzag::{decode_componentwise_delta_vec2s, decode_zigzag, decode_zigzag_delta};
 use crate::decoder::{
-    IntLogical, LogicalEncoding, LogicalTechnique, LogicalValue, RleMeta, StreamMeta, VertexLogical,
+    FloatLogical, IntLogical, LogicalEncoding, LogicalTechnique, LogicalValue, RleMeta, StreamMeta,
+    VertexLogical,
 };
 use crate::errors::{AsMltError as _, fail_if_invalid_stream_size};
 use crate::{Decoder, MltResult};
@@ -128,7 +129,9 @@ impl LogicalValue {
         use VertexLogical as VL;
 
         match self.meta.encoding.logical {
-            LE::Int(IL::None) | LE::Vertex(VL::None) => decode_zigzag(data, dec),
+            LE::Int(IL::None) | LE::Vertex(VL::None) | LE::Float(FloatLogical::Alp(_)) => {
+                decode_zigzag(data, dec)
+            }
             LE::Int(IL::Rle(v)) => decode_zigzag(&v.decode(data, dec)?, dec),
             LE::Vertex(VL::ComponentwiseDelta) => decode_componentwise_delta_vec2s(data, dec),
             LE::Int(IL::Delta) | LE::Vertex(VL::Delta) => decode_zigzag_delta::<i32, _>(data, dec),
@@ -156,7 +159,7 @@ impl LogicalValue {
     pub fn decode_u32(self, data: &[u32], dec: &mut Decoder) -> MltResult<Vec<u32>> {
         let num = self.meta.num_values.into_usize();
         match self.meta.encoding.logical {
-            LogicalEncoding::Int(IntLogical::None) => {
+            LogicalEncoding::Int(IntLogical::None) | LogicalEncoding::Float(FloatLogical::Dict) => {
                 // Caller should have used the direct-output path; this is a fallback.
                 dec.consume_items::<u32>(num)?;
                 Ok(data.to_vec())
@@ -181,7 +184,8 @@ impl LogicalValue {
     /// in the bridge (physical buffer decoded into a fresh output Vec).
     pub fn decode_i64(self, data: &[u64], dec: &mut Decoder) -> MltResult<Vec<i64>> {
         match self.meta.encoding.logical {
-            LogicalEncoding::Int(IntLogical::None) => decode_zigzag(data, dec),
+            LogicalEncoding::Int(IntLogical::None)
+            | LogicalEncoding::Float(FloatLogical::Alp(_)) => decode_zigzag(data, dec),
             LogicalEncoding::Int(IntLogical::Delta) => decode_zigzag_delta::<i64, _>(data, dec),
             LogicalEncoding::Int(IntLogical::DeltaRle(rle)) => {
                 let expanded = rle.decode(data, dec)?;
@@ -208,7 +212,7 @@ impl LogicalValue {
     pub fn decode_u64(self, data: &[u64], dec: &mut Decoder) -> MltResult<Vec<u64>> {
         let num = self.meta.num_values.into_usize();
         match self.meta.encoding.logical {
-            LogicalEncoding::Int(IntLogical::None) => {
+            LogicalEncoding::Int(IntLogical::None) | LogicalEncoding::Float(FloatLogical::Dict) => {
                 // Caller should have used the direct-output path; this is a fallback.
                 dec.consume_items::<u64>(num)?;
                 Ok(data.to_vec())

--- a/rust/mlt-core/src/decoder/stream/model.rs
+++ b/rust/mlt-core/src/decoder/stream/model.rs
@@ -97,6 +97,30 @@ impl Morton {
     }
 }
 
+/// ALP parameters: `v = i * 10^f / 10^e`.
+/// Written as two header varints, the stream itself holding plain integers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Alp {
+    /// Decimal exponent the values were scaled by.
+    pub(crate) e: u8,
+    /// Factor dividing out the trailing zeros `e` introduced, never exceeding `e`.
+    pub(crate) f: u8,
+}
+
+#[cfg(feature = "unstable-v2")]
+impl Alp {
+    /// Largest exponent any supported float type uses.
+    pub(crate) const MAX_EXPONENT: u8 = 18;
+
+    pub(crate) fn new(e: u8, f: u8) -> MltResult<Self> {
+        if e <= Self::MAX_EXPONENT && f <= e {
+            Ok(Self { e, f })
+        } else {
+            Err(MltError::InvalidAlpParams(e, f))
+        }
+    }
+}
+
 /// What kind of values a stream holds, which fixes the encodings it can name.
 /// Neither wire format stores it: v1 reads it from the column type, v2 from the stream's context.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -136,6 +160,9 @@ pub enum FloatLogical {
     /// One code per element, with the distinct values following as a second stream.
     /// Only the tag `0x02` codec reads or writes it.
     Dict,
+    /// Integers scaled by these parameters.
+    /// Only the tag `0x02` codec reads or writes it.
+    Alp(Alp),
 }
 
 /// Logical encoding of a geometry vertex stream, whose values are interleaved coordinate pairs.
@@ -184,14 +211,14 @@ impl LogicalEncoding {
     }
 
     /// Whether the stream's own logical pass is a no-op, so the physical words are already the output.
-    /// True for a float dictionary's codes, which the column turns back into floats.
+    /// True for a float dictionary's codes and for ALP's integers, which the column turns back into floats.
     #[must_use]
     pub(crate) fn is_identity(self) -> bool {
         matches!(
             self,
             Self::Int(IntLogical::None)
                 | Self::Bool(BoolLogical::None)
-                | Self::Float(FloatLogical::None | FloatLogical::Dict)
+                | Self::Float(FloatLogical::None | FloatLogical::Dict | FloatLogical::Alp(_))
                 | Self::Vertex(VertexLogical::None)
         )
     }

--- a/rust/mlt-core/src/dump/walker02.rs
+++ b/rust/mlt-core/src/dump/walker02.rs
@@ -267,16 +267,15 @@ impl<'a> Walker<'a> {
 
         // Re-walk the consumed header bytes to annotate each field.
         let hi = self.open(input, "header".to_string());
+        let family = ctx.family();
         let (mut c, enc_byte) = self.byte_field(
             input,
             "encoding",
             |b| {
-                format!(
-                    "0x{b:02X} logical={:?} physical={:?}",
-                    stream.meta.encoding.logical, stream.meta.encoding.physical
-                )
+                let (logical, physical) = describe_encoding(family, b);
+                format!("0x{b:02X} logical={logical} physical={physical}")
             },
-            |b| encoding_bits02(b, implicit_count, ctx.family()),
+            move |b| encoding_bits02(b, implicit_count, family),
         )?;
 
         if enc_byte & HAS_EXPLICIT_COUNT != 0 {
@@ -294,6 +293,15 @@ impl<'a> Walker<'a> {
             |i| parse_varint::<u32>(i),
             |v| Some(v.to_string()),
         )?;
+        // ALP's parameters ride in the header, after the byte length.
+        if matches!(
+            stream.meta.encoding.logical,
+            LogicalEncoding::Float(FloatLogical::Alp(_))
+        ) {
+            for name in ["alp_e", "alp_f"] {
+                (c, _) = self.field(c, name, |i| parse_varint::<u8>(i), |v| Some(v.to_string()))?;
+            }
+        }
         self.close(hi, c);
 
         let (after_payload, payload) = take(c, byte_length)?;
@@ -301,6 +309,15 @@ impl<'a> Walker<'a> {
         if self.off(after_payload) != self.off(rest) {
             return Err(MltError::NotImplemented("v2 stream header re-walk desync"));
         }
+        // A dictionary's codes and ALP's integers are integer streams, whatever the column's type is.
+        let hint = match stream.meta.encoding.logical {
+            LogicalEncoding::Float(FloatLogical::Dict) => DecodeHint::U32,
+            LogicalEncoding::Float(FloatLogical::Alp(_)) => DecodeHint::I64,
+            LogicalEncoding::Float(FloatLogical::None)
+            | LogicalEncoding::Int(_)
+            | LogicalEncoding::Bool(_)
+            | LogicalEncoding::Vertex(_) => hint,
+        };
         self.stream_blob(
             payload,
             payload.len(),

--- a/rust/mlt-core/src/encoder/fuzzing.rs
+++ b/rust/mlt-core/src/encoder/fuzzing.rs
@@ -20,7 +20,8 @@ impl Arbitrary<'_> for EncoderConfig {
         #[cfg(feature = "unstable-v2")]
         let config = config
             .with_wire_version(u.arbitrary()?)
-            .with_float_dict(u.arbitrary()?);
+            .with_float_dict(u.arbitrary()?)
+            .with_float_alp(u.arbitrary()?);
         Ok(config)
     }
 }

--- a/rust/mlt-core/src/encoder/model.rs
+++ b/rust/mlt-core/src/encoder/model.rs
@@ -230,6 +230,9 @@ pub struct EncoderConfig {
     /// Allow the v2-only float dictionary encoding
     #[cfg(feature = "unstable-v2")]
     allow_float_dict: bool,
+    /// Allow the v2-only ALP float encoding
+    #[cfg(feature = "unstable-v2")]
+    allow_float_alp: bool,
 }
 impl Default for EncoderConfig {
     fn default() -> Self {
@@ -246,6 +249,8 @@ impl Default for EncoderConfig {
             // Off by default while the encoding is still being measured.
             #[cfg(feature = "unstable-v2")]
             allow_float_dict: false,
+            #[cfg(feature = "unstable-v2")]
+            allow_float_alp: false,
         }
     }
 }
@@ -306,6 +311,13 @@ impl EncoderConfig {
         self.allow_float_dict && self.wire_version != WireVersion::V01
     }
 
+    /// Whether float columns may use ALP, which only v2 can express.
+    #[cfg(feature = "unstable-v2")]
+    #[must_use]
+    pub fn allow_float_alp(self) -> bool {
+        self.allow_float_alp && self.wire_version != WireVersion::V01
+    }
+
     #[cfg(feature = "unstable-v2")]
     #[must_use]
     pub fn with_wire_version(mut self, version: WireVersion) -> Self {
@@ -362,6 +374,14 @@ impl EncoderConfig {
     #[must_use]
     pub fn with_float_dict(mut self, enabled: bool) -> Self {
         self.allow_float_dict = enabled;
+        self
+    }
+
+    /// Allow float columns to store each value as a decimal-scaled integer.
+    #[cfg(feature = "unstable-v2")]
+    #[must_use]
+    pub fn with_float_alp(mut self, enabled: bool) -> Self {
+        self.allow_float_alp = enabled;
         self
     }
 }

--- a/rust/mlt-core/src/encoder/stream/codecs.rs
+++ b/rust/mlt-core/src/encoder/stream/codecs.rs
@@ -4,6 +4,7 @@ use bytemuck::{NoUninit, cast_slice};
 use fastpfor::FastPFor256;
 
 use crate::codecs::bytes::encode_bools_to_bytes;
+use crate::codecs::float::FloatValue;
 use crate::codecs::rle::encode_byte_rle;
 #[cfg(feature = "unstable-v2")]
 use crate::decoder::FloatLogical;
@@ -16,7 +17,8 @@ use crate::decoder::{
 use crate::encoder;
 use crate::encoder::Encoder;
 use crate::encoder::model::StreamCtx;
-use crate::encoder::stream::float_dict::FloatBits;
+#[cfg(feature = "unstable-v2")]
+use crate::encoder::stream::float_alp::AlpStream;
 #[cfg(feature = "unstable-v2")]
 use crate::encoder::stream::float_dict::FloatDict;
 use crate::encoder::stream::logical::LogicalEncoder;
@@ -101,7 +103,7 @@ impl Codecs {
             reason = "kept as a Codecs method to match the other stream writers"
         )
     )]
-    pub(crate) fn write_float_stream<T: NoUninit + FloatBits>(
+    pub(crate) fn write_float_stream<T: NoUninit + FloatValue>(
         &mut self,
         values: &[T],
         stream_type: StreamType,
@@ -111,20 +113,56 @@ impl Codecs {
         compile_error!("not implemented for non-little-endian targets");
 
         #[cfg(feature = "unstable-v2")]
-        if enc.config().allow_float_dict()
-            && let Some(dict) = FloatDict::worth_building(values)
         {
-            return self.write_float_dict_streams(values, &dict, stream_type, enc);
+            // Both candidates already beat storing the floats raw, so the smaller of the two does too.
+            let dict = if enc.config().allow_float_dict() {
+                FloatDict::worth_building(values)
+            } else {
+                None
+            };
+            let alp = if enc.config().allow_float_alp() {
+                AlpStream::worth_building(values)
+            } else {
+                None
+            };
+            let dict_bytes = dict.as_ref().map_or(usize::MAX, FloatDict::stored_bytes);
+            let alp_bytes = alp.as_ref().map_or(usize::MAX, AlpStream::stored_bytes);
+            if alp_bytes <= dict_bytes
+                && let Some(alp) = alp
+            {
+                return self.write_alp_stream(&alp, stream_type, enc);
+            }
+            if let Some(dict) = dict {
+                return self.write_float_dict_streams(values, &dict, stream_type, enc);
+            }
         }
 
         let meta = StreamMeta::new_none(stream_type, ValueKind::Float, values.len())?;
         encoder::write_stream_payload(enc, meta, false, cast_slice(values))
     }
 
+    /// Write a float column as ALP integers, its parameters in the header.
+    #[cfg(feature = "unstable-v2")]
+    fn write_alp_stream(
+        &mut self,
+        alp: &AlpStream,
+        stream_type: StreamType,
+        enc: &mut Encoder,
+    ) -> MltResult<()> {
+        let meta = StreamMeta::new2(
+            stream_type,
+            LogicalEncoding::Float(FloatLogical::Alp(alp.params)),
+            PhysicalEncoding::VarInt,
+            alp.codes.len(),
+        )?;
+        let codes = self.physical.varint(&alp.codes);
+        encoder::write_stream_payload(enc, meta, false, codes)
+    }
+
     /// Write a float column as a codes stream followed by its dictionary.
     /// Codes first, so only the dictionary needs a count in its header.
     #[cfg(feature = "unstable-v2")]
-    fn write_float_dict_streams<T: NoUninit + FloatBits>(
+    fn write_float_dict_streams<T: NoUninit + FloatValue>(
         &mut self,
         values: &[T],
         dict: &FloatDict<T>,

--- a/rust/mlt-core/src/encoder/stream/float_alp.rs
+++ b/rust/mlt-core/src/encoder/stream/float_alp.rs
@@ -1,0 +1,56 @@
+//! Choosing ALP parameters for a float column.
+
+use zigzag::ZigZag as _;
+
+use crate::codecs::alp::{candidates, encode_exact};
+use crate::codecs::float::FloatValue;
+use crate::decoder::Alp;
+use crate::encoder::stream::float_cost::{ENCODING_BYTE, data_bytes, raw_stored_bytes, varint_len};
+
+/// A float column encoded as ALP integers, with the parameters that produced it.
+pub(crate) struct AlpStream {
+    pub(crate) params: Alp,
+    /// Zigzagged, ready for the varint physical encoding.
+    pub(crate) codes: Vec<u64>,
+}
+
+impl AlpStream {
+    /// The smallest exception-free ALP encoding of `values`, or [`None`] when none exists or none beats raw.
+    pub(crate) fn worth_building<T: FloatValue>(values: &[T]) -> Option<Self> {
+        if values.is_empty() {
+            return None;
+        }
+        let mut scratch = Vec::new();
+        let mut best: Option<Alp> = None;
+        let mut best_bytes = raw_stored_bytes::<T>(values.len());
+
+        for params in candidates::<T>() {
+            if encode_exact(values, params, &mut scratch).is_none() {
+                continue;
+            }
+            let bytes = stored_bytes(scratch.iter().map(|&c| i64::encode(c)), params);
+            if bytes < best_bytes {
+                best_bytes = bytes;
+                best = Some(params);
+            }
+        }
+
+        let params = best?;
+        encode_exact(values, params, &mut scratch)
+            .expect("the winning parameters encoded every value a moment ago");
+        Some(Self {
+            params,
+            codes: scratch.into_iter().map(i64::encode).collect(),
+        })
+    }
+
+    /// Bytes this stream occupies, for the competition against a dictionary.
+    pub(crate) fn stored_bytes(&self) -> usize {
+        stored_bytes(self.codes.iter().copied(), self.params)
+    }
+}
+
+/// Bytes an ALP stream of these zigzagged integers occupies, header included.
+fn stored_bytes(codes: impl Iterator<Item = u64>, params: Alp) -> usize {
+    ENCODING_BYTE + varint_len(params.e) + varint_len(params.f) + data_bytes(codes)
+}

--- a/rust/mlt-core/src/encoder/stream/float_cost.rs
+++ b/rust/mlt-core/src/encoder/stream/float_cost.rs
@@ -1,0 +1,22 @@
+//! Stored size of a v2 float column, for choosing between its encodings.
+
+/// The encoding byte every stream header starts with.
+pub(crate) const ENCODING_BYTE: usize = 1;
+
+/// Bytes a raw column of `count` elements occupies, header included.
+pub(crate) fn raw_stored_bytes<T>(count: usize) -> usize {
+    let values = count * size_of::<T>();
+    ENCODING_BYTE + varint_len(values) + values
+}
+
+/// Bytes a varint-coded payload occupies, including its byte-length varint.
+pub(crate) fn data_bytes(values: impl Iterator<Item = u64>) -> usize {
+    let data: usize = values.map(varint_len).sum();
+    varint_len(data) + data
+}
+
+/// Encoded length of a varint, for costing a header that is not written yet.
+pub(crate) fn varint_len(value: impl TryInto<u64>) -> usize {
+    let value: u64 = value.try_into().unwrap_or(u64::MAX);
+    integer_encoding::VarInt::required_space(value)
+}

--- a/rust/mlt-core/src/encoder/stream/float_dict.rs
+++ b/rust/mlt-core/src/encoder/stream/float_dict.rs
@@ -1,35 +1,9 @@
 //! Dictionary building for float columns.
 
-/// A float whose bit pattern is its dictionary key.
-/// `-0.0` must stay a distinct entry from `0.0`, and a NaN is equal to no float at all, itself included.
-pub(crate) trait FloatBits: Copy {
-    type Bits: Copy + Eq + std::hash::Hash;
-
-    #[cfg_attr(
-        not(feature = "unstable-v2"),
-        expect(dead_code, reason = "only the v2 float dictionary keys on bits")
-    )]
-    fn key(self) -> Self::Bits;
-}
-
-impl FloatBits for f32 {
-    type Bits = u32;
-
-    fn key(self) -> u32 {
-        self.to_bits()
-    }
-}
-
-impl FloatBits for f64 {
-    type Bits = u64;
-
-    fn key(self) -> u64 {
-        self.to_bits()
-    }
-}
+use crate::codecs::float::FloatValue;
+use crate::encoder::stream::float_cost::{ENCODING_BYTE, raw_stored_bytes, varint_len};
 
 /// A float column's distinct values and one code per element.
-#[cfg(feature = "unstable-v2")]
 pub(crate) struct FloatDict<T> {
     /// Distinct values in first-appearance order, so the result does not depend on hash iteration order.
     pub(crate) values: Vec<T>,
@@ -37,8 +11,7 @@ pub(crate) struct FloatDict<T> {
     pub(crate) codes: Vec<u32>,
 }
 
-#[cfg(feature = "unstable-v2")]
-impl<T: FloatBits> FloatDict<T> {
+impl<T: FloatValue> FloatDict<T> {
     /// Build a dictionary for `values`, or [`None`] when it would not be smaller.
     /// Both layouts are costed as stored bytes, headers included, assuming nothing about transport compression.
     pub(crate) fn worth_building(values: &[T]) -> Option<Self> {
@@ -66,7 +39,7 @@ impl<T: FloatBits> FloatDict<T> {
 
     /// Bytes the codes and dictionary streams occupy, headers included.
     /// The codes count is implied by context, while the dictionary's always needs its own varint.
-    fn stored_bytes(&self) -> usize {
+    pub(crate) fn stored_bytes(&self) -> usize {
         let codes: usize = self.codes.iter().copied().map(varint_len).sum();
         let values = size_of_val(self.values.as_slice());
         let codes_stream = ENCODING_BYTE + varint_len(codes) + codes;
@@ -74,22 +47,4 @@ impl<T: FloatBits> FloatDict<T> {
             ENCODING_BYTE + varint_len(self.values.len()) + varint_len(values) + values;
         codes_stream + dict_stream
     }
-}
-
-/// The encoding byte every stream header starts with.
-#[cfg(feature = "unstable-v2")]
-const ENCODING_BYTE: usize = 1;
-
-/// Bytes a raw column of `count` elements occupies, header included.
-#[cfg(feature = "unstable-v2")]
-fn raw_stored_bytes<T>(count: usize) -> usize {
-    let values = count * size_of::<T>();
-    ENCODING_BYTE + varint_len(values) + values
-}
-
-/// Encoded length of a varint, for costing a header that is not written yet.
-#[cfg(feature = "unstable-v2")]
-fn varint_len(value: impl TryInto<u64>) -> usize {
-    let value: u64 = value.try_into().unwrap_or(u64::MAX);
-    integer_encoding::VarInt::required_space(value)
 }

--- a/rust/mlt-core/src/encoder/stream/mod.rs
+++ b/rust/mlt-core/src/encoder/stream/mod.rs
@@ -1,4 +1,9 @@
 mod codecs;
+#[cfg(feature = "unstable-v2")]
+mod float_alp;
+#[cfg(feature = "unstable-v2")]
+mod float_cost;
+#[cfg(feature = "unstable-v2")]
 mod float_dict;
 pub(crate) use codecs::LogicalCodecs;
 #[cfg(feature = "__private")]

--- a/rust/mlt-core/src/encoder/stream/write.rs
+++ b/rust/mlt-core/src/encoder/stream/write.rs
@@ -40,8 +40,7 @@ pub(crate) fn write_stream_payload(
         }
         WireVersion::V02 => {
             debug_assert!(!is_boolean, "v2 layers have no bool-RLE streams");
-            let implicit_count = enc.count_context;
-            let family = enc.family_context;
+            let (implicit_count, family) = (enc.count_context, enc.family_context);
             header02::write_stream_meta(
                 &meta,
                 enc.data_mut(),

--- a/rust/mlt-core/src/errors.rs
+++ b/rust/mlt-core/src/errors.rs
@@ -122,6 +122,8 @@ pub enum MltError {
     #[cfg(feature = "unstable-v2")]
     #[error("dictionary code {0} is out of range for a dictionary of {1} values")]
     DictionaryCodeOutOfRange(u32, usize),
+    #[error("invalid ALP parameters: e={0}, f={1}")]
+    InvalidAlpParams(u8, u8),
     #[error("presence stream has {0} bits set but {1} values provided")]
     PresenceValueCountMismatch(usize, usize),
     #[error("need to encode before being able to write")]

--- a/rust/mlt-core/src/lib.rs
+++ b/rust/mlt-core/src/lib.rs
@@ -55,7 +55,7 @@ pub(crate) use utils::lazy_state::{Decode, DecodeState, Lazy, LazyParsed, Parsed
 pub mod wire {
     pub use crate::decoder::ColumnType;
     pub use crate::decoder::stream::model::{
-        BoolLogical, DictionaryType, FloatLogical, IntEncoding, IntLogical, LengthType,
+        Alp, BoolLogical, DictionaryType, FloatLogical, IntEncoding, IntLogical, LengthType,
         LogicalEncoding, LogicalTechnique, Morton, OffsetType, PhysicalEncoding, RleLayout,
         RleMeta, StreamMeta, StreamType, ValueKind, VertexLogical,
     };

--- a/rust/mlt-core/tests/tag02_roundtrip.rs
+++ b/rust/mlt-core/tests/tag02_roundtrip.rs
@@ -608,23 +608,84 @@ fn tessellation_not_yet_supported() {
     assert!(err.to_string().contains("not"), "unexpected error: {err}");
 }
 
-/// Float columns encoded as a dictionary: off by default, so these opt in.
-mod float_dictionary {
+mod float_codecs {
+    use mlt_core::wire::{FloatLogical, LogicalEncoding};
+
     use super::*;
 
-    fn cfg_dict() -> EncoderConfig {
+    pub fn cfg_dict() -> EncoderConfig {
         cfg_v2().with_float_dict(true)
     }
 
-    fn f64_col(values: &[f64]) -> Vec<PropValue> {
+    pub fn cfg_alp() -> EncoderConfig {
+        cfg_v2().with_float_alp(true)
+    }
+
+    pub fn cfg_both() -> EncoderConfig {
+        cfg_dict().with_float_alp(true)
+    }
+
+    pub fn f64_col(values: &[f64]) -> Vec<PropValue> {
         values.iter().map(|&v| PropValue::F64(Some(v))).collect()
     }
 
-    fn f32_col(values: &[f32]) -> Vec<PropValue> {
+    pub fn f32_col(values: &[f32]) -> Vec<PropValue> {
         values.iter().map(|&v| PropValue::F32(Some(v))).collect()
     }
 
-    fn round_trip(l: &TileLayer, config: EncoderConfig) -> TileLayer {
+    pub fn f32_column(values: &[f32]) -> TileLayer {
+        layer(
+            points(&"1".repeat(values.len())),
+            None,
+            &[("v", f32_col(values))],
+        )
+    }
+
+    /// A few decimals repeated, which is what a float dictionary is for.
+    pub fn repeated_decimals(n: usize) -> Vec<f64> {
+        const PATTERN: [f64; 6] = [1.5, 2.5, 1.5, 1.5, 2.5, 3.5];
+        (0..n).map(|i| PATTERN[i % PATTERN.len()]).collect()
+    }
+
+    /// Values no power of ten scales to an integer, so ALP cannot take them.
+    pub fn irrational(n: usize) -> Vec<f64> {
+        use std::f64::consts::{E, PI, SQRT_2};
+        (0..n).map(|i| [PI, E, SQRT_2][i % 3]).collect()
+    }
+
+    /// The column's values as bit patterns, so NaN and `-0.0` compare usefully.
+    #[expect(
+        clippy::wildcard_enum_match_arm,
+        reason = "only float values are expected"
+    )]
+    pub fn value_bits(tile: &TileLayer) -> Vec<u64> {
+        tile.features()
+            .iter()
+            .map(|f| match f.properties()[0] {
+                PropValue::F64(Some(v)) => v.to_bits(),
+                PropValue::F32(Some(v)) => u64::from(v.to_bits()),
+                ref other => panic!("unexpected {other:?}"),
+            })
+            .collect()
+    }
+
+    /// The encoding each float stream in the tile carries, in wire order.
+    pub fn float_encodings(bytes: &[u8]) -> Vec<FloatLogical> {
+        annotate_tile(bytes)
+            .expect("annotate_tile")
+            .regions
+            .iter()
+            .filter_map(|r| r.blob)
+            .filter_map(|b| match b.meta.encoding.logical {
+                LogicalEncoding::Float(logical) => Some(logical),
+                LogicalEncoding::Int(_) | LogicalEncoding::Bool(_) | LogicalEncoding::Vertex(_) => {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    pub fn round_trip(l: &TileLayer, config: EncoderConfig) -> TileLayer {
         let bytes = l.clone().encode(config).expect("encode");
         let (tag, tile) = decode(&bytes);
         assert_eq!(tag, 2);
@@ -632,22 +693,20 @@ mod float_dictionary {
         tile
     }
 
-    fn column(values: &[f64]) -> TileLayer {
+    pub fn column(values: &[f64]) -> TileLayer {
         let mask = "1".repeat(values.len());
         layer(points(&mask), None, &[("v", f64_col(values))])
     }
 
     #[test]
     fn a_repetitive_column_round_trips_through_a_dictionary() {
-        const VALUES: &[f64] = &[1.5, 2.5, 1.5, 1.5, 2.5, 3.5, 1.5, 2.5, 1.5, 1.5, 2.5, 3.5];
-        let l = column(VALUES);
+        let l = column(&repeated_decimals(12));
         assert_eq!(round_trip(&l, cfg_dict()), round_trip(&l, cfg_v2()));
     }
 
     #[test]
-    fn the_dictionary_is_smaller_and_shows_in_the_dump() {
-        const VALUES: &[f64] = &[1.5, 2.5, 1.5, 1.5, 2.5, 3.5, 1.5, 2.5, 1.5, 1.5, 2.5, 3.5];
-        let l = column(VALUES);
+    fn a_dictionary_column_is_smaller_than_the_raw_one() {
+        let l = column(&repeated_decimals(12));
         let plain = l.clone().encode(cfg_v2()).unwrap();
         let dict = l.clone().encode(cfg_dict()).unwrap();
         assert!(
@@ -656,13 +715,34 @@ mod float_dictionary {
             dict.len(),
             plain.len()
         );
-
-        let dump = dump_text(&dict);
-        assert!(
-            dump.contains("logical = Dict, numbered for a v2 float column"),
-            "{dump}"
+        assert_eq!(
+            value_bits(&round_trip(&l, cfg_dict())),
+            value_bits(&round_trip(&l, cfg_v2()))
         );
-        assert!(dump.contains("dictionary"), "{dump}");
+    }
+
+    #[test]
+    fn a_decimal_column_takes_the_dictionary_when_alp_is_off() {
+        let bytes = column(&repeated_decimals(12)).encode(cfg_dict()).unwrap();
+        assert_eq!(
+            float_encodings(&bytes),
+            [FloatLogical::Dict, FloatLogical::None]
+        );
+    }
+
+    #[test]
+    fn a_column_alp_cannot_carry_still_takes_the_dictionary() {
+        let bytes = column(&irrational(12)).encode(cfg_both()).unwrap();
+        assert_eq!(
+            float_encodings(&bytes),
+            [FloatLogical::Dict, FloatLogical::None]
+        );
+    }
+
+    #[test]
+    fn both_flags_off_keeps_a_repetitive_column_raw() {
+        let bytes = column(&repeated_decimals(12)).encode(cfg_v2()).unwrap();
+        assert_eq!(float_encodings(&bytes), [FloatLogical::None]);
     }
 
     #[test]
@@ -708,20 +788,21 @@ mod float_dictionary {
     }
 
     #[test]
-    fn an_all_distinct_column_stays_raw() {
-        let values: Vec<f64> = (0..16).map(f64::from).collect();
+    fn an_all_distinct_column_no_encoding_fits_stays_raw() {
+        let values: Vec<f64> = (0..16)
+            .map(|i| std::f64::consts::PI * f64::from(i + 1))
+            .collect();
         let l = column(&values);
         assert_eq!(
-            l.clone().encode(cfg_dict()).unwrap(),
+            l.clone().encode(cfg_both()).unwrap(),
             l.encode(cfg_v2()).unwrap()
         );
     }
 
     #[test]
     fn f32_columns_round_trip_through_a_dictionary() {
-        const VALUES: &[f32] = &[1.5, 2.5, 1.5, 1.5, 2.5, 3.5, 1.5, 2.5, 1.5, 1.5, 2.5, 3.5];
-        let mask = "1".repeat(VALUES.len());
-        let l = layer(points(&mask), None, &[("v", f32_col(VALUES))]);
+        let values: Vec<f32> = (0..12).map(|i| [1.5_f32, 2.5, 3.5][i % 3]).collect();
+        let l = f32_column(&values);
         assert_eq!(round_trip(&l, cfg_dict()), round_trip(&l, cfg_v2()));
     }
 
@@ -734,13 +815,109 @@ mod float_dictionary {
         assert_eq!(round_trip(&l, cfg_dict()), round_trip(&l, cfg_v2()));
     }
 
-    #[test]
-    fn v1_ignores_the_flag() {
+    #[rstest]
+    #[case::dict(cfg_v1().with_float_dict(true))]
+    #[case::alp(cfg_v1().with_float_alp(true))]
+    #[case::both(cfg_v1().with_float_dict(true).with_float_alp(true))]
+    fn v1_ignores_the_flags(#[case] config: EncoderConfig) {
         const VALUES: &[f64] = &[1.5, 1.5, 1.5, 1.5];
         let l = column(VALUES);
         assert_eq!(
-            l.clone().encode(cfg_v1().with_float_dict(true)).unwrap(),
+            l.clone().encode(config).unwrap(),
             l.encode(cfg_v1()).unwrap()
         );
+    }
+}
+
+mod alp {
+    use mlt_core::wire::FloatLogical;
+
+    use super::float_codecs::*;
+    use super::*;
+
+    #[test]
+    fn a_decimal_column_is_smaller_through_alp() {
+        let values: Vec<f64> = (0..64).map(|i| f64::from(i) * 0.25 - 8.0).collect();
+        let l = column(&values);
+        let plain = l.clone().encode(cfg_v2()).unwrap();
+        let coded = l.clone().encode(cfg_alp()).unwrap();
+
+        assert_eq!(round_trip(&l, cfg_alp()), round_trip(&l, cfg_v2()));
+        assert!(
+            coded.len() < plain.len(),
+            "{} vs {}",
+            coded.len(),
+            plain.len()
+        );
+    }
+
+    #[test]
+    fn a_decimal_column_takes_alp_when_the_dictionary_is_off() {
+        let values: Vec<f64> = (0..12).map(|i| f64::from(i) * 0.25).collect();
+        let bytes = column(&values).encode(cfg_alp()).unwrap();
+        assert!(matches!(
+            float_encodings(&bytes)[..],
+            [FloatLogical::Alp(_)]
+        ));
+    }
+
+    #[test]
+    fn alp_beats_the_dictionary_on_a_repetitive_decimal_column() {
+        let bytes = column(&repeated_decimals(12)).encode(cfg_both()).unwrap();
+        assert!(matches!(
+            float_encodings(&bytes)[..],
+            [FloatLogical::Alp(_)]
+        ));
+    }
+
+    #[test]
+    #[expect(
+        clippy::wildcard_enum_match_arm,
+        reason = "only f64 values are expected"
+    )]
+    fn coordinates_round_trip_bit_for_bit() {
+        const VALUES: &[f64] = &[13.404_954, 52.520_008, -74.006, 40.712_776, 0.0, 180.0];
+        let l = column(VALUES);
+        let tile = round_trip(&l, cfg_alp());
+        let bits: Vec<u64> = tile
+            .features()
+            .iter()
+            .map(|f| match f.properties()[0] {
+                PropValue::F64(Some(v)) => v.to_bits(),
+                ref other => panic!("unexpected {other:?}"),
+            })
+            .collect();
+        let expected: Vec<u64> = VALUES.iter().map(|v| v.to_bits()).collect();
+        assert_eq!(bits, expected);
+    }
+
+    #[rstest]
+    #[case::nan(f64::NAN)]
+    #[case::infinity(f64::INFINITY)]
+    #[case::negative_zero(-0.0)]
+    fn one_value_alp_cannot_carry_keeps_the_whole_column_off_alp(#[case] odd: f64) {
+        let mut values: Vec<f64> = (0..16).map(|i| f64::from(i) * 0.5).collect();
+        values.push(odd);
+        let l = column(&values);
+        assert_eq!(
+            value_bits(&round_trip(&l, cfg_alp())),
+            value_bits(&round_trip(&l, cfg_v2()))
+        );
+    }
+
+    #[test]
+    fn an_optional_alp_column_round_trips() {
+        let values: Vec<PropValue> = (0..24)
+            .map(|i| PropValue::F64((i % 4 != 0).then(|| f64::from(i) * 0.125)))
+            .collect();
+        let l = layer(points(&"1".repeat(24)), None, &[("v", values)]);
+        assert_eq!(round_trip(&l, cfg_alp()), round_trip(&l, cfg_v2()));
+    }
+
+    #[test]
+    fn f32_columns_round_trip_through_alp() {
+        let values: Vec<f32> = (0_i16..32).map(|i| f32::from(i) * 0.5 - 8.0).collect();
+        let l = f32_column(&values);
+        assert_eq!(round_trip(&l, cfg_alp()), round_trip(&l, cfg_v2()));
     }
 }

--- a/rust/mlt/src/ls.rs
+++ b/rust/mlt/src/ls.rs
@@ -185,6 +185,7 @@ impl std::fmt::Display for FileAlgorithm {
                     StatLogicalCodec::MortonDelta => "MortonDelta",
                     StatLogicalCodec::MortonRle => "MortonRle",
                     StatLogicalCodec::Dict => "Dict",
+                    StatLogicalCodec::Alp => "ALP",
                 };
                 write!(f, "{phys_type}")?;
                 if !physical.is_empty() {
@@ -668,6 +669,7 @@ pub enum StatLogicalCodec {
     MortonDelta,
     MortonRle,
     Dict,
+    Alp,
 }
 
 impl From<LogicalEncoding> for StatLogicalCodec {
@@ -686,6 +688,7 @@ impl From<LogicalEncoding> for StatLogicalCodec {
             LE::Vertex(VertexLogical::MortonDelta(_)) => Self::MortonDelta,
             LE::Vertex(VertexLogical::MortonRle(_)) => Self::MortonRle,
             LE::Float(FloatLogical::Dict) => Self::Dict,
+            LE::Float(FloatLogical::Alp(_)) => Self::Alp,
         }
     }
 }


### PR DESCRIPTION
ALP stores a float as a scaled integer and recovers it exactly, so decimal data compresses where the raw bit patterns did not. Exception-free only: a column takes ALP when every value returns bit-for-bit, and it then competes with the dictionary on stored bytes.
