### PR TITLE
chore(rust): release

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -153,9 +153,9 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "async-compression"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
+checksum = "515a1f282e33d55983c499d7e9e87082e81cbc32974825bf9032f928392d5844"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
 dependencies = [
  "cc",
  "cmake",
@@ -496,7 +496,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls 0.26.5",
  "tower",
  "tracing",
 ]
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954c563ce84507722d2679f07a35d21b9c6466b3872d513020d0281fc8112ac9"
+checksum = "9c054752dd9e4dc73d0b75748c99ac2d0feafbf2f25c7b0516f03a3534161223"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -589,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.6.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce83ce9abbb198d25bc7131e468d0f9fe1257125e58c39f3f9fc9f5098c9647"
+checksum = "8f94d16e797ec62cd999fc9d5942b48fa7050c3093ddadff48e4d7528d16fcb9"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -843,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "buffa"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e6224bc4ee1f189ad257120c156fb05f95b826f5369d620b24984476c200a"
+checksum = "a92f2f5df67a9d5ccfc65237bfc954c56328aee40a04a9b92381ecba370be246"
 dependencies = [
  "base64",
  "bytes",
@@ -922,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1089,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+checksum = "2fe67f2944eef52fc7b106b8c9450d243a88701a0c065f7f57235e76abaed7df"
 dependencies = [
  "brotli",
  "compression-core",
@@ -1103,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+checksum = "6e8ccc4ea9f6acc32d102c0f6d471d11d913ad15f20c04de743374861fa1d414"
 
 [[package]]
 name = "console"
@@ -1792,7 +1792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1931,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "finl_unicode"
@@ -2721,7 +2721,7 @@ dependencies = [
  "rustls 0.23.43",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls 0.26.5",
  "tower-service",
  "webpki-roots",
 ]
@@ -2743,7 +2743,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -3029,7 +3029,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3202,9 +3202,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
 dependencies = [
  "libc",
 ]
@@ -3264,9 +3264,9 @@ checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d317b4b9eb398e6acce275758ec6125535505e7a146fb1a9b8bda2451b0ff4c"
+checksum = "ff9840bcc50b71349309900da0ce7279aa336ae71d73250b07998932c7d97c25"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -3447,9 +3447,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "log",
@@ -3459,7 +3459,7 @@ dependencies = [
 
 [[package]]
 name = "mlt"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-core"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "arbitrary",
  "bitvec",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-ffi"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-py"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "mlt-core",
  "pyo3",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-wasm"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "js-sys",
  "mlt-core",
@@ -4204,9 +4204,9 @@ checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
 dependencies = [
  "portable-atomic",
 ]
@@ -4501,7 +4501,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls 0.23.43",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -4540,9 +4540,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4961,7 +4961,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls 0.26.5",
  "tokio-util",
  "tower",
  "tower-http",
@@ -5001,7 +5001,7 @@ dependencies = [
  "serde_json",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls 0.26.5",
  "tower",
  "tower-http",
  "tower-service",
@@ -5236,7 +5236,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5307,7 +5307,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5804,9 +5804,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 dependencies = [
  "serde",
 ]
@@ -6073,9 +6073,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
+checksum = "c25ac7aff0abd1dbc474536e40416e1102c7dd9bfba0b9861c6d357f835dcfb4"
 dependencies = [
  "bytes",
  "futures-util",
@@ -6265,10 +6265,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6512,9 +6512,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -6563,9 +6563,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls 0.23.43",
  "tokio",
@@ -6598,9 +6598,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -7243,7 +7243,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7665,9 +7665,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.4"
+version = "7.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+checksum = "64d80649ab6db9d9f6f9c80a40becd948eda4714a0a5ac8c4d157a32231c7882"
 dependencies = [
  "zstd-sys",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -50,7 +50,7 @@ js-sys = "0.3"
 martin-tile-utils = "0.7"
 mbtiles = { version = "0.19", default-features = false, features = ["transcode"] }
 mimalloc = "0.1.52"
-mlt-core = { version = "0.12.7", path = "mlt-core" }
+mlt-core = { version = "0.12.8", path = "mlt-core" }
 moka = { version = "0.12", features = ["sync"] }
 num-traits = "0.2.19"
 num_enum = "0.7.6"

--- a/rust/mlt-core/CHANGELOG.md
+++ b/rust/mlt-core/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.8](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-core-v0.12.7...rust-mlt-core-v0.12.8) - 2026-09-04
+
+### Added
+
+- *(rust)* `mlt convert --bbox` to convert only part of an archive ([#1620](https://github.com/maplibre/maplibre-tile-spec/pull/1620))
+
+### Fixed
+
+- *(rust)* reject malformed FSST data instead of panicking ([#1621](https://github.com/maplibre/maplibre-tile-spec/pull/1621))
+
+### Other
+
+- *(rust)* enable clippy::wildcard_enum_match_arm ([#1610](https://github.com/maplibre/maplibre-tile-spec/pull/1610))
+- *(rust)* generate every property column kind in the fuzz generator ([#1608](https://github.com/maplibre/maplibre-tile-spec/pull/1608))
+- remove the never-implemented Pseudodecimal encoding ([#1605](https://github.com/maplibre/maplibre-tile-spec/pull/1605))
+- *(rust)* decode boolean streams as packed bits instead of `Vec<bool>` ([#1596](https://github.com/maplibre/maplibre-tile-spec/pull/1596))
+
 ## [0.12.7](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-core-v0.12.6...rust-mlt-core-v0.12.7) - 2026-08-31
 
 ### Added

--- a/rust/mlt-core/Cargo.toml
+++ b/rust/mlt-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-core"
 description = "MapLibre Tile library code"
-version = "0.12.7"
+version = "0.12.8"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/rust/mlt-ffi/CHANGELOG.md
+++ b/rust/mlt-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.16](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-ffi-v0.1.15...rust-mlt-ffi-v0.1.16) - 2026-09-04
+
+### Other
+
+- updated the following local packages: mlt-core
+
 ## [0.1.15](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-ffi-v0.1.14...rust-mlt-ffi-v0.1.15) - 2026-08-31
 
 ### Other

--- a/rust/mlt-ffi/Cargo.toml
+++ b/rust/mlt-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-ffi"
 description = "Diplomat FFI bindings for mlt-core"
-version = "0.1.15"
+version = "0.1.16"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/rust/mlt-py/CHANGELOG.md
+++ b/rust/mlt-py/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.29](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.28...python-mlt-v0.1.29) - 2026-09-04
+
+### Added
+
+- *(rust)* `mlt convert --bbox` to convert only part of an archive ([#1620](https://github.com/maplibre/maplibre-tile-spec/pull/1620))
+
 ## [0.1.28](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.27...python-mlt-v0.1.28) - 2026-08-31
 
 ### Other

--- a/rust/mlt-py/Cargo.toml
+++ b/rust/mlt-py/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-py"
 description = "Python bindings for MapLibre Tile (MLT) format via PyO3"
-version = "0.1.28"
+version = "0.1.29"
 repository.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/rust/mlt-py/pyproject.toml
+++ b/rust/mlt-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "maplibre-tiles"
-version = "0.1.28"
+version = "0.1.29"
 description = "Python bindings for MapLibre Tile (MLT) format"
 requires-python = ">=3.10"
 license = { text = "MIT OR Apache-2.0" }

--- a/rust/mlt-wasm/CHANGELOG.md
+++ b/rust/mlt-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.22](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-wasm-v0.1.21...rust-mlt-wasm-v0.1.22) - 2026-09-04
+
+### Other
+
+- updated the following local packages: mlt-core
+
 ## [0.1.21](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-wasm-v0.1.20...rust-mlt-wasm-v0.1.21) - 2026-08-31
 
 ### Added

--- a/rust/mlt-wasm/Cargo.toml
+++ b/rust/mlt-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-wasm"
 description = "WebAssembly bindings for the MapLibre Tile (MLT) format"
-version = "0.1.21"
+version = "0.1.22"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/rust/mlt-wasm/package-lock.json
+++ b/rust/mlt-wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/mlt-wasm",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/mlt-wasm",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@mapbox/point-geometry": "1.1.0"

--- a/rust/mlt-wasm/package.json
+++ b/rust/mlt-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/mlt-wasm",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "WebAssembly-backed MapLibre Tile (MLT) decoder",
   "type": "module",
   "main": "dist/index.js",

--- a/rust/mlt/CHANGELOG.md
+++ b/rust/mlt/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.27](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.26...rust-mlt-v0.1.27) - 2026-09-04
+
+### Added
+
+- *(rust)* `mlt convert --bbox` to convert only part of an archive ([#1620](https://github.com/maplibre/maplibre-tile-spec/pull/1620))
+
+### Fixed
+
+- *(rust)* floor the mbtiles zoom level with a tolerance ([#1627](https://github.com/maplibre/maplibre-tile-spec/pull/1627))
+
+### Other
+
+- *(rust)* drive the mlt ui from tests through TestBackend ([#1638](https://github.com/maplibre/maplibre-tile-spec/pull/1638))
+- *(rust)* enable clippy::wildcard_enum_match_arm ([#1610](https://github.com/maplibre/maplibre-tile-spec/pull/1610))
+- remove the never-implemented Pseudodecimal encoding ([#1605](https://github.com/maplibre/maplibre-tile-spec/pull/1605))
+
 ## [0.1.26](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.25...rust-mlt-v0.1.26) - 2026-08-31
 
 ### Added

--- a/rust/mlt/Cargo.toml
+++ b/rust/mlt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt"
 description = "MapLibre Tile Tools"
-version = "0.1.26"
+version = "0.1.27"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `mlt-core`: 0.12.7 -> 0.12.8 (✓ API compatible changes)
* `mlt`: 0.1.26 -> 0.1.27
* `mlt-py`: 0.1.28 -> 0.1.29
* `mlt-ffi`: 0.1.15 -> 0.1.16
* `mlt-wasm`: 0.1.21 -> 0.1.22

<details><summary><i><b>Changelog</b></i></summary><p>

## `mlt-core`

<blockquote>

## [0.12.8](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-core-v0.12.7...rust-mlt-core-v0.12.8) - 2026-09-04

### Added

- *(rust)* `mlt convert --bbox` to convert only part of an archive ([#1620](https://github.com/maplibre/maplibre-tile-spec/pull/1620))

### Fixed

- *(rust)* reject malformed FSST data instead of panicking ([#1621](https://github.com/maplibre/maplibre-tile-spec/pull/1621))

### Other

- *(rust)* enable clippy::wildcard_enum_match_arm ([#1610](https://github.com/maplibre/maplibre-tile-spec/pull/1610))
- *(rust)* generate every property column kind in the fuzz generator ([#1608](https://github.com/maplibre/maplibre-tile-spec/pull/1608))
- remove the never-implemented Pseudodecimal encoding ([#1605](https://github.com/maplibre/maplibre-tile-spec/pull/1605))
- *(rust)* decode boolean streams as packed bits instead of `Vec<bool>` ([#1596](https://github.com/maplibre/maplibre-tile-spec/pull/1596))
</blockquote>

## `mlt`

<blockquote>

## [0.1.27](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.26...rust-mlt-v0.1.27) - 2026-09-04

### Added

- *(rust)* `mlt convert --bbox` to convert only part of an archive ([#1620](https://github.com/maplibre/maplibre-tile-spec/pull/1620))

### Fixed

- *(rust)* floor the mbtiles zoom level with a tolerance ([#1627](https://github.com/maplibre/maplibre-tile-spec/pull/1627))

### Other

- *(rust)* drive the mlt ui from tests through TestBackend ([#1638](https://github.com/maplibre/maplibre-tile-spec/pull/1638))
- *(rust)* enable clippy::wildcard_enum_match_arm ([#1610](https://github.com/maplibre/maplibre-tile-spec/pull/1610))
- remove the never-implemented Pseudodecimal encoding ([#1605](https://github.com/maplibre/maplibre-tile-spec/pull/1605))
</blockquote>

## `mlt-py`

<blockquote>

## [0.1.29](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.28...python-mlt-v0.1.29) - 2026-09-04

### Added

- *(rust)* `mlt convert --bbox` to convert only part of an archive ([#1620](https://github.com/maplibre/maplibre-tile-spec/pull/1620))
</blockquote>

## `mlt-ffi`

<blockquote>

## [0.1.16](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-ffi-v0.1.15...rust-mlt-ffi-v0.1.16) - 2026-09-04

### Other

- updated the following local packages: mlt-core
</blockquote>

## `mlt-wasm`

<blockquote>

## [0.1.22](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-wasm-v0.1.21...rust-mlt-wasm-v0.1.22) - 2026-09-04

### Other

- updated the following local packages: mlt-core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).