### PR TITLE
feat(rust): share v2 presence bitfields with dictionary children

### DIFF
--- a/rust/mlt-core/src/encoder/encode02.rs
+++ b/rust/mlt-core/src/encoder/encode02.rs
@@ -29,7 +29,8 @@ use crate::decoder::{
 use crate::encoder::geometry::encode02::encode_geometry02;
 use crate::encoder::model::{StagedLayer, StreamCtx};
 use crate::encoder::{
-    Codecs, Encoder, StagedId, StagedOptScalar, StagedProperty, write_stream_payload,
+    Codecs, Encoder, StagedId, StagedOptScalar, StagedProperty, StagedSharedDictItem,
+    write_stream_payload,
 };
 use crate::utils::BinarySerializer as _;
 
@@ -39,13 +40,14 @@ use crate::utils::BinarySerializer as _;
 /// many masks there are and the block right after it holds them - both come
 /// before the geometry section.
 ///
-/// A mask only earns a slot when more than one column has it; a mask used once is
-/// no cheaper shared than inline. The layout byte fits at most
-/// [`LayerLayout::MAX_SHARED_PRESENCE`] of them, so when more groups qualify the
-/// ones shared by the most columns win, since every extra sharer saves exactly
+/// A mask only earns a slot when more than one column reads it; a mask read once is
+/// no cheaper shared than inline. Each child of a shared dictionary counts as a
+/// reader in its own right, since each writes its own bitfield otherwise. The layout
+/// byte fits at most [`LayerLayout::MAX_SHARED_PRESENCE`] of them, so when more
+/// groups qualify the most-read ones win, since every extra reader saves exactly
 /// one copy of the same `ceil(feature_count/8)` bytes.
 #[derive(Debug)]
-struct SharedPresence {
+pub(crate) struct SharedPresence {
     /// The masks in wire index order.
     masks: Vec<Vec<bool>>,
     /// Wire index of each mask, for resolving a column's nibble.
@@ -53,7 +55,7 @@ struct SharedPresence {
 }
 
 impl SharedPresence {
-    /// Group the layer's optional columns by mask and keep the shared ones.
+    /// Group the layer's optional columns and dictionary children by mask and keep the shared ones.
     fn plan(id: &StagedId, properties: &[StagedProperty]) -> Self {
         // (column count, index of the first column with this mask) per mask.
         let mut groups: HashMap<Vec<bool>, (usize, usize)> = HashMap::new();
@@ -96,7 +98,7 @@ impl SharedPresence {
 
     /// Where an optional column's nulls live: this layer's shared bitfield when
     /// another column has the same mask, the column's own bitfield otherwise.
-    fn nibble_for(&self, mask: &[bool]) -> Presence02 {
+    pub(crate) fn nibble_for(&self, mask: &[bool]) -> Presence02 {
         self.index
             .get(mask)
             .map_or(Presence02::Inline, |&i| Presence02::Shared(i))
@@ -110,8 +112,9 @@ impl SharedPresence {
     }
 }
 
-/// The presence mask of every optional column, in the order the columns are
-/// written: the ID column first, then the properties.
+/// The presence mask of everything that writes one, in the order it is written:
+/// the ID column first, then the properties, a shared dictionary contributing one
+/// mask per child at its parent column's position.
 ///
 /// Owned, because a string column derives its mask from its lengths rather than storing one.
 /// Columns that cannot be null contribute nothing - there is no mask to share.
@@ -129,21 +132,28 @@ fn column_masks<'a>(
         StagedId::OptU64(v) => Some(mask(v)),
         StagedId::None | StagedId::U32(_) | StagedId::U64(_) => None,
     };
-    let props = properties.iter().filter_map(|prop| {
+    let props = properties.iter().flat_map(|prop| {
         use StagedProperty as D;
         match prop {
-            D::OptBool(v) => Some(mask(v)),
-            D::OptI8(v) => Some(mask(v)),
-            D::OptU8(v) => Some(mask(v)),
-            D::OptI32(v) => Some(mask(v)),
-            D::OptU32(v) => Some(mask(v)),
-            D::OptI64(v) => Some(mask(v)),
-            D::OptU64(v) => Some(mask(v)),
-            D::OptF32(v) => Some(mask(v)),
-            D::OptF64(v) => Some(mask(v)),
-            D::OptStr(v) => Some(v.presence_bools().collect()),
-            // A column with no null mask has no presence bits, and shared
-            // dictionaries are not encodable as v2 yet.
+            D::OptBool(v) => vec![mask(v)],
+            D::OptI8(v) => vec![mask(v)],
+            D::OptU8(v) => vec![mask(v)],
+            D::OptI32(v) => vec![mask(v)],
+            D::OptU32(v) => vec![mask(v)],
+            D::OptI64(v) => vec![mask(v)],
+            D::OptU64(v) => vec![mask(v)],
+            D::OptF32(v) => vec![mask(v)],
+            D::OptF64(v) => vec![mask(v)],
+            D::OptStr(v) => vec![v.presence_bools().collect()],
+            // A shared dictionary holds no values of its own, but each of its
+            // children is null on its own features, so each is a sharer in its
+            // own right - listed here, where its parent column sits.
+            D::SharedDict(v) => v
+                .items
+                .iter()
+                .filter_map(StagedSharedDictItem::optional_presence)
+                .collect(),
+            // A column with no null mask has no presence bits.
             D::Bool(_)
             | D::I8(_)
             | D::U8(_)
@@ -153,8 +163,7 @@ fn column_masks<'a>(
             | D::U64(_)
             | D::F32(_)
             | D::F64(_)
-            | D::Str(_)
-            | D::SharedDict(_) => None,
+            | D::Str(_) => vec![],
         }
     });
     id.into_iter().chain(props)
@@ -416,6 +425,6 @@ fn write_prop02(
                 codecs.write_str_col02(v, enc)
             })
         }
-        D::SharedDict(v) => codecs.write_shared_dict02(v, enc),
+        D::SharedDict(v) => codecs.write_shared_dict02(v, shared, enc),
     }
 }

--- a/rust/mlt-core/src/encoder/property/shared_dict.rs
+++ b/rust/mlt-core/src/encoder/property/shared_dict.rs
@@ -257,6 +257,18 @@ impl StagedSharedDictItem {
             .map(|&range| decode_shared_dict_range(range).is_some())
     }
 
+    /// The mask describing this child's nulls, or [`None`] when it has none to describe.
+    ///
+    /// A child with nothing to mask writes no presence bits at all, so it must not
+    /// claim one of the layer's shared bitfields either.
+    /// The v2 planner and writer both decide through this, so they cannot disagree.
+    #[cfg(feature = "unstable-v2")]
+    pub(crate) fn optional_presence(&self) -> Option<Vec<bool>> {
+        let presence: Vec<bool> = self.presence_bools().collect();
+        let optional = self.has_presence && presence.iter().any(|&p| !p);
+        optional.then_some(presence)
+    }
+
     pub fn dense_spans(&self) -> impl Iterator<Item = (u32, u32)> + '_ {
         self.ranges
             .iter()

--- a/rust/mlt-core/src/encoder/property/shared_dict02.rs
+++ b/rust/mlt-core/src/encoder/property/shared_dict02.rs
@@ -10,7 +10,7 @@ use crate::codecs::front_coding::front_code;
 use crate::codecs::fsst::{compress_fsst_bytes, compress_fsst_with};
 use crate::decoder::stream::header02::{BlobLayout, Family, StrLayout};
 use crate::decoder::{ColumnType02, DataType02, Presence02, SharedDictKind};
-use crate::encoder::encode02::write_presence_bits;
+use crate::encoder::encode02::{SharedPresence, write_presence_bits};
 use crate::encoder::model::StreamCtx;
 use crate::encoder::property::shared_dict::collect_staged_shared_dict_spans;
 use crate::encoder::property::strings::{
@@ -38,6 +38,7 @@ impl Codecs {
     pub(crate) fn write_shared_dict02(
         &mut self,
         shared_dict: &StagedSharedDict,
+        shared: &SharedPresence,
         enc: &mut Encoder,
     ) -> MltResult<()> {
         let plain = group(shared_dict)?;
@@ -63,13 +64,13 @@ impl Codecs {
         alt.with(|enc| {
             begin_shared_dict02(enc, SharedDictKind::Plain, shared_dict)?;
             write_dict_tail02(&plain.entries, name, enc, self)?;
-            write_children02(shared_dict, &plain.codes, features, enc, self)
+            write_children02(shared_dict, &plain.codes, features, shared, enc, self)
         })?;
         alt.with(|enc| {
             begin_shared_dict02(enc, SharedDictKind::Plain, shared_dict)?;
             write_front_lengths02(&front, name, enc, self)?;
             write_blob02(&front.suffixes, BlobLayout::FrontCoded, enc)?;
-            write_children02(shared_dict, &sorted.codes, features, enc, self)
+            write_children02(shared_dict, &sorted.codes, features, shared, enc, self)
         })?;
         if let Some(ref raw) = fsst {
             alt.with(|enc| {
@@ -85,7 +86,7 @@ impl Codecs {
                     enc,
                     self,
                 )?;
-                write_children02(shared_dict, &plain.codes, features, enc, self)
+                write_children02(shared_dict, &plain.codes, features, shared, enc, self)
             })?;
         }
         if let Some(ref blob) = front_fsst {
@@ -101,7 +102,7 @@ impl Codecs {
                     enc,
                     self,
                 )?;
-                write_children02(shared_dict, &sorted.codes, features, enc, self)
+                write_children02(shared_dict, &sorted.codes, features, shared, enc, self)
             })?;
         }
         Ok(())
@@ -182,26 +183,28 @@ fn begin_shared_dict02(
 }
 
 /// Write each child: its type byte and name, its presence bitfield, then its codes.
+///
+/// A child whose mask the layer already stores as a shared bitfield names that one
+/// instead of repeating it, which is what keeps a wide dictionary from paying
+/// `ceil(feature_count/8)` bytes per child for masks its siblings already carry.
 fn write_children02(
     shared_dict: &StagedSharedDict,
     per_child_codes: &[Vec<u32>],
     features: u32,
+    shared: &SharedPresence,
     enc: &mut Encoder,
     codecs: &mut Codecs,
 ) -> MltResult<()> {
     for (item, child_codes) in shared_dict.items.iter().zip(per_child_codes) {
-        let presence: Vec<bool> = item.presence_bools().collect();
-        let optional = item.has_presence() && presence.iter().any(|&p| !p);
-        let where_ = if optional {
-            Presence02::Inline
-        } else {
-            Presence02::AllPresent
-        };
+        let presence = item.optional_presence();
+        let where_ = presence
+            .as_ref()
+            .map_or(Presence02::AllPresent, |mask| shared.nibble_for(mask));
         let data = enc.data_mut();
         data.push(ColumnType02::new(where_, DataType02::Str).to_byte());
         data.write_string(&item.suffix)?;
-        if optional {
-            write_presence_bits(enc.data_mut(), &presence);
+        if let (Presence02::Inline, Some(mask)) = (where_, &presence) {
+            write_presence_bits(enc.data_mut(), mask);
         }
 
         enc.count_context = u32::try_from(child_codes.len())?;

--- a/rust/mlt-core/tests/snapshots/tag02_roundtrip__strings__shared_dict_presence__shared_dict_child_presence_layout.snap
+++ b/rust/mlt-core/tests/snapshots/tag02_roundtrip__strings__shared_dict_presence__shared_dict_child_presence_layout.snap
@@ -1,0 +1,133 @@
+---
+source: mlt-core/tests/tag02_roundtrip.rs
+expression: dump_text(&l.encode(cfg_v2()).unwrap())
+---
+00000000                                                                     | layer[0] (152 B)
+00000000  96 01                                             ..               |   size: 150 (varint) - tag + body
+00000002  02                                                .                |   tag: 0x02 -> Tag02
+00000003  0a 74 65 73 74 5f 6c 61 79 65 72                  .test_layer      |   name: "test_layer"
+0000000e  80 20                                             .                |   extent: 4096
+00000010  06                                                .                |   feature_count: 6
+00000011  10                                                .                |   layout: 0x10 Points
+                                                                             |     └ bit 7 = 0 -> reserved = 0
+                                                                             |     └ bits 6-4 = 001 -> shared presence bitfields = 1
+                                                                             |     └ bits 3-0 = 0000 -> geometry layout = Points
+00000012                                                                     |   shared_presence (1 B)
+00000012  2d                                                -                |     present[0] [Present Bool(None)/None, 6 values, 1 B]
+                                                                             |       decoded: 6 present-bits: 101101
+00000013                                                                     |   geometry (19 B)
+00000013                                                                     |     types (4 B)
+00000013                                                                     |       header (2 B)
+00000013  30                                                0                |         encoding: 0x30 logical=DeltaRle physical=implied
+                                                                             |           └ bit 7 = 0 -> has_explicit_count = false -> 6 values from context
+                                                                             |           └ bits 6-4 = 011 -> logical = DeltaRle, numbered for a v2 integer stream
+                                                                             |           └ bits 3-2 = 00 -> physical = implied
+                                                                             |           └ bits 1-0 = 00 -> extension = 0
+00000014  02                                                .                |         byte_length: 2
+00000015  06 00                                             ..               |       data [Length(VarBinary) Int(DeltaRle(Interleaved { num_rle_values: 6 }))/VarInt, 6 values, 2 B]
+                                                                             |         decoded: [0, 0, 0, 0, 0, 0]
+00000017                                                                     |     vertices (15 B)
+00000017                                                                     |       header (3 B)
+00000017  a8                                                .                |         encoding: 0xA8 logical=CwDelta physical=VarInt
+                                                                             |           └ bit 7 = 1 -> has_explicit_count = true -> a num_values varint follows
+                                                                             |           └ bits 6-4 = 010 -> logical = CwDelta, numbered for a v2 vertex stream
+                                                                             |           └ bits 3-2 = 10 -> physical = VarInt
+                                                                             |           └ bits 1-0 = 00 -> extension = 0
+00000018  0c                                                .                |         num_values: 12
+00000019  0c                                                .                |         byte_length: 12
+0000001a  00 00 02 00 02 00 02 00 02 00 02 00               ............     |       data [Data(Vertex) Vertex(ComponentwiseDelta)/VarInt, 12 values, 12 B]
+                                                                             |         decoded: [0, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0]
+00000026  02                                                .                |   column_count: 2
+00000027                                                                     |   columns (113 B)
+00000027                                                                     |     column[0] SharedDict "name:" (103 B)
+00000027  0f                                                .                |       type: 0x0F Plain SharedDict
+                                                                             |         └ bits 7-4 = 0000 -> corpus = Plain
+                                                                             |         └ bits 3-0 = 1111 -> data type = SharedDict
+00000028  05 6e 61 6d 65 3a                                 .name:           |       name: "name:"
+0000002e  03                                                .                |       child_count: 3
+0000002f                                                                     |       dict_lengths (5 B)
+0000002f                                                                     |         header (3 B)
+0000002f  98                                                .                |           encoding: 0x98 logical=Delta physical=VarInt
+                                                                             |             └ bit 7 = 1 -> has_explicit_count = true -> a num_values varint follows
+                                                                             |             └ bits 6-4 = 001 -> logical = Delta, numbered for a v2 integer stream
+                                                                             |             └ bits 3-2 = 10 -> physical = VarInt
+                                                                             |             └ bits 1-0 = 00 -> extension = 0
+00000030  02                                                .                |           num_values: 2
+00000031  02                                                .                |           byte_length: 2
+00000032  3c 00                                             <.               |         data [Length(Dictionary) Int(Delta)/VarInt, 2 values, 2 B]
+                                                                             |           decoded: [30, 30]
+00000034                                                                     |       dict_values (62 B)
+00000034                                                                     |         header (2 B)
+00000034  04                                                .                |           encoding: 0x04 logical=None physical=WithLen
+                                                                             |             └ bit 7 = 0 -> has_explicit_count = false -> a blob's byte length is its value count
+                                                                             |             └ bits 6-4 = 000 -> logical = None, numbered for a v2 byte blob
+                                                                             |             └ bits 3-2 = 01 -> physical = WithLen
+                                                                             |             └ bits 1-0 = 00 -> extension = 0
+00000035  3c                                                <                |           byte_length: 60
+00000036  41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41   AAAAAAAAAAAAAAAA |         data [Data(Shared) Int(None)/None, 60 values, 60 B]
+00000046  41 41 41 41 41 41 41 41 41 41 41 41 41 41 42 42   AAAAAAAAAAAAAABB | 
+00000056  42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42   BBBBBBBBBBBBBBBB | 
+00000066  42 42 42 42 42 42 42 42 42 42 42 42               BBBBBBBBBBBB     | 
+                                                                             |           decoded: utf-8 "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+00000072                                                                     |       child[0] "0" (9 B)
+00000072  2b                                                +                |         type: 0x2B Shared(0) Str
+                                                                             |           └ bits 7-4 = 0010 -> presence = Shared(0)
+                                                                             |           └ bits 3-0 = 1011 -> data type = Str
+00000073  01 30                                             .0               |         name: "0"
+00000075                                                                     |         codes (6 B)
+00000075                                                                     |           header (2 B)
+00000075  19                                                .                |             encoding: 0x19 logical=Delta physical=VarInt
+                                                                             |               └ bit 7 = 0 -> has_explicit_count = false -> 4 values from context
+                                                                             |               └ bits 6-4 = 001 -> logical = Delta, numbered for a v2 string column
+                                                                             |               └ bits 3-2 = 10 -> physical = VarInt
+                                                                             |               └ bits 1-0 = 01 -> string layout = Dict
+00000076  04                                                .                |             byte_length: 4
+00000077  00 00 02 00                                       ....             |           data [Offset(String) Int(Delta)/VarInt, 4 values, 4 B]
+                                                                             |             decoded: [0, 0, 1, 1]
+0000007b                                                                     |       child[1] "1" (9 B)
+0000007b  2b                                                +                |         type: 0x2B Shared(0) Str
+                                                                             |           └ bits 7-4 = 0010 -> presence = Shared(0)
+                                                                             |           └ bits 3-0 = 1011 -> data type = Str
+0000007c  01 31                                             .1               |         name: "1"
+0000007e                                                                     |         codes (6 B)
+0000007e                                                                     |           header (2 B)
+0000007e  19                                                .                |             encoding: 0x19 logical=Delta physical=VarInt
+                                                                             |               └ bit 7 = 0 -> has_explicit_count = false -> 4 values from context
+                                                                             |               └ bits 6-4 = 001 -> logical = Delta, numbered for a v2 string column
+                                                                             |               └ bits 3-2 = 10 -> physical = VarInt
+                                                                             |               └ bits 1-0 = 01 -> string layout = Dict
+0000007f  04                                                .                |             byte_length: 4
+00000080  00 00 02 00                                       ....             |           data [Offset(String) Int(Delta)/VarInt, 4 values, 4 B]
+                                                                             |             decoded: [0, 0, 1, 1]
+00000084                                                                     |       child[2] "2" (10 B)
+00000084  1b                                                .                |         type: 0x1B Inline Str
+                                                                             |           └ bits 7-4 = 0001 -> presence = Inline
+                                                                             |           └ bits 3-0 = 1011 -> data type = Str
+00000085  01 32                                             .2               |         name: "2"
+00000087  33                                                3                |         present [Present Bool(None)/None, 6 values, 1 B]
+                                                                             |           decoded: 6 present-bits: 110011
+00000088                                                                     |         codes (6 B)
+00000088                                                                     |           header (2 B)
+00000088  09                                                .                |             encoding: 0x09 logical=None physical=VarInt
+                                                                             |               └ bit 7 = 0 -> has_explicit_count = false -> 4 values from context
+                                                                             |               └ bits 6-4 = 000 -> logical = None, numbered for a v2 string column
+                                                                             |               └ bits 3-2 = 10 -> physical = VarInt
+                                                                             |               └ bits 1-0 = 01 -> string layout = Dict
+00000089  04                                                .                |             byte_length: 4
+0000008a  00 01 00 01                                       ....             |           data [Offset(String) Int(None)/VarInt, 4 values, 4 B]
+                                                                             |             decoded: [0, 1, 0, 1]
+0000008e                                                                     |     column[1] OptU32 "n0" (10 B)
+0000008e  26                                                &                |       type: 0x26 Shared(0) U32
+                                                                             |         └ bits 7-4 = 0010 -> presence = Shared(0)
+                                                                             |         └ bits 3-0 = 0110 -> data type = U32
+0000008f  02 6e 30                                          .n0              |       name: "n0"
+00000092                                                                     |       data (6 B)
+00000092                                                                     |         header (2 B)
+00000092  18                                                .                |           encoding: 0x18 logical=Delta physical=VarInt
+                                                                             |             └ bit 7 = 0 -> has_explicit_count = false -> 4 values from context
+                                                                             |             └ bits 6-4 = 001 -> logical = Delta, numbered for a v2 integer stream
+                                                                             |             └ bits 3-2 = 10 -> physical = VarInt
+                                                                             |             └ bits 1-0 = 00 -> extension = 0
+00000093  04                                                .                |           byte_length: 4
+00000094  00 04 02 04                                       ....             |         data [Data(None) Int(Delta)/VarInt, 4 values, 4 B]
+                                                                             |           decoded: [0, 2, 3, 5]

--- a/rust/mlt-core/tests/tag02_roundtrip.rs
+++ b/rust/mlt-core/tests/tag02_roundtrip.rs
@@ -970,6 +970,137 @@ mod strings {
         let l = column(fsst_dict_values(6).into_iter().map(Some));
         assert_snapshot!(dump_text(&l.encode(cfg_v2()).unwrap()));
     }
+
+    mod shared_dict_presence {
+        use super::*;
+
+        /// A shared-dictionary child per mask, holding a [`dict_values`] entry at each `'1'`.
+        ///
+        /// Every mask must cover an even and an odd index, so all children hold the same two
+        /// distinct values and the encoder groups them into one dictionary.
+        fn dict_children(masks: &[&str]) -> Vec<(String, Vec<PropValue>)> {
+            let values = dict_values(masks[0].len());
+            masks
+                .iter()
+                .enumerate()
+                .map(|(child, mask)| {
+                    let column = mask
+                        .bytes()
+                        .zip(&values)
+                        .map(|(b, v)| PropValue::Str((b == b'1').then(|| v.clone())))
+                        .collect();
+                    (format!("name:{child}"), column)
+                })
+                .collect()
+        }
+
+        /// A layer of one shared-dictionary column over `dict_masks`, then a `u32` column per
+        /// mask in `scalar_masks`.
+        fn dict_layer(dict_masks: &[&str], scalar_masks: &[&str]) -> TileLayer {
+            let mut props = dict_children(dict_masks);
+            for (i, mask) in scalar_masks.iter().enumerate() {
+                props.push((format!("n{i}"), opt_col(mask)));
+            }
+            let borrowed: Vec<(&str, Vec<PropValue>)> = props
+                .iter()
+                .map(|(name, values)| (name.as_str(), values.clone()))
+                .collect();
+            layer(points(dict_masks[0]), None, &borrowed)
+        }
+
+        /// How often `needle` annotates the v2 dump of `l`.
+        fn count(l: &TileLayer, needle: &str) -> usize {
+            dump_text(&l.clone().encode(cfg_v2()).unwrap())
+                .matches(needle)
+                .count()
+        }
+
+        #[test]
+        fn dict_children_with_the_same_nulls_share_one_presence_bitfield() {
+            let l = dict_layer(&["101101", "101101", "101101"], &[]);
+            assert_differential(&l);
+
+            assert_eq!(count(&l, "shared presence bitfields = 1"), 1);
+            assert_eq!(count(&l, "presence = Shared(0)"), 3);
+            assert_eq!(count(&l, "[Present "), 1);
+        }
+
+        #[test]
+        fn a_mask_only_one_dict_child_has_stays_inline() {
+            let l = dict_layer(&["101101", "101101", "110011"], &[]);
+            assert_differential(&l);
+
+            assert_eq!(count(&l, "shared presence bitfields = 1"), 1);
+            assert_eq!(count(&l, "presence = Shared(0)"), 2);
+            assert_eq!(count(&l, "presence = Inline"), 1);
+            assert_eq!(count(&l, "[Present "), 2);
+        }
+
+        #[test]
+        fn a_dict_child_without_nulls_stays_all_present() {
+            let l = dict_layer(&["111111", "101101", "101101"], &[]);
+            assert_differential(&l);
+
+            assert_eq!(count(&l, "shared presence bitfields = 1"), 1);
+            assert_eq!(count(&l, "presence = AllPresent"), 1);
+            assert_eq!(count(&l, "presence = Shared(0)"), 2);
+            assert_eq!(count(&l, "[Present "), 1);
+        }
+
+        #[test]
+        fn a_mask_a_dict_child_and_a_scalar_column_share_costs_one_slot() {
+            // Neither mask is shared within the dictionary, so both slots are earned
+            // only by counting the dict children alongside the scalar columns.
+            let l = dict_layer(&["101101", "110011"], &["101101", "110011"]);
+            assert_differential(&l);
+
+            assert_eq!(count(&l, "shared presence bitfields = 2"), 1);
+            assert_eq!(count(&l, "presence = Shared(0)"), 2);
+            assert_eq!(count(&l, "presence = Shared(1)"), 2);
+            assert_eq!(count(&l, "[Present "), 2);
+        }
+
+        #[test]
+        fn dict_children_compete_for_the_seven_slots_the_layout_byte_allows() {
+            // Eight masks, each held by two children: one group has to lose the tie-break.
+            let masks: Vec<String> = (0..8)
+                .map(|i| {
+                    let mut mask = vec![b'0'; 9];
+                    mask[0] = b'1';
+                    mask[1] = b'1';
+                    if i > 0 {
+                        mask[i + 1] = b'1';
+                    }
+                    String::from_utf8(mask).unwrap()
+                })
+                .collect();
+            let paired: Vec<&str> = masks
+                .iter()
+                .flat_map(|mask| [mask.as_str(), mask.as_str()])
+                .collect();
+            let l = dict_layer(&paired, &[]);
+            assert_differential(&l);
+
+            assert_eq!(count(&l, "shared presence bitfields = 7"), 1);
+            assert_eq!(count(&l, "presence = Inline"), 2);
+            assert_eq!(count(&l, "[Present "), 9);
+        }
+
+        #[test]
+        fn which_masks_win_a_slot_does_not_depend_on_hash_map_order() {
+            let l = dict_layer(&["101101", "101101", "110011", "110011", "111101"], &[]);
+            let first = l.clone().encode(cfg_v2()).unwrap();
+            let second = l.encode(cfg_v2()).unwrap();
+            assert_eq!(first, second);
+        }
+
+        #[test]
+        fn shared_dict_child_presence_layout() {
+            let l = dict_layer(&["101101", "101101", "110011"], &["101101"]);
+            assert_differential(&l);
+            assert_snapshot!(dump_text(&l.encode(cfg_v2()).unwrap()));
+        }
+    }
 }
 
 mod float_codecs {


### PR DESCRIPTION
Extends v2's per-layer shared presence-bitfield dedup to shared-dictionary children, which shrinks 1655 Berlin tiles from +2.03% to +0.075% versus v1.
