### PR TITLE
refactor: remove the never-implemented Pseudodecimal encoding

### DIFF
--- a/cpp/include/mlt/metadata/stream.hpp
+++ b/cpp/include/mlt/metadata/stream.hpp
@@ -49,8 +49,7 @@ enum class LogicalLevelTechnique : std::uint8_t {
     COMPONENTWISE_DELTA = 2,
     RLE = 3,
     MORTON = 4,
-    PSEUDODECIMAL = 5,
-    VALUE_COUNT = 6,
+    VALUE_COUNT = 5,
 };
 
 enum class OffsetType : std::uint8_t {

--- a/cpp/src/mlt/decode/int_template.hpp
+++ b/cpp/src/mlt/decode/int_template.hpp
@@ -38,7 +38,6 @@ inline std::size_t IntegerDecoder::getIntArrayBufferSize(const std::size_t count
         case LogicalLevelTechnique::MORTON: {
             return 2 * count;
         }
-        case LogicalLevelTechnique::PSEUDODECIMAL:
         default:
             return 0;
     }
@@ -121,7 +120,6 @@ void IntegerDecoder::decodeIntArray(const T* values,
             }
             break;
         }
-        case LogicalLevelTechnique::PSEUDODECIMAL:
         default:
             throw std::runtime_error("The specified logical level technique is not supported for integers: " +
                                      std::to_string(std::to_underlying(streamMetadata.getLogicalLevelTechnique1())));

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/DoubleEncoder.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/DoubleEncoder.java
@@ -19,7 +19,7 @@ public class DoubleEncoder {
   }
 
   public static ArrayList<byte[]> encodeDoubleStream(final double[] values) throws IOException {
-    // TODO: add encodings -> RLE, Dictionary, PDE
+    // TODO: add encodings -> RLE, Dictionary
     return encodeDoubleStream(values.length, EncodingUtils.encodeDoublesLE(values));
   }
 

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/FloatEncoder.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/FloatEncoder.java
@@ -24,7 +24,7 @@ public class FloatEncoder {
 
   private static ArrayList<byte[]> encodeFloatStream(final int size, final byte[] encoded)
       throws IOException {
-    // TODO: add encodings -> RLE, Dictionary, PDE
+    // TODO: add encodings -> RLE, Dictionary
     final var result =
         new StreamMetadata(
                 PhysicalStreamType.DATA,

--- a/java/mlt-core/src/main/java/org/maplibre/mlt/metadata/stream/LogicalLevelTechnique.java
+++ b/java/mlt-core/src/main/java/org/maplibre/mlt/metadata/stream/LogicalLevelTechnique.java
@@ -5,8 +5,5 @@ public enum LogicalLevelTechnique {
   DELTA,
   COMPONENTWISE_DELTA,
   RLE,
-  MORTON,
-  /* Pseudodecimal Encoding of floats -> only for the exponent integer part an additional logical level technique is used.
-   *  Both exponent and significant parts are encoded with the same physical level technique */
-  PDE;
+  MORTON;
 }

--- a/rust/mlt-core/src/decoder/stream/header01.rs
+++ b/rust/mlt-core/src/decoder/stream/header01.rs
@@ -141,15 +141,14 @@ pub(crate) fn parse_stream_meta<'a>(
 
     let mut input = input;
     let logical_encoding = match logical {
-        LC::None | LC::Delta | LC::ComponentwiseDelta | LC::PseudoDecimal => {
+        LC::None | LC::Delta | LC::ComponentwiseDelta => {
             // Reserve decoded memory upper bound: worst case u64 = 8 bytes per value
             let decoded_bytes = num_values.saturating_mul(8);
             parser.reserve(decoded_bytes)?;
             match logical {
                 LC::None => LogicalEncoding::None,
                 LC::Delta => LogicalEncoding::Delta,
-                LC::ComponentwiseDelta => LogicalEncoding::ComponentwiseDelta,
-                _ => LogicalEncoding::PseudoDecimal,
+                _ => LogicalEncoding::ComponentwiseDelta,
             }
         }
         LC::Rle | LC::DeltaRle => {
@@ -223,7 +222,6 @@ pub(crate) fn write_stream_meta<W: io::Write>(
         LE::Morton(_) => LC::Morton,
         LE::MortonRle(_) => LC::MortonRle,
         LE::MortonDelta(_) => LC::MortonDelta,
-        LE::PseudoDecimal => LC::PseudoDecimal,
     };
     writer.write_u8(encoding_byte(logical, meta.encoding.physical))?;
     writer.write_varint(meta.num_values)?;
@@ -256,7 +254,7 @@ pub(crate) fn write_stream_meta<W: io::Write>(
             writer.write_varint(m.bits)?;
             writer.write_varint(m.shift)?;
         }
-        LE::None | LE::Delta | LE::ComponentwiseDelta | LE::PseudoDecimal => {}
+        LE::None | LE::Delta | LE::ComponentwiseDelta => {}
     }
     Ok(())
 }
@@ -460,11 +458,6 @@ mod tests {
         LogicalCombination::MortonRle,
         LogicalTechnique::Morton,
         LogicalTechnique::Rle
-    )]
-    #[case::pseudo_decimal(
-        LogicalCombination::PseudoDecimal,
-        LogicalTechnique::PseudoDecimal,
-        LogicalTechnique::None
     )]
     fn combination_holds_both_field_bits(
         #[case] combination: LogicalCombination,

--- a/rust/mlt-core/src/decoder/stream/header02.rs
+++ b/rust/mlt-core/src/decoder/stream/header02.rs
@@ -6,7 +6,7 @@
 //! [u8 encoding_byte]
 //!      bit  7:   has_explicit_count (1 = a count varint follows)
 //!      bits 6-4: logical  (0=None, 1=Delta, 2=CwDelta, 3=Rle, 4=DeltaRle,
-//!                          5=Morton, 6=PseudoDecimal, 7=reserved)
+//!                          5=Morton, 6-7=reserved)
 //!      bits 3-2: physical (0=None-noLen, 1=None-withLen, 2=VarInt, 3=FastPFor128);
 //!                reserved (must be 0) for Rle/DeltaRle, whose physical
 //!                encoding is implied to be VarInt
@@ -24,8 +24,7 @@
 //! from the count context.
 //!
 //! Not yet implemented (rejected with [`MltError::NotImplemented`]):
-//! `None-noLen` (requires element-width context), `FastPFor128`, `Morton`,
-//! and `PseudoDecimal`.
+//! `None-noLen` (requires element-width context), `FastPFor128`, and `Morton`.
 
 use std::io;
 
@@ -51,7 +50,7 @@ pub(crate) const PHYSICAL_MASK: u8 = 0b0000_1100;
 /// Mask of the encoding byte bits held in reserve, which must be zero.
 pub(crate) const ENCODING_RESERVED_MASK: u8 = 0b0000_0011;
 
-/// Logical field (bits 6-4 of the encoding byte). Bit pattern 7 is reserved.
+/// Logical field (bits 6-4 of the encoding byte). Bit patterns 6 and 7 are reserved.
 ///
 /// Variants are already shifted into place, so the byte is matched with
 /// `byte & LOGICAL_MASK` rather than shifted down first.
@@ -64,7 +63,6 @@ pub(crate) enum LogicalField {
     Rle = 0b0011_0000,
     DeltaRle = 0b0100_0000,
     Morton = 0b0101_0000,
-    PseudoDecimal = 0b0110_0000,
 }
 
 /// Physical field (bits 3-2 of the encoding byte), also shifted into place.
@@ -126,9 +124,6 @@ pub(crate) fn parse_stream<'a>(
             IntEncoding::new(logical, PhysicalEncoding::VarInt)
         }
         LogicalField::Morton => return Err(MltError::NotImplemented("v2 Morton streams")),
-        LogicalField::PseudoDecimal => {
-            return Err(MltError::NotImplemented("v2 PseudoDecimal streams"));
-        }
         LogicalField::None => IntEncoding::new(
             LogicalEncoding::None,
             physical_encoding_for(physical_field)?,
@@ -202,7 +197,6 @@ pub(crate) fn write_stream_meta<W: io::Write>(
         LE::Morton(_) | LE::MortonDelta(_) | LE::MortonRle(_) => {
             return Err(MltError::NotImplemented("v2 Morton streams"));
         }
-        LE::PseudoDecimal => return Err(MltError::NotImplemented("v2 PseudoDecimal streams")),
     };
 
     // For RLE streams the wire count is the *decoded* count (the encoder's
@@ -346,7 +340,8 @@ mod tests {
     #[case::reserved_low_bits2(0b0000_1010)]
     #[case::rle_with_physical(0b0011_0100)]
     #[case::delta_rle_with_physical(0b0100_1000)]
-    #[case::logical_reserved(0b0111_1000)]
+    #[case::logical_reserved6(0b0110_1000)]
+    #[case::logical_reserved7(0b0111_1000)]
     fn rejects_reserved_bits(#[case] enc_byte: u8) {
         let buf = [enc_byte, 0];
         let err = parse_stream(&buf, DATA, 0, &mut parser()).unwrap_err();
@@ -358,7 +353,6 @@ mod tests {
     #[case::none_no_len(0b0000_0000)]
     #[case::fastpfor128(0b0000_1100)]
     #[case::morton(0b0101_0000)]
-    #[case::pseudo_decimal(0b0110_0000)]
     fn rejects_unimplemented(#[case] enc_byte: u8) {
         let buf = [enc_byte, 0];
         let err = parse_stream(&buf, DATA, 0, &mut parser()).unwrap_err();

--- a/rust/mlt-core/src/decoder/stream/logical.rs
+++ b/rust/mlt-core/src/decoder/stream/logical.rs
@@ -136,10 +136,6 @@ impl LogicalValue {
                 self.meta.encoding.logical,
                 "i32 (MortonRle)",
             )),
-            LogicalEncoding::PseudoDecimal => Err(UnsupportedLogicalEncoding(
-                self.meta.encoding.logical,
-                "i32",
-            )),
         }
     }
 

--- a/rust/mlt-core/src/decoder/stream/model.rs
+++ b/rust/mlt-core/src/decoder/stream/model.rs
@@ -17,7 +17,6 @@ pub enum LogicalTechnique {
     ComponentwiseDelta = 0b0100_0000,
     Rle = 0b0110_0000,
     Morton = 0b1000_0000,
-    PseudoDecimal = 0b1010_0000,
 }
 
 /// The combinations of the two [`LogicalTechnique`] fields that are legal on the wire
@@ -36,7 +35,6 @@ pub enum LogicalCombination {
     Morton = 0b1000_0000,
     MortonDelta = 0b1000_0100,
     MortonRle = 0b1000_1100,
-    PseudoDecimal = 0b1010_0000,
 }
 
 /// Which RLE stream layout the encoder should produce.
@@ -110,7 +108,6 @@ pub enum LogicalEncoding {
     Morton(Morton),
     MortonDelta(Morton),
     MortonRle(Morton),
-    PseudoDecimal,
 }
 
 /// Carries the stream metadata needed to perform the logical decode pass.

--- a/rust/mlt-core/src/encoder/stream/tests.rs
+++ b/rust/mlt-core/src/encoder/stream/tests.rs
@@ -256,8 +256,6 @@ fn allow_fastpfor_gates_fastpfor_selection() {
 )]
 #[case::varint(StreamType::Data(DictionaryType::None), 5, LogicalEncoding::Delta, PhysicalEncoding::VarInt, vec![0x00, 0x02, 0x02, 0x02, 0x02], false
 )]
-#[case::varint(StreamType::Data(DictionaryType::None), 3, LogicalEncoding::PseudoDecimal, PhysicalEncoding::VarInt, vec![0x01, 0x02, 0x03], false
-)]
 #[case::varint(StreamType::Length(LengthType::VarBinary), 3, LogicalEncoding::Delta, PhysicalEncoding::VarInt, vec![0x00, 0x02, 0x02], false
 )]
 #[case::rle(StreamType::Data(DictionaryType::None), 6, LogicalEncoding::Rle(RleMeta::Split { runs: 3, num_rle_values: 6 }), PhysicalEncoding::VarInt, vec![0x03, 0x02, 0x01, 0x0A, 0x14, 0x1E], false

--- a/rust/mlt/src/ls.rs
+++ b/rust/mlt/src/ls.rs
@@ -184,7 +184,6 @@ impl std::fmt::Display for FileAlgorithm {
                     StatLogicalCodec::Morton => "Morton",
                     StatLogicalCodec::MortonDelta => "MortonDelta",
                     StatLogicalCodec::MortonRle => "MortonRle",
-                    StatLogicalCodec::PseudoDecimal => "PseudoDec",
                 };
                 write!(f, "{phys_type}")?;
                 if !physical.is_empty() {
@@ -661,7 +660,6 @@ pub enum StatLogicalCodec {
     Morton,
     MortonDelta,
     MortonRle,
-    PseudoDecimal,
 }
 
 impl From<LogicalEncoding> for StatLogicalCodec {
@@ -675,7 +673,6 @@ impl From<LogicalEncoding> for StatLogicalCodec {
             LogicalEncoding::Morton(_) => Self::Morton,
             LogicalEncoding::MortonDelta(_) => Self::MortonDelta,
             LogicalEncoding::MortonRle(_) => Self::MortonRle,
-            LogicalEncoding::PseudoDecimal => Self::PseudoDecimal,
         }
     }
 }

--- a/ts/src/decoding/integerStreamDecoder.spec.ts
+++ b/ts/src/decoding/integerStreamDecoder.spec.ts
@@ -395,8 +395,8 @@ describe("decodeUnsignedConstInt32Stream", () => {
         expect(result).toBe(4);
     });
 
-    it("should throw for unsupported technique", () => {
-        const metadata = createStreamMetadata(LogicalLevelTechnique.PDE, LogicalLevelTechnique.NONE, 3);
+    it("should throw for an unknown logical level technique", () => {
+        const metadata = createStreamMetadata("UNKNOWN" as LogicalLevelTechnique, LogicalLevelTechnique.NONE, 3);
         const offset = new IntWrapper(0);
         const bitVector = new BitVector(new Uint8Array([0b00000111]), 3);
 

--- a/ts/src/metadata/tile/logicalLevelTechnique.ts
+++ b/ts/src/metadata/tile/logicalLevelTechnique.ts
@@ -4,7 +4,4 @@ export enum LogicalLevelTechnique {
     COMPONENTWISE_DELTA = "COMPONENTWISE_DELTA",
     RLE = "RLE",
     MORTON = "MORTON",
-    // Pseudodecimal Encoding of floats -> only for the exponent integer part an additional logical level technique is used.
-    // Both exponent and significant parts are encoded with the same physical level technique
-    PDE = "PDE",
 }

--- a/ts/src/metadata/tile/streamMetadataDecoder.ts
+++ b/ts/src/metadata/tile/streamMetadataDecoder.ts
@@ -47,7 +47,6 @@ const LOGICAL_LEVEL_TECHNIQUE_BY_ID: readonly LogicalLevelTechnique[] = [
     LogicalLevelTechnique.COMPONENTWISE_DELTA,
     LogicalLevelTechnique.RLE,
     LogicalLevelTechnique.MORTON,
-    LogicalLevelTechnique.PDE,
 ];
 
 const PHYSICAL_LEVEL_TECHNIQUE_BY_ID: readonly PhysicalLevelTechnique[] = [


### PR DESCRIPTION
No encoder in this repo ever emitted a Pseudodecimal (`PDE` / `PSEUDODECIMAL`) stream, and no decoder ever read one.
In v2, I am adding a better version based on ALP with a nice exception mechanism instead

-> 🗑️ 