### PR TITLE
feat(rust): scrollbars on every mlt ui panel and a sideways tree scroll

### DIFF
--- a/rust/mlt/README.md
+++ b/rust/mlt/README.md
@@ -64,6 +64,8 @@ Features:
   - "All" - every layer, with layer and feature counts and the tile's geometry types
   - Individual layers - the layer's features, with each property's value types and the layer's geometry types
   - Individual features - the feature's properties and geometry statistics
+  - Every panel scrolls and shows a scrollbar when its content does not fit
+  - The tree also scrolls sideways with `Shift+Left`/`Shift+Right` or a sideways mouse scroll
   - Hovered rows are highlighted with underlined green text
 - **Map Panel (right)**: Visual representation of the geometries
   - Shows the extent boundary as a thin gray rectangle

--- a/rust/mlt/src/ui/mod.rs
+++ b/rust/mlt/src/ui/mod.rs
@@ -78,6 +78,8 @@ pub const STYLE_BOLD: Style = Style::new().add_modifier(Modifier::BOLD);
 
 /// Throttle hover-driven redraws so mouse move over map doesn't flood the loop
 const HOVER_REDRAW_THROTTLE: Duration = Duration::from_millis(32);
+/// Columns the feature tree moves per sideways scroll step.
+const TREE_HSCROLL_STEP: u16 = 4;
 
 #[derive(Args)]
 pub struct UiArgs {
@@ -528,6 +530,14 @@ fn handle_key(app: &mut App, key: KeyEvent) -> bool {
             app.open_help();
         }
         KeyCode::Enter => app.handle_enter(),
+        KeyCode::Right if key.modifiers.contains(KeyModifiers::SHIFT) => {
+            app.tree_hscroll = app.tree_hscroll.saturating_add(TREE_HSCROLL_STEP);
+            app.invalidate();
+        }
+        KeyCode::Left if key.modifiers.contains(KeyModifiers::SHIFT) => {
+            app.tree_hscroll = app.tree_hscroll.saturating_sub(TREE_HSCROLL_STEP);
+            app.invalidate();
+        }
         KeyCode::Char('+' | '=') | KeyCode::Right => app.handle_plus(),
         KeyCode::Char('-') => app.handle_minus(),
         KeyCode::Char('*') => app.handle_star(),
@@ -1165,6 +1175,14 @@ fn handle_mouse(
             }
             if app.mode == ViewMode::LayerOverview {
                 if areas
+                    .geom
+                    .is_some_and(|a| point_in_rect(mouse.column, mouse.row, a))
+                {
+                    app.geometry_scroll = scroll_by(app.geometry_scroll, step, up);
+                    app.invalidate();
+                    return Ok(());
+                }
+                if areas
                     .props
                     .is_some_and(|a| point_in_rect(mouse.column, mouse.row, a))
                 {
@@ -1342,7 +1360,16 @@ fn handle_mouse(
                 }
             }
         }
-        MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => {}
+        MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => {
+            if app.mode == ViewMode::LayerOverview
+                && let Some(area) = areas.tree
+                && point_in_rect(mouse.column, mouse.row, area)
+            {
+                let left = matches!(mouse.kind, MouseEventKind::ScrollLeft);
+                app.tree_hscroll = scroll_by(app.tree_hscroll, TREE_HSCROLL_STEP, left);
+                app.invalidate();
+            }
+        }
     }
     Ok(())
 }

--- a/rust/mlt/src/ui/rendering/files.rs
+++ b/rust/mlt/src/ui/rendering/files.rs
@@ -9,6 +9,7 @@ use usize_cast::{FromUsize as _, IntoUsize as _};
 
 use crate::ls::{LsRow, NA, na, path_display, row_cells_6};
 use crate::ui::rendering::map;
+use crate::ui::rendering::scrollbar::{Scroll, render_vscrollbar, wrapped_rows};
 use crate::ui::state::App;
 use crate::ui::{
     CLR_DIMMED, CLR_HINT, CLR_HOVERED, STYLE_BOLD, STYLE_LABEL, STYLE_SELECTED, block_with_title,
@@ -78,6 +79,7 @@ pub fn render_file_browser(f: &mut Frame<'_>, area: Rect, app: &mut App) {
         .iter()
         .map(|&i| Row::new(row_cells_6(&app.files[i], base).map(Cell::from)))
         .collect();
+    let row_count = rows.len();
 
     let status = app.scan_status();
     let sort_hint = if app.data_loaded() {
@@ -110,6 +112,15 @@ pub fn render_file_browser(f: &mut Frame<'_>, area: Rect, app: &mut App) {
         .highlight_symbol(">> ")
         .highlight_spacing(HighlightSpacing::Always);
     f.render_stateful_widget(table, area, &mut app.file_list_state);
+    render_vscrollbar(
+        f,
+        area,
+        Scroll {
+            content: row_count,
+            view: app.file_table_inner_height,
+            pos: app.file_list_state.offset(),
+        },
+    );
 }
 
 pub fn render_file_filter_panel(f: &mut Frame<'_>, area: Rect, app: &mut App) {
@@ -182,13 +193,14 @@ pub fn render_file_filter_panel(f: &mut Frame<'_>, area: Rect, app: &mut App) {
         lines.push(Line::from("(loading…)"));
     }
 
-    let inner = area.height.saturating_sub(2);
-    let max = u16::try_from(lines.len().saturating_sub(inner.into_usize())).unwrap_or(0);
-    app.filter_scroll = app.filter_scroll.min(max);
+    let inner = area.height.saturating_sub(2).into_usize();
+    let content = lines.len();
+    app.filter_scroll = app.filter_scroll.min(Scroll::max_pos(content, inner));
     let para = Paragraph::new(lines)
         .block(block_with_title("Filter (click to toggle)"))
         .scroll((app.filter_scroll, 0));
     f.render_widget(para, area);
+    render_vscrollbar(f, area, Scroll::new(content, inner, app.filter_scroll));
 }
 
 pub fn render_file_info_panel(f: &mut Frame<'_>, area: Rect, app: &mut App) {
@@ -272,13 +284,15 @@ pub fn render_file_info_panel(f: &mut Frame<'_>, area: Rect, app: &mut App) {
         vec![Line::from("Select a file to view details")]
     };
 
-    let inner = area.height.saturating_sub(2).into_usize();
-    let max = u16::try_from(lines.len().saturating_sub(inner)).unwrap_or(0);
-    app.file_info_scroll = app.file_info_scroll.min(max);
+    let inner_h = area.height.saturating_sub(2).into_usize();
+    let inner_w = area.width.saturating_sub(2).into_usize();
+    let rows = wrapped_rows(&lines, inner_w);
+    app.file_info_scroll = app.file_info_scroll.min(Scroll::max_pos(rows, inner_h));
 
     let para = Paragraph::new(lines)
         .block(block_with_title("File Info"))
         .wrap(Wrap { trim: false })
         .scroll((app.file_info_scroll, 0));
     f.render_widget(para, area);
+    render_vscrollbar(f, area, Scroll::new(rows, inner_h, app.file_info_scroll));
 }

--- a/rust/mlt/src/ui/rendering/help.rs
+++ b/rust/mlt/src/ui/rendering/help.rs
@@ -5,6 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Padding, Paragraph, Wrap};
 use usize_cast::IntoUsize as _;
 
+use crate::ui::rendering::scrollbar::{Scroll, render_vscrollbar};
 use crate::ui::state::{App, ViewMode};
 use crate::ui::{
     CLR_BAD_WINDING, CLR_CONTEXT_FEATURE, CLR_CONTEXT_LAYER, CLR_DIMMED, CLR_EXTENT, CLR_HOVERED,
@@ -64,7 +65,8 @@ pub fn render_help_overlay(f: &mut Frame<'_>, app: &mut App) {
         ViewMode::LayerOverview => help_layer_overview(),
         ViewMode::MbtilesMap => help_mbtiles_map(),
     };
-    let height = u16::try_from(lines.len())
+    let total = lines.len();
+    let height = u16::try_from(total)
         .unwrap_or(u16::MAX)
         .saturating_add(2)
         .min(area.height.saturating_sub(2));
@@ -75,9 +77,8 @@ pub fn render_help_overlay(f: &mut Frame<'_>, app: &mut App) {
         width,
         height,
     );
-    let inner = height.saturating_sub(2);
-    let max = u16::try_from(lines.len().saturating_sub(inner.into_usize())).unwrap_or(0);
-    app.help_scroll = app.help_scroll.min(max);
+    let inner = height.saturating_sub(2).into_usize();
+    app.help_scroll = app.help_scroll.min(Scroll::max_pos(total, inner));
     f.render_widget(ratatui::widgets::Clear, popup);
     let para = Paragraph::new(lines)
         .block(block_with_title(
@@ -85,6 +86,7 @@ pub fn render_help_overlay(f: &mut Frame<'_>, app: &mut App) {
         ))
         .scroll((app.help_scroll, 0));
     f.render_widget(para, popup);
+    render_vscrollbar(f, popup, Scroll::new(total, inner, app.help_scroll));
 }
 
 fn heading(text: &str) -> Line<'static> {
@@ -164,6 +166,7 @@ fn help_layer_overview() -> Vec<Line<'static>> {
         key("-", "Collapse (or jump to parent)"),
         key("*", "Expand/collapse all layers"),
         key("Left", "Jump to parent node"),
+        key("Shift+Left/Right", "Scroll the tree sideways"),
         key("Ctrl+h / Ctrl+l", "Resize left/right split"),
         key("Shift+J / Shift+K", "Resize top/bottom split"),
         Line::from(""),
@@ -173,7 +176,8 @@ fn help_layer_overview() -> Vec<Line<'static>> {
         key("Hover tree/map", "Highlight the layer, feature, or part"),
         key("", "at the current level"),
         key("Click on map", "Select the hovered item"),
-        key("Scroll panels", "Scroll tree/properties"),
+        key("Scroll panels", "Scroll tree/properties/geometry"),
+        key("Scroll sideways", "Scroll the tree horizontally"),
         key("Drag dividers", "Resize panels"),
         Line::from(""),
         heading("Map Colors"),

--- a/rust/mlt/src/ui/rendering/layers.rs
+++ b/rust/mlt/src/ui/rendering/layers.rs
@@ -12,6 +12,7 @@ use ratatui::widgets::{Paragraph, Wrap};
 use usize_cast::IntoUsize as _;
 
 use crate::ui::mbt::MbtTileData;
+use crate::ui::rendering::scrollbar::{Scroll, render_hscrollbar, render_vscrollbar, wrapped_rows};
 use crate::ui::state::{App, TreeItem, ViewMode};
 use crate::ui::tile::{geometry_coord_count, polygon_coord_count};
 use crate::ui::{
@@ -118,14 +119,24 @@ pub fn render_tree_panel(f: &mut Frame<'_>, area: Rect, app: &mut App) {
         }
         ViewMode::FileBrowser | ViewMode::MbtilesMap => "Features".into(),
     };
-    let inner = area.height.saturating_sub(2).into_usize();
-    app.tree_inner_height = inner;
-    let max = u16::try_from(app.tree_items.len().saturating_sub(inner)).unwrap_or(0);
-    app.tree_scroll = app.tree_scroll.min(max);
+    let inner_h = area.height.saturating_sub(2).into_usize();
+    let inner_w = area.width.saturating_sub(2).into_usize();
+    app.tree_inner_height = inner_h;
+    let content_w = lines.iter().map(Line::width).max().unwrap_or(0);
+    app.tree_scroll = app
+        .tree_scroll
+        .min(Scroll::max_pos(app.tree_items.len(), inner_h));
+    app.tree_hscroll = app.tree_hscroll.min(Scroll::max_pos(content_w, inner_w));
     let para = Paragraph::new(lines)
         .block(block_with_title(title))
-        .scroll((app.tree_scroll, 0));
+        .scroll((app.tree_scroll, app.tree_hscroll));
     f.render_widget(para, area);
+    render_vscrollbar(
+        f,
+        area,
+        Scroll::new(app.tree_items.len(), inner_h, app.tree_scroll),
+    );
+    render_hscrollbar(f, area, Scroll::new(content_w, inner_w, app.tree_hscroll));
 }
 
 fn feature_property_lines(feat: &Feature) -> Vec<Line<'static>> {
@@ -258,6 +269,7 @@ fn render_properties_top(f: &mut Frame<'_>, area: Rect, app: &mut App) {
     let (target, hover) = info_target(app);
     if app.last_properties_key.as_ref() != Some(&target) {
         app.properties_scroll = 0;
+        app.geometry_scroll = 0;
         app.last_properties_key = Some(target.clone());
     }
     let suffix = if hover { ", hover" } else { "" };
@@ -272,14 +284,16 @@ fn render_properties_top(f: &mut Frame<'_>, area: Rect, app: &mut App) {
             feature_property_lines(app.feature(*layer, *feat)),
         ),
     };
-    let inner = area.height.saturating_sub(2);
-    let max = u16::try_from(lines.len().saturating_sub(inner.into_usize())).unwrap_or(0);
-    app.properties_scroll = app.properties_scroll.min(max);
+    let inner_h = area.height.saturating_sub(2).into_usize();
+    let inner_w = area.width.saturating_sub(2).into_usize();
+    let rows = wrapped_rows(&lines, inner_w);
+    app.properties_scroll = app.properties_scroll.min(Scroll::max_pos(rows, inner_h));
     let para = Paragraph::new(lines)
         .block(block_with_title(title))
         .wrap(Wrap { trim: true })
         .scroll((app.properties_scroll, 0));
     f.render_widget(para, area);
+    render_vscrollbar(f, area, Scroll::new(rows, inner_h, app.properties_scroll));
 }
 
 fn info_point(lines: &mut Vec<Line<'static>>, p: Point<i32>) {
@@ -400,14 +414,16 @@ fn tessellation_line(
 /// Renders the left panel for `MbtilesMap` mode: shows hovered feature properties only.
 pub fn render_mbtiles_hover_panel(f: &mut Frame<'_>, area: Rect, app: &mut App) {
     let (title, lines) = mbt_hover_title_and_lines(app);
-    let inner = area.height.saturating_sub(2).into_usize();
-    let max = u16::try_from(lines.len().saturating_sub(inner)).unwrap_or(0);
-    app.properties_scroll = app.properties_scroll.min(max);
+    let inner_h = area.height.saturating_sub(2).into_usize();
+    let inner_w = area.width.saturating_sub(2).into_usize();
+    let rows = wrapped_rows(&lines, inner_w);
+    app.properties_scroll = app.properties_scroll.min(Scroll::max_pos(rows, inner_h));
     let para = Paragraph::new(lines)
         .block(block_with_title(title))
         .wrap(Wrap { trim: true })
         .scroll((app.properties_scroll, 0));
     f.render_widget(para, area);
+    render_vscrollbar(f, area, Scroll::new(rows, inner_h, app.properties_scroll));
 }
 
 fn mbt_hover_title_and_lines(app: &App) -> (String, Vec<Line<'static>>) {
@@ -452,7 +468,7 @@ fn mbt_hover_title_and_lines(app: &App) -> (String, Vec<Line<'static>>) {
     (title, feature_property_lines(feat))
 }
 
-fn render_geometry_stats(f: &mut Frame<'_>, area: Rect, app: &App) {
+fn render_geometry_stats(f: &mut Frame<'_>, area: Rect, app: &mut App) {
     let (target, _) = info_target(app);
     let (title, lines) = match target {
         TreeItem::All => (
@@ -475,8 +491,14 @@ fn render_geometry_stats(f: &mut Frame<'_>, area: Rect, app: &App) {
         }
     };
 
+    let inner_h = area.height.saturating_sub(2).into_usize();
+    let inner_w = area.width.saturating_sub(2).into_usize();
+    let rows = wrapped_rows(&lines, inner_w);
+    app.geometry_scroll = app.geometry_scroll.min(Scroll::max_pos(rows, inner_h));
     let para = Paragraph::new(lines)
         .block(block_with_title(title))
-        .wrap(Wrap { trim: false });
+        .wrap(Wrap { trim: false })
+        .scroll((app.geometry_scroll, 0));
     f.render_widget(para, area);
+    render_vscrollbar(f, area, Scroll::new(rows, inner_h, app.geometry_scroll));
 }

--- a/rust/mlt/src/ui/rendering/mod.rs
+++ b/rust/mlt/src/ui/rendering/mod.rs
@@ -2,3 +2,4 @@ pub mod files;
 pub mod help;
 pub mod layers;
 pub mod map;
+pub mod scrollbar;

--- a/rust/mlt/src/ui/rendering/scrollbar.rs
+++ b/rust/mlt/src/ui/rendering/scrollbar.rs
@@ -1,0 +1,69 @@
+use ratatui::Frame;
+use ratatui::layout::{Margin, Rect};
+use ratatui::text::Line;
+use ratatui::widgets::{Scrollbar, ScrollbarOrientation, ScrollbarState};
+use usize_cast::IntoUsize as _;
+
+/// How much of a panel's content is visible, in the panel's own scroll units.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Scroll {
+    pub content: usize,
+    pub view: usize,
+    pub pos: usize,
+}
+
+impl Scroll {
+    pub(crate) fn new(content: usize, view: usize, pos: u16) -> Self {
+        Self {
+            content,
+            view,
+            pos: pos.into_usize(),
+        }
+    }
+
+    /// Largest scroll position that still shows a full view of content.
+    pub(crate) fn max_pos(content: usize, view: usize) -> u16 {
+        u16::try_from(content.saturating_sub(view)).unwrap_or(u16::MAX)
+    }
+}
+
+/// Draw a scrollbar on the right border of a bordered panel when its content does not fit.
+pub(crate) fn render_vscrollbar(f: &mut Frame<'_>, area: Rect, scroll: Scroll) {
+    let bar = area.inner(Margin {
+        vertical: 1,
+        horizontal: 0,
+    });
+    render_scrollbar(f, bar, ScrollbarOrientation::VerticalRight, scroll);
+}
+
+/// Draw a scrollbar on the bottom border of a bordered panel when its content does not fit.
+pub(crate) fn render_hscrollbar(f: &mut Frame<'_>, area: Rect, scroll: Scroll) {
+    let bar = area.inner(Margin {
+        vertical: 0,
+        horizontal: 1,
+    });
+    render_scrollbar(f, bar, ScrollbarOrientation::HorizontalBottom, scroll);
+}
+
+/// The thumb spans the visible share of the content.
+fn render_scrollbar(
+    f: &mut Frame<'_>,
+    bar: Rect,
+    orientation: ScrollbarOrientation,
+    scroll: Scroll,
+) {
+    if scroll.content <= scroll.view {
+        return;
+    }
+    let mut state = ScrollbarState::new(scroll.content)
+        .position(scroll.pos)
+        .viewport_content_length(scroll.view);
+    f.render_stateful_widget(Scrollbar::new(orientation), bar, &mut state);
+}
+
+/// Rows the lines take when wrapped into `width` columns.
+/// Word wrapping can add a row or two, so this is a lower bound.
+pub(crate) fn wrapped_rows(lines: &[Line<'_>], width: usize) -> usize {
+    let width = width.max(1);
+    lines.iter().map(|l| l.width().max(1).div_ceil(width)).sum()
+}

--- a/rust/mlt/src/ui/state.rs
+++ b/rust/mlt/src/ui/state.rs
@@ -123,7 +123,9 @@ pub struct App {
     pub(crate) features_pct: u16,
     pub(crate) resizing: Option<ResizeHandle>,
     pub(crate) properties_scroll: u16,
+    pub(crate) geometry_scroll: u16,
     pub(crate) tree_scroll: u16,
+    pub(crate) tree_hscroll: u16,
     pub(crate) tree_inner_height: usize,
     pub(crate) last_properties_key: Option<TreeItem>,
     pub(crate) properties_pct: u16,
@@ -186,8 +188,10 @@ impl Default for App {
             features_pct: 50,
             resizing: None,
             properties_scroll: 0,
+            geometry_scroll: 0,
             last_properties_key: None,
             tree_scroll: 0,
+            tree_hscroll: 0,
             tree_inner_height: 0,
             properties_pct: 50,
             geometry_index: None,
@@ -395,6 +399,7 @@ impl App {
         self.selected_index = 0;
         self.hovered = None;
         self.tree_scroll = 0;
+        self.tree_hscroll = 0;
         self.invalidate_bounds();
         Ok(())
     }

--- a/rust/mlt/src/ui/tests.rs
+++ b/rust/mlt/src/ui/tests.rs
@@ -170,7 +170,7 @@ fn layer_overview_starts_on_all_layers() {
     "│                            ││     ⢸      ⢸                    ⢸       ⢀⠔⠁         ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⡖⠒⠒⠒⠒⠒⠒⢺⠒⠒⠒⠒⠒⡲⡎⠁           ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⡇      ⢸  ⢀⠔⠊ ⡇            ⢸        ⡇     │"
-    "└────────────────────────────┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
+    "└◄██████████════════════════►┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
     "┌Properties (all layers)─────┐│     ⢸⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⢉⠭⢻⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⡇     │"
     "│Layers: 3                   ││     ⢸      ⢸             ⡇  ⡠⠔⠁ ⢸      ⡇            ⢸        ⡇     │"
     "│Features: 6                 ││     ⢸      ⢸             ⣇⡠⠊    ⢸      ⡇            ⢸        ⡇     │"
@@ -180,11 +180,11 @@ fn layer_overview_starts_on_all_layers() {
     "│                            ││     ⢸      ⢸    ⡠⠒⠁             ⢸                   ⢸        ⡇     │"
     "└────────────────────────────┘│     ⢸  ⢸⠉⠉⠉⢹⠉⢉⠭⢻                ⢸                   ⢸        ⡇     │"
     "┌Geometry (all layers)───────┐│     ⢸  ⢸   ⡸⠴⠥⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼        ⡇     │"
-    "│Vertices: 29                ││     ⢸  ⢸⢀⡠⠊    ⢸                ⢸                            ⡇     │"
-    "│Point: 1                    ││     ⢸ ⢀⠜⠓⠒⠒⠒⠒⠒⠒⠚                ⢸                            ⡇     │"
-    "│LineString: 1               ││     ⠸⠮⠥⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
-    "│Polygon: 1                  ││                                                                    │"
-    "│MultiPoint: 1               ││                                                                    │"
+    "│Vertices: 29                ▲│     ⢸  ⢸⢀⡠⠊    ⢸                ⢸                            ⡇     │"
+    "│Point: 1                    █│     ⢸ ⢀⠜⠓⠒⠒⠒⠒⠒⠒⠚                ⢸                            ⡇     │"
+    "│LineString: 1               ║│     ⠸⠮⠥⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
+    "│Polygon: 1                  ║│                                                                    │"
+    "│MultiPoint: 1               ▼│                                                                    │"
     "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
     "#);
 }
@@ -210,7 +210,7 @@ fn keys_expand_a_layer_and_select_a_feature() {
     "│                            ││     ⢸      ⢸                    ⢸       ⢀⠔⠁         ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⡖⠒⠒⠒⠒⠒⠒⢺⠒⠒⠒⠒⠒⡲⡎⠁           ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⡇      ⢸  ⢀⠔⠊ ⡇            ⢸        ⡇     │"
-    "└────────────────────────────┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
+    "└◄██████████════════════════►┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
     "┌Properties (feat 0)─────────┐│     ⢸⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⢉⠭⢻⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⡇     │"
     "│class: lake                 ││     ⢸      ⢸             ⡇  ⡠⠔⠁ ⢸      ⡇            ⢸        ⡇     │"
     "│name: Loch                  ││     ⢸      ⢸             ⣇⡠⠊    ⢸      ⡇            ⢸        ⡇     │"
@@ -253,7 +253,7 @@ fn keys_drill_into_a_multipolygon_part() {
     "│                            ││     ⢸      ⢸                    ⢸       ⢀⠔⠁         ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⡖⠒⠒⠒⠒⠒⠒⢺⠒⠒⠒⠒⠒⡲⡎⠁           ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⡇      ⢸  ⢀⠔⠊ ⡇            ⢸        ⡇     │"
-    "└────────────────────────────┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
+    "└◄██████████════════════════►┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
     "┌Properties (feat 1)─────────┐│     ⢸⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⢉⠭⢻⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⡇     │"
     "│class: pond                 ││     ⢸      ⢸             ⡇  ⡠⠔⠁ ⢸      ⡇            ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⣇⡠⠊    ⢸      ⡇            ⢸        ⡇     │"
@@ -263,11 +263,11 @@ fn keys_drill_into_a_multipolygon_part() {
     "│                            ││     ⢸      ⢸    ⡠⠒⠁             ⢸                   ⢸        ⡇     │"
     "└────────────────────────────┘│     ⢸  ⢸⠉⠉⠉⢹⠉⢉⠭⢻                ⢸                   ⢸        ⡇     │"
     "┌Geometry────────────────────┐│     ⢸  ⢸   ⡸⠴⠥⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼        ⡇     │"
-    "│Component: part #0 of a     ││     ⢸  ⢸⢀⡠⠊    ⢸                ⢸                            ⡇     │"
-    "│MultiPolygon                ││     ⢸ ⢀⠜⠓⠒⠒⠒⠒⠒⠒⠚                ⢸                            ⡇     │"
-    "│Type: Polygon               ││     ⠸⠮⠥⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
-    "│Vertices: 5                 ││                                                                    │"
-    "│Rings: 1                    ││                                                                    │"
+    "│Component: part #0 of a     ▲│     ⢸  ⢸⢀⡠⠊    ⢸                ⢸                            ⡇     │"
+    "│MultiPolygon                █│     ⢸ ⢀⠜⠓⠒⠒⠒⠒⠒⠒⠚                ⢸                            ⡇     │"
+    "│Type: Polygon               █│     ⠸⠮⠥⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
+    "│Vertices: 5                 ║│                                                                    │"
+    "│Rings: 1                    ▼│                                                                    │"
     "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
     "#);
 }
@@ -292,7 +292,7 @@ fn star_expands_every_layer_and_end_jumps_to_the_last_row() {
     "│                            ││     ⢸      ⢸                    ⢸       ⢀⠔⠁         ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⡖⠒⠒⠒⠒⠒⠒⢺⠒⠒⠒⠒⠒⡲⡎⠁           ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⡇      ⢸  ⢀⠔⠊ ⡇            ⢸        ⡇     │"
-    "└────────────────────────────┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
+    "└◄██████████════════════════►┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
     "┌Properties (feat 1)─────────┐│     ⢸⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⢉⠭⢻⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⡇     │"
     "│name: Twin peaks            ││     ⢸      ⢸             ⡇  ⡠⠔⠁ ⢸      ⡇            ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⣇⡠⠊    ⢸      ⡇            ⢸        ⡇     │"
@@ -331,7 +331,7 @@ fn hovering_the_map_highlights_the_nearest_feature() {
     "│                            ││     ⢸      ⢸                    ⢸       ⢀⠔⠁         ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⡖⠒⠒⠒⠒⠒⠒⢺⠒⠒⠒⠒⠒⡲⡎⠁           ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⡇      ⢸  ⢀⠔⠊ ⡇            ⢸        ⡇     │"
-    "└────────────────────────────┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
+    "└◄██████████════════════════►┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
     "┌Properties (layer poi, hover┐│     ⢸⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⢉⠭⢻⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⡇     │"
     "│Features: 2                 ││     ⢸      ⢸             ⡇  ⡠⠔⠁ ⢸      ⡇            ⢸        ⡇     │"
     "│Properties: 2               ││     ⢸      ⢸             ⣇⡠⠊    ⢸      ⡇            ⢸        ⡇     │"
@@ -357,32 +357,32 @@ fn help_overlay_lists_the_layer_overview_keys() {
     insta::assert_snapshot!(render(&mut app), @r#"
     "┌sample.mlt - Enter/+/-:expan┐┌Map View────────────────────────────────────────────────────────────┐"
     "│>> All            ┌Help (↑/↓/scroll to navigate, any other key to close)───────┐                  │"
-    "│     Layer: water │Keyboard                                                    │                  │"
-    "│     Layer: roads │  ?  h  F1            Toggle this help                      │⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⢒⡲⡆     │"
-    "│     Layer: poi (2│  q  Ctrl+c           Quit                                  │ ⡤⠤⠤⠤⠤⠤⠤⢤⡔⠁ ⡇     │"
-    "│                  │  Esc                 Back to file browser                  │ ⡇    ⡠⠊⠁⡇  ⡇     │"
-    "│                  │  Up/Down  j/k        Navigate feature tree                 │⣀⣇⣀⣀⠔⠊   ⡇  ⡇     │"
-    "│                  │  PageUp/PageDown     Scroll by page                        │ ⣧⣒⣹⣀⣀⣀⣀⣀⡇  ⡇     │"
-    "│                  │  Home/End            Jump to first/last                    │⠊  ⢸        ⡇     │"
-    "│                  │  Enter               Expand/collapse layer or feature      │   ⢸        ⡇     │"
-    "│                  │  +  =  Right         Expand selected node                  │   ⢸        ⡇     │"
-    "│                  │  -                   Collapse (or jump to parent)          │   ⢸        ⡇     │"
-    "│                  │  *                   Expand/collapse all layers            │   ⢸        ⡇     │"
-    "│                  │  Left                Jump to parent node                   │   ⢸        ⡇     │"
-    "└──────────────────│  Ctrl+h / Ctrl+l     Resize left/right split               │   ⢸        ⡇     │"
-    "┌Properties (all la│  Shift+J / Shift+K   Resize top/bottom split               │⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⡇     │"
-    "│Layers: 3         │                                                            │   ⢸        ⡇     │"
-    "│Features: 6       │Mouse                                                       │   ⢸        ⡇     │"
-    "│water: 2 features │  Click tree item     Select (drill into level)             │   ⢸        ⡇     │"
-    "│roads: 2 features │  Double-click        Expand/collapse                       │   ⢸        ⡇     │"
-    "│poi: 2 features   │  Hover tree/map      Highlight the layer, feature, or part │   ⢸        ⡇     │"
-    "│                  │                      at the current level                  │   ⢸        ⡇     │"
-    "└──────────────────│  Click on map        Select the hovered item               │   ⢸        ⡇     │"
-    "┌Geometry (all laye│  Scroll panels       Scroll tree/properties                │⠤⠤⠤⠼        ⡇     │"
-    "│Vertices: 29      │  Drag dividers       Resize panels                         │            ⡇     │"
-    "│Point: 1          │                                                            │            ⡇     │"
-    "│LineString: 1     │Map Colors                                                  │⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
-    "│Polygon: 1        │  Magenta             Point                                 │                  │"
+    "│     Layer: water │Keyboard                                                    ▲                  │"
+    "│     Layer: roads │  ?  h  F1            Toggle this help                      █⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⢒⡲⡆     │"
+    "│     Layer: poi (2│  q  Ctrl+c           Quit                                  █ ⡤⠤⠤⠤⠤⠤⠤⢤⡔⠁ ⡇     │"
+    "│                  │  Esc                 Back to file browser                  █ ⡇    ⡠⠊⠁⡇  ⡇     │"
+    "│                  │  Up/Down  j/k        Navigate feature tree                 █⣀⣇⣀⣀⠔⠊   ⡇  ⡇     │"
+    "│                  │  PageUp/PageDown     Scroll by page                        █ ⣧⣒⣹⣀⣀⣀⣀⣀⡇  ⡇     │"
+    "│                  │  Home/End            Jump to first/last                    █⠊  ⢸        ⡇     │"
+    "│                  │  Enter               Expand/collapse layer or feature      █   ⢸        ⡇     │"
+    "│                  │  +  =  Right         Expand selected node                  █   ⢸        ⡇     │"
+    "│                  │  -                   Collapse (or jump to parent)          █   ⢸        ⡇     │"
+    "│                  │  *                   Expand/collapse all layers            ║   ⢸        ⡇     │"
+    "│                  │  Left                Jump to parent node                   ║   ⢸        ⡇     │"
+    "└◄██████████═══════│  Shift+Left/Right    Scroll the tree sideways              ║   ⢸        ⡇     │"
+    "┌Properties (all la│  Ctrl+h / Ctrl+l     Resize left/right split               ║⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⡇     │"
+    "│Layers: 3         │  Shift+J / Shift+K   Resize top/bottom split               ║   ⢸        ⡇     │"
+    "│Features: 6       │                                                            ║   ⢸        ⡇     │"
+    "│water: 2 features │Mouse                                                       ║   ⢸        ⡇     │"
+    "│roads: 2 features │  Click tree item     Select (drill into level)             ║   ⢸        ⡇     │"
+    "│poi: 2 features   │  Double-click        Expand/collapse                       ║   ⢸        ⡇     │"
+    "│                  │  Hover tree/map      Highlight the layer, feature, or part ║   ⢸        ⡇     │"
+    "└──────────────────│                      at the current level                  ║   ⢸        ⡇     │"
+    "┌Geometry (all laye│  Click on map        Select the hovered item               ║⠤⠤⠤⠼        ⡇     │"
+    "│Vertices: 29      │  Scroll panels       Scroll tree/properties/geometry       ║            ⡇     │"
+    "│Point: 1          │  Scroll sideways     Scroll the tree horizontally          ║            ⡇     │"
+    "│LineString: 1     │  Drag dividers       Resize panels                         ║⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
+    "│Polygon: 1        │                                                            ▼                  │"
     "│MultiPoint: 1     └────────────────────────────────────────────────────────────┘                  │"
     "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
     "#);
@@ -409,7 +409,7 @@ fn error_popup_shows_the_message_until_a_key_is_pressed() {
     "│                            ││     ⢸      ⢸                    ⢸       ⢀⠔⠁         ⢸        ⡇     │"
     "│         ┌ Unable to open broken.mlt ───────────────────────────────────────────────────┐   ⡇     │"
     "│         │                                                                              │   ⡇     │"
-    "└─────────│                           unexpected end of buffer                           │   ⡇     │"
+    "└◄████████│                           unexpected end of buffer                           │   ⡇     │"
     "┌Propertie│                                                                              │⠉⠉⠉⡇     │"
     "│Layers: 3│                                                                              │   ⡇     │"
     "│Features:└──────────────────────────────────────────────────────────────any key to close┘   ⡇     │"
@@ -419,11 +419,11 @@ fn error_popup_shows_the_message_until_a_key_is_pressed() {
     "│                            ││     ⢸      ⢸    ⡠⠒⠁             ⢸                   ⢸        ⡇     │"
     "└────────────────────────────┘│     ⢸  ⢸⠉⠉⠉⢹⠉⢉⠭⢻                ⢸                   ⢸        ⡇     │"
     "┌Geometry (all layers)───────┐│     ⢸  ⢸   ⡸⠴⠥⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼        ⡇     │"
-    "│Vertices: 29                ││     ⢸  ⢸⢀⡠⠊    ⢸                ⢸                            ⡇     │"
-    "│Point: 1                    ││     ⢸ ⢀⠜⠓⠒⠒⠒⠒⠒⠒⠚                ⢸                            ⡇     │"
-    "│LineString: 1               ││     ⠸⠮⠥⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
-    "│Polygon: 1                  ││                                                                    │"
-    "│MultiPoint: 1               ││                                                                    │"
+    "│Vertices: 29                ▲│     ⢸  ⢸⢀⡠⠊    ⢸                ⢸                            ⡇     │"
+    "│Point: 1                    █│     ⢸ ⢀⠜⠓⠒⠒⠒⠒⠒⠒⠚                ⢸                            ⡇     │"
+    "│LineString: 1               ║│     ⠸⠮⠥⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
+    "│Polygon: 1                  ║│                                                                    │"
+    "│MultiPoint: 1               ▼│                                                                    │"
     "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
     "#);
     press(&mut app, KeyCode::Enter);
@@ -459,24 +459,24 @@ fn file_browser_lists_the_directory() {
     "│                                                                    ││                            │"
     "│                                                                    │└────────────────────────────┘"
     "│                                                                    │┌Filter (click to toggle)────┐"
-    "│                                                                    ││[Reset filters]             │"
-    "│                                                                    ││                            │"
-    "│                                                                    ││Extensions:                 │"
-    "│                                                                    ││  [ ] mvt                   │"
-    "│                                                                    ││                            │"
-    "│                                                                    ││Geometry Types:             │"
-    "│                                                                    ││  [ ] Point                 │"
-    "│                                                                    ││  [ ] LineString            │"
+    "│                                                                    ││[Reset filters]             ▲"
+    "│                                                                    ││                            █"
+    "│                                                                    ││Extensions:                 █"
+    "│                                                                    ││  [ ] mvt                   ║"
+    "│                                                                    ││                            ║"
+    "│                                                                    ││Geometry Types:             ║"
+    "│                                                                    ││  [ ] Point                 ║"
+    "│                                                                    ││  [ ] LineString            ▼"
     "│                                                                    │└────────────────────────────┘"
     "│                                                                    │┌File Info───────────────────┐"
-    "│                                                                    ││File: line-boolean.mvt      │"
-    "│                                                                    ││Size: 40B  raw MLT file size│"
-    "│                                                                    ││Encoding: -  MLT / (data +  │"
-    "│                                                                    ││metadata)                   │"
-    "│                                                                    ││Data: -  decoded payload    │"
-    "│                                                                    ││size                        │"
-    "│                                                                    ││Metadata: -  encoding       │"
-    "│                                                                    ││overhead                    │"
+    "│                                                                    ││File: line-boolean.mvt      ▲"
+    "│                                                                    ││Size: 40B  raw MLT file size█"
+    "│                                                                    ││Encoding: -  MLT / (data +  █"
+    "│                                                                    ││metadata)                   ║"
+    "│                                                                    ││Data: -  decoded payload    ║"
+    "│                                                                    ││size                        ║"
+    "│                                                                    ││Metadata: -  encoding       ║"
+    "│                                                                    ││overhead                    ▼"
     "└────────────────────────────────────────────────────────────────────┘└────────────────────────────┘"
     "#);
 }
@@ -500,24 +500,24 @@ fn file_browser_previews_the_selected_tile() {
     "│                                                                    ││⣇⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣸│"
     "│                                                                    │└────────────────────────────┘"
     "│                                                                    │┌Filter (click to toggle)────┐"
-    "│                                                                    ││[Reset filters]             │"
-    "│                                                                    ││                            │"
-    "│                                                                    ││Extensions:                 │"
-    "│                                                                    ││  [ ] mvt                   │"
-    "│                                                                    ││                            │"
-    "│                                                                    ││Geometry Types:             │"
-    "│                                                                    ││  [ ] Point                 │"
-    "│                                                                    ││  [ ] LineString            │"
+    "│                                                                    ││[Reset filters]             ▲"
+    "│                                                                    ││                            █"
+    "│                                                                    ││Extensions:                 █"
+    "│                                                                    ││  [ ] mvt                   ║"
+    "│                                                                    ││                            ║"
+    "│                                                                    ││Geometry Types:             ║"
+    "│                                                                    ││  [ ] Point                 ║"
+    "│                                                                    ││  [ ] LineString            ▼"
     "│                                                                    │└────────────────────────────┘"
     "│                                                                    │┌File Info───────────────────┐"
-    "│                                                                    ││File: multiline-boolean.mvt │"
-    "│                                                                    ││Size: 46B  raw MLT file size│"
-    "│                                                                    ││Encoding: -  MLT / (data +  │"
-    "│                                                                    ││metadata)                   │"
-    "│                                                                    ││Data: -  decoded payload    │"
-    "│                                                                    ││size                        │"
-    "│                                                                    ││Metadata: -  encoding       │"
-    "│                                                                    ││overhead                    │"
+    "│                                                                    ││File: multiline-boolean.mvt ▲"
+    "│                                                                    ││Size: 46B  raw MLT file size█"
+    "│                                                                    ││Encoding: -  MLT / (data +  █"
+    "│                                                                    ││metadata)                   ║"
+    "│                                                                    ││Data: -  decoded payload    ║"
+    "│                                                                    ││size                        ║"
+    "│                                                                    ││Metadata: -  encoding       ║"
+    "│                                                                    ││overhead                    ▼"
     "└────────────────────────────────────────────────────────────────────┘└────────────────────────────┘"
     "#);
 }
@@ -538,24 +538,24 @@ fn file_browser_sorts_by_a_clicked_header() {
     "│                                                                    ││                            │"
     "│                                                                    │└────────────────────────────┘"
     "│                                                                    │┌Filter (click to toggle)────┐"
-    "│                                                                    ││[Reset filters]             │"
-    "│                                                                    ││                            │"
-    "│                                                                    ││Extensions:                 │"
-    "│                                                                    ││  [ ] mvt                   │"
-    "│                                                                    ││                            │"
-    "│                                                                    ││Geometry Types:             │"
-    "│                                                                    ││  [ ] Point                 │"
-    "│                                                                    ││  [ ] LineString            │"
+    "│                                                                    ││[Reset filters]             ▲"
+    "│                                                                    ││                            █"
+    "│                                                                    ││Extensions:                 █"
+    "│                                                                    ││  [ ] mvt                   ║"
+    "│                                                                    ││                            ║"
+    "│                                                                    ││Geometry Types:             ║"
+    "│                                                                    ││  [ ] Point                 ║"
+    "│                                                                    ││  [ ] LineString            ▼"
     "│                                                                    │└────────────────────────────┘"
     "│                                                                    │┌File Info───────────────────┐"
-    "│                                                                    ││File: line-boolean.mvt      │"
-    "│                                                                    ││Size: 40B  raw MLT file size│"
-    "│                                                                    ││Encoding: -  MLT / (data +  │"
-    "│                                                                    ││metadata)                   │"
-    "│                                                                    ││Data: -  decoded payload    │"
-    "│                                                                    ││size                        │"
-    "│                                                                    ││Metadata: -  encoding       │"
-    "│                                                                    ││overhead                    │"
+    "│                                                                    ││File: line-boolean.mvt      ▲"
+    "│                                                                    ││Size: 40B  raw MLT file size█"
+    "│                                                                    ││Encoding: -  MLT / (data +  █"
+    "│                                                                    ││metadata)                   ║"
+    "│                                                                    ││Data: -  decoded payload    ║"
+    "│                                                                    ││size                        ║"
+    "│                                                                    ││Metadata: -  encoding       ║"
+    "│                                                                    ││overhead                    ▼"
     "└────────────────────────────────────────────────────────────────────┘└────────────────────────────┘"
     "#);
 }
@@ -577,24 +577,24 @@ fn filter_click_narrows_the_file_list() {
     "│                                                                    ││                            │"
     "│                                                                    │└────────────────────────────┘"
     "│                                                                    │┌Filter (click to toggle)────┐"
-    "│                                                                    ││[Reset filters]             │"
-    "│                                                                    ││                            │"
-    "│                                                                    ││Extensions:                 │"
-    "│                                                                    ││  [ ] mvt                   │"
-    "│                                                                    ││                            │"
-    "│                                                                    ││Geometry Types:             │"
-    "│                                                                    ││  [x] Point                 │"
-    "│                                                                    ││  [ ] LineString            │"
+    "│                                                                    ││[Reset filters]             ▲"
+    "│                                                                    ││                            █"
+    "│                                                                    ││Extensions:                 █"
+    "│                                                                    ││  [ ] mvt                   ║"
+    "│                                                                    ││                            ║"
+    "│                                                                    ││Geometry Types:             ║"
+    "│                                                                    ││  [x] Point                 ║"
+    "│                                                                    ││  [ ] LineString            ▼"
     "│                                                                    │└────────────────────────────┘"
     "│                                                                    │┌File Info───────────────────┐"
-    "│                                                                    ││File: point-boolean.mvt     │"
-    "│                                                                    ││Size: 35B  raw MLT file size│"
-    "│                                                                    ││Encoding: -  MLT / (data +  │"
-    "│                                                                    ││metadata)                   │"
-    "│                                                                    ││Data: -  decoded payload    │"
-    "│                                                                    ││size                        │"
-    "│                                                                    ││Metadata: -  encoding       │"
-    "│                                                                    ││overhead                    │"
+    "│                                                                    ││File: point-boolean.mvt     ▲"
+    "│                                                                    ││Size: 35B  raw MLT file size█"
+    "│                                                                    ││Encoding: -  MLT / (data +  █"
+    "│                                                                    ││metadata)                   ║"
+    "│                                                                    ││Data: -  decoded payload    ║"
+    "│                                                                    ││size                        ║"
+    "│                                                                    ││Metadata: -  encoding       ║"
+    "│                                                                    ││overhead                    ▼"
     "└────────────────────────────────────────────────────────────────────┘└────────────────────────────┘"
     "#);
 }
@@ -619,7 +619,7 @@ fn enter_opens_a_file_and_escape_returns_to_the_browser() {
     "│                            ││     ⢸                                                        ⡇     │"
     "│                            ││     ⢸                                                        ⡇     │"
     "│                            ││     ⢸                                                        ⡇     │"
-    "└────────────────────────────┘│     ⢸                                                        ⡇     │"
+    "└◄██████████════════════════►┘│     ⢸                                                        ⡇     │"
     "┌Properties (all layers)─────┐│     ⢸                                                        ⡇     │"
     "│Layers: 1                   ││     ⢸                                                        ⡇     │"
     "│Features: 1                 ││     ⢸                                                        ⡇     │"
@@ -660,7 +660,7 @@ fn layer_selection_summarizes_properties_and_geometry() {
     "│                            ││     ⢸      ⢸                    ⢸       ⢀⠔⠁         ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⡖⠒⠒⠒⠒⠒⠒⢺⠒⠒⠒⠒⠒⡲⡎⠁           ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⡇      ⢸  ⢀⠔⠊ ⡇            ⢸        ⡇     │"
-    "└────────────────────────────┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
+    "└◄██████████════════════════►┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
     "┌Properties (layer roads)────┐│     ⢸⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⢉⠭⢻⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⡇     │"
     "│Features: 2                 ││     ⢸      ⢸             ⡇  ⡠⠔⠁ ⢸      ⡇            ⢸        ⡇     │"
     "│Properties: 2               ││     ⢸      ⢸             ⣇⡠⠊    ⢸      ⡇            ⢸        ⡇     │"
@@ -704,7 +704,7 @@ fn hovering_inside_a_layer_targets_a_feature() {
     "│                            ││     ⢸      ⢸                    ⢸       ⢀⠔⠁         ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⡖⠒⠒⠒⠒⠒⠒⢺⠒⠒⠒⠒⠒⡲⡎⠁           ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⡇      ⢸  ⢀⠔⠊ ⡇            ⢸        ⡇     │"
-    "└────────────────────────────┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
+    "└◄██████████════════════════►┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
     "┌Properties (feat 1, hover)──┐│     ⢸⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⢉⠭⢻⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⡇     │"
     "│class: pond                 ││     ⢸      ⢸             ⡇  ⡠⠔⠁ ⢸      ⡇            ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⣇⡠⠊    ⢸      ⡇            ⢸        ⡇     │"
@@ -755,7 +755,7 @@ fn hovering_inside_a_feature_targets_a_part() {
     "│                            ││     ⢸      ⢸                    ⢸       ⢀⠔⠁         ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⡖⠒⠒⠒⠒⠒⠒⢺⠒⠒⠒⠒⠒⡲⡎⠁           ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⡇      ⢸  ⢀⠔⠊ ⡇            ⢸        ⡇     │"
-    "└────────────────────────────┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
+    "└◄██████████════════════════►┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
     "┌Properties (feat 1, hover)──┐│     ⢸⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⢉⠭⢻⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⡇     │"
     "│class: pond                 ││     ⢸      ⢸             ⡇  ⡠⠔⠁ ⢸      ⡇            ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⣇⡠⠊    ⢸      ⡇            ⢸        ⡇     │"
@@ -765,11 +765,11 @@ fn hovering_inside_a_feature_targets_a_part() {
     "│                            ││     ⢸      ⢸    ⡠⠒⠁             ⢸                   ⢸        ⡇     │"
     "└────────────────────────────┘│     ⢸  ⢸⠉⠉⠉⢹⠉⢉⠭⢻                ⢸                   ⢸        ⡇     │"
     "┌Geometry────────────────────┐│     ⢸  ⢸   ⡸⠴⠥⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼        ⡇     │"
-    "│Component: part #1 of a     ││     ⢸  ⢸⢀⡠⠊    ⢸                ⢸                            ⡇     │"
-    "│MultiPolygon                ││     ⢸ ⢀⠜⠓⠒⠒⠒⠒⠒⠒⠚                ⢸                            ⡇     │"
-    "│Type: Polygon               ││     ⠸⠮⠥⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
-    "│Vertices: 5                 ││                                                                    │"
-    "│Rings: 1                    ││                                                                    │"
+    "│Component: part #1 of a     ▲│     ⢸  ⢸⢀⡠⠊    ⢸                ⢸                            ⡇     │"
+    "│MultiPolygon                █│     ⢸ ⢀⠜⠓⠒⠒⠒⠒⠒⠒⠚                ⢸                            ⡇     │"
+    "│Type: Polygon               █│     ⠸⠮⠥⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
+    "│Vertices: 5                 ║│                                                                    │"
+    "│Rings: 1                    ▼│                                                                    │"
     "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
     "#);
 }
@@ -841,7 +841,7 @@ fn hovering_a_tree_row_targets_that_row() {
     "│                            ││     ⢸      ⢸                    ⢸       ⢀⠔⠁         ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⡖⠒⠒⠒⠒⠒⠒⢺⠒⠒⠒⠒⠒⡲⡎⠁           ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⡇      ⢸  ⢀⠔⠊ ⡇            ⢸        ⡇     │"
-    "└────────────────────────────┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
+    "└◄██████████════════════════►┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
     "┌Properties (layer roads, hov┐│     ⢸⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⢉⠭⢻⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⡇     │"
     "│Features: 2                 ││     ⢸      ⢸             ⡇  ⡠⠔⠁ ⢸      ⡇            ⢸        ⡇     │"
     "│Properties: 2               ││     ⢸      ⢸             ⣇⡠⠊    ⢸      ⡇            ⢸        ⡇     │"
@@ -857,6 +857,51 @@ fn hovering_a_tree_row_targets_that_row() {
     "│                            ││                                                                    │"
     "│                            ││                                                                    │"
     "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
+    "#);
+}
+
+#[test]
+fn small_terminal_shows_scrollbars_and_scrolls_the_tree_sideways() {
+    let mut app = sample_app();
+    press(&mut app, KeyCode::Char('*'));
+    insta::assert_snapshot!(render_sized(&mut app, 60, 16), @r#"
+    "┌sample.mlt - Ent┐┌Map View────────────────────────────────┐"
+    "│>> All          ▲│                                        │"
+    "│     Layer: wate█│   ⢰⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⢲⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⣒⣒⣒⣒⣒⠶⡆   │"
+    "│       Feat 0: P█│   ⢸   ⢀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣸⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣇⣀⡠⠊⢹ ⡇   │"
+    "│       Feat 1: M║│   ⢸   ⢸   ×       ⢸        ⢀⡠⠓⢻⠒⠒⠚ ⡇   │"
+    "│     Layer: road║│   ⢸   ⢸           ⢸      ⡠⠒⠁  ⢸    ⡇   │"
+    "│       Feat 0: L▼│   ⢸   ⢸       ⢠⠤⠤⠤⢼⠤⠤⠤⣤⠔⠉     ⢸    ⡇   │"
+    "└◄████══════════►┘│   ⢸   ⢸       ⢸   ⢸⡠⠔⠉⢸       ⢸    ⡇   │"
+    "┌Properties (all ┐│   ⢸⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⢹⠉⣉⠝⢻⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⡇   │"
+    "│Layers: 3       ││   ⢸   ⢸      ⣀⠼⠮⠤⠤⢼⠤⠤⠤⠼    ×  ⢸    ⡇   │"
+    "│Features: 6     ││   ⢸   ⢸   ⢀⠤⠊     ⢸       ×   ⢸    ⡇   │"
+    "└────────────────┘│   ⢸ ⡖⠒⢺⢒⢶⠊⠁       ⢸           ⢸    ⡇   │"
+    "┌Geometry (all la┐│   ⢸ ⣇⡠⠚⠓⢺⠒⠒⠒⠒⠒⠒⠒⠒⠒⢺⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠚    ⡇   │"
+    "│Vertices: 29    ││   ⠸⠶⠭⠭⠭⠭⠭⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇   │"
+    "│Point: 1        ││                                        │"
+    "└────────────────┘└────────────────────────────────────────┘"
+    "#);
+    let shift_right = KeyEvent::new(KeyCode::Right, KeyModifiers::SHIFT);
+    assert!(!handle_key(&mut app, shift_right));
+    assert!(!handle_key(&mut app, shift_right));
+    insta::assert_snapshot!(render_sized(&mut app, 60, 16), @r#"
+    "┌sample.mlt - Ent┐┌Map View────────────────────────────────┐"
+    "│                ▲│                                        │"
+    "│er: water (2 fea█│   ⢰⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⢲⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⣒⣒⣒⣒⣒⠶⡆   │"
+    "│eat 0: Polygon (█│   ⢸   ⢀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣸⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣇⣀⡠⠊⢹ ⡇   │"
+    "│eat 1: MultiPoly║│   ⢸   ⢸   ×       ⢸        ⢀⡠⠓⢻⠒⠒⠚ ⡇   │"
+    "│er: roads (2 fea║│   ⢸   ⢸           ⢸      ⡠⠒⠁  ⢸    ⡇   │"
+    "│eat 0: LineStrin▼│   ⢸   ⢸       ⢠⠤⠤⠤⢼⠤⠤⠤⣤⠔⠉     ⢸    ⡇   │"
+    "└◄══████════════►┘│   ⢸   ⢸       ⢸   ⢸⡠⠔⠉⢸       ⢸    ⡇   │"
+    "┌Properties (all ┐│   ⢸⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⢹⠉⣉⠝⢻⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⡇   │"
+    "│Layers: 3       ││   ⢸   ⢸      ⣀⠼⠮⠤⠤⢼⠤⠤⠤⠼    ×  ⢸    ⡇   │"
+    "│Features: 6     ││   ⢸   ⢸   ⢀⠤⠊     ⢸       ×   ⢸    ⡇   │"
+    "└────────────────┘│   ⢸ ⡖⠒⢺⢒⢶⠊⠁       ⢸           ⢸    ⡇   │"
+    "┌Geometry (all la┐│   ⢸ ⣇⡠⠚⠓⢺⠒⠒⠒⠒⠒⠒⠒⠒⠒⢺⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠚    ⡇   │"
+    "│Vertices: 29    ││   ⠸⠶⠭⠭⠭⠭⠭⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇   │"
+    "│Point: 1        ││                                        │"
+    "└────────────────┘└────────────────────────────────────────┘"
     "#);
 }
 
@@ -894,7 +939,7 @@ fn tessellated_polygons_show_their_triangles() {
     "│                            ││     ⢸           ⠈⠑⠛⠭⣒⠒⠬⠵⣢⣄⡀⢠⠃    ⠑⡄        ⢠⠃                ⡇     │"
     "│                            ││     ⢸                ⠉⠒⠢⢄⡀⠉⠑⠢⢄    ⠈⢢       ⡜                 ⡇     │"
     "│                            ││     ⢸                    ⠈⠉⠒⠤⣀⡉⠒⢄⡀  ⠑⡄    ⢰⠁                 ⡇     │"
-    "└────────────────────────────┘│     ⢸                         ⠈⠑⠢⠬⣑⠤⡀⠈⢢   ⡎                  ⡇     │"
+    "└◄███████████═══════════════►┘│     ⢸                         ⠈⠑⠢⠬⣑⠤⡀⠈⢢   ⡎                  ⡇     │"
     "┌Properties (feat 1)─────────┐│     ⢸                              ⠉⠚⠵⢦⣑⡄⢸                   ⡇     │"
     "│(no properties)             ││     ⢸                                  ⠈⠙⠃                   ⡇     │"
     "│                            ││     ⢸                                                        ⡇     │"
@@ -904,11 +949,11 @@ fn tessellated_polygons_show_their_triangles() {
     "│                            ││     ⢸                                       ⢸       ⢀⠤⠊⠁     ⡇     │"
     "└────────────────────────────┘│     ⢸                                       ⡜    ⢀⡠⠒⠁        ⡇     │"
     "┌Geometry────────────────────┐│     ⢸                                       ⡇  ⡠⠔⠁           ⡇     │"
-    "│Type: Polygon               ││     ⢸                                      ⢰⣁⠔⠉              ⡇     │"
-    "│Vertices: 8                 ││     ⢸                                      ⠈                 ⡇     │"
-    "│Rings: 2                    ││     ⠸⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
-    "│  Ring 0: 4v, CW            ││                                                                    │"
-    "│  Ring 1: 4v, CCW           ││                                                                    │"
+    "│Type: Polygon               ▲│     ⢸                                      ⢰⣁⠔⠉              ⡇     │"
+    "│Vertices: 8                 █│     ⢸                                      ⠈                 ⡇     │"
+    "│Rings: 2                    █│     ⠸⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
+    "│  Ring 0: 4v, CW            ║│                                                                    │"
+    "│  Ring 1: 4v, CCW           ▼│                                                                    │"
     "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
     "#);
 }
@@ -978,24 +1023,24 @@ fn preview_failures_are_reported() {
     "│                                                                    ││                            │"
     "│                                                                    │└────────────────────────────┘"
     "│                                                                    │┌Filter (click to toggle)────┐"
-    "│                                                                    ││[Reset filters]             │"
-    "│                                                                    ││                            │"
-    "│                                                                    ││Extensions:                 │"
-    "│                                                                    ││  [ ] mvt                   │"
-    "│                                                                    ││                            │"
-    "│                                                                    ││Geometry Types:             │"
-    "│                                                                    ││  [ ] Point                 │"
-    "│                                                                    ││  [ ] LineString            │"
+    "│                                                                    ││[Reset filters]             ▲"
+    "│                                                                    ││                            █"
+    "│                                                                    ││Extensions:                 █"
+    "│                                                                    ││  [ ] mvt                   ║"
+    "│                                                                    ││                            ║"
+    "│                                                                    ││Geometry Types:             ║"
+    "│                                                                    ││  [ ] Point                 ║"
+    "│                                                                    ││  [ ] LineString            ▼"
     "│                                                                    │└────────────────────────────┘"
     "│                                                                    │┌File Info───────────────────┐"
-    "│                                                                    ││File: line-boolean.mvt      │"
-    "│                                                                    ││Size: 40B  raw MLT file size│"
-    "│                                                                    ││Encoding: -  MLT / (data +  │"
-    "│                                                                    ││metadata)                   │"
-    "│                                                                    ││Data: -  decoded payload    │"
-    "│                                                                    ││size                        │"
-    "│                                                                    ││Metadata: -  encoding       │"
-    "│                                                                    ││overhead                    │"
+    "│                                                                    ││File: line-boolean.mvt      ▲"
+    "│                                                                    ││Size: 40B  raw MLT file size█"
+    "│                                                                    ││Encoding: -  MLT / (data +  █"
+    "│                                                                    ││metadata)                   ║"
+    "│                                                                    ││Data: -  decoded payload    ║"
+    "│                                                                    ││size                        ║"
+    "│                                                                    ││Metadata: -  encoding       ║"
+    "│                                                                    ││overhead                    ▼"
     "└────────────────────────────────────────────────────────────────────┘└────────────────────────────┘"
     "#);
 }
@@ -1082,34 +1127,34 @@ fn mbtiles_hover_describes_the_nearest_feature() {
     assert!(mbt(&mut app).hovered.is_some());
     insta::assert_snapshot!(render(&mut app), @r#"
     "┌Properties - place feat 5 (t┐┌World Map - 0/0/0 - zoom 0.0  drag=pan  hover=info  q/Esc quit──────┐"
-    "│class: continent            ││⡏⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢹│"
-    "│name: Oceania               ││⡇×               ⢀⣠⠤⠤⠤⡄  ⣠⣴⡏⠒⠤⡀                                    ⢸│"
-    "│name:ar: أوقيانوسيا         ││⡇               ⣴⡊⡁ ⢀⣶⡯⠭⠾⠽⠉⠲⢭⠻⢴⡶     ⢀⡀   ⣀⣀       ⢠⡀              ⢸│"
-    "│name:be: Акіянія            ││⡇           ⢀⡄⣤⣼⣤⣸⠍⢠⣺⡵⠊      ⢉⡟    ⠐⡝⢓⡟⠁  ⠈⠁       ⠱⣱⢄             ⢸│"
-    "│name:ca: Oceania            ││⡇         ⠠⣊⠿⣧⣬⣽⣷⣿⣥⠊⠙⠷⠤⡀     ⢾⡗     ⠙⠋⠋     ⢀⢤⡶   ⢀⡤⡨⠛⠦⡄   ⢀⠤⣀     ⢸│"
-    "│name:cs: Oceánie            ││⡇         ⡰⣳⠯⢽⣧⢿⡿⡿⢽⡧⡀  ⢣⡀   ⢰⣾⠃            ⢠⡟⠁⢠⢤⣄⡖⠋   ⠐⠗⠦⠖⣄⣀⡿⢍⡁    ⢸│"
-    "│name:da: Oceanien           ││⡯⣀⢠⡖⠉⠉⠑⢲⠔⠚⠚⢻⣯⣤⣽⣻⡜⣿⢲⢲⡉⢇⡀⢘⢧  ⣠⡿⠟      ⢀⡴⡾⣟⠢⢄⣤⣀⠭⠖⠺⢹⡅         ⠉⠉  ⠈⠙⠒⠲⠖⢺│"
-    "│name:de: Ozeanien           ││⡗⠻⢝⠿ ⢀ ⢸  ⠘⢛⣄×  ⢠⠼⣷⣒⡧⢽⠃⠈⢿⣠⡞⠉ ⠹⠭⠃  ⢀⡰⡵⣵⠟⢸⣽⠛⠉    ⠉   ×           ⣀⢀ ⢀⣺│"
-    "│name:el: Ωκεανία            ││⡇ ⠈⣙⡶⠞⠉⠙⠺⣆  ⠉⠒⠲⢀⠳⢄⣀⡣⠈⠚⢄⡀⠈⠉      ×⣦⠈⢲⣷⣪⣿⢏⠉     ⣀⣀⡀     ⣀    ⣠⢔⠒⠛⡖⡯⠉⠁⢸│"
-    "│name:en: Oceania            ││⡇        ⠻⢦⡤⠤×⠤⠽⢄⣤⡘⠃⢀⣠⣤⣿⡄       ⠻×××⣽⣦⣿⣞⣓⡢⢰⣖⠒⡛ ⢉⣉⢒×⡒⠖⠾⠥⢤⡜⠹⢄⣌⢿⠄ ⠛⠁  ⢸│"
-    "│name:eo: Oceanio            ││⡇         ⢸ ⠰ ×  ⠘⠛⢻⠽⠙⠋   ×     ×⣹⣖⣻⣻⡿⣿×⣛⣗⣾×⣟⡷⣧⣾⡾⠃ ⠉⠒×⠚⠉⣤×⡞⢊⡾⠃     ⢸│"
-    "│name:es: Oceanía            ││⡇×         ⠙⣶⣒×⣤⠤⠤⣴⣊           ⢠⣮⠟ ⢻⠓⠲×⠚⣿×⠼⣄⣀⣿×⡻×⢤⣤⣠⣄   ⢹⠈⠛⠋⠁      ⢸│"
-    "│name:fi: Oseania            ││⡇   ⠰       ⠈⠁⠣⢜⢴⣶⡊⠿⠶⠤        ⢰⣟⣸⣉×⡚×⠑⡞⠒×⣧⠤⣬⠿⠉⠘⢳ ⡔⠚⢫⣿×⣶⠊⢽⡀         ⢸│"
-    "│name:fr: Océanie            ││⡇         ×      ⠈⢓×⢛⣭⣽⣤⣄     ⠈⠙⠻⠿⠿⢼⣻×⠿⢮×⢬⡿⠋   ⠈⠚⠇ ⠠⣿⣝⣁⡴⣟⣿⡀ ×      ⢸│"
-    "│name:fy: Oseaanje           ││⡇                 ⠘×⢿⣀⡀×⠈⠉⠉⡆       ⠈⢟⠧⣄⣿⣍⣏ ⡀  ×     ⠈⠻⠭⠽⢿⡿⣛×⢷⢶⡓⢤⡀  ⢸│"
-    "│name:ga: An Aigéine         ││⡇                  ⠈⢹⣦×⢆ ⣀⡜         ⢳⢲×⣯⢿⠜⣎⠇           ⡤⠤⠊×⠉⠊⠣⡀ ⠠⡅ ⢺│"
-    "│name:hi: ओशिआनिया           ││⡇                   ⢸× ⣯⠜           ⠘⣞⣉⠾⠃ ⠈            ⢣⣀⡤⠤⣤⡀ ⡸   ⣀⢸│" Hidden by multi-width symbols: [(12, " "), (15, " "), (17, " ")]
-    "│name:hr: Oceanija           ││⡇        ×         ⢀⣟⣰⠎⠁      ×                             ⠑⠿⠁  ⣠⡾⢿│"
-    "│name:hu: Óceánia            ││⡇                  ⠸⣯⡏⠠⠄                      ⠐⠂                 ⠉ ⢸│"
-    "│name:is: Eyjaálfa           ││⡇                   ⠉⠉                            ×                ⢸│"
-    "│name:it: Oceania            ││⡇                    ⢀⡤⠂                   ⢀⣀     ⡀  ⡀⢀⣀⢀⣀⣀⣄       ⢸│"
-    "│name:kn: ಒಷ್ಯಾನಿಯ             ││⡇                   ⡰⡟⡆         ⣀⣀⣀⡤⣠⠤⣄⡠⠒⠖⠊⠉ ⠉⢩⢦⠴⠉⠉⠉⠉⠈⠁ ⠉  ⠈⠉⠙⠒⠤⣀⣀ ⢸│" Hidden by multi-width symbols: [(13, " ")]
-    "│name:ku: Okyanûsya          ││⡇      ⣀⣀⣀⣦⣦⢤⡀⣸⡿⠴⠒⠴⠬⠿⠃⡕       ⢠⡎⠉⠉            ⠈⠁                 ⡤⠃⢸│"
-    "│name:la: Oceania            ││⡇   ⡤⡤⠚      ⠈ ⠁   ⢰⡒⠊  ⢀⣀ ⣀⠔⠒⠁  ×                              ⢸  ⢸│"
-    "│name:latin: Oceania         ││⡇  ⠹⠕⠒⢄            ⢏⡀⢀⣠⢀⠎⢸ ⠧⢆                                  ⢀⠞⠁ ⢸│"
-    "│name:lt: Okeanija           ││⡇   ⠐⡗⠁             ⠈⠚⢍⢈⡩⢥⠖⠊⠁                                  ⠈⡆  ⢸│"
-    "│name:nl: Oceanië            ││⡇ ⡀  ⣇                ⠈⠊                                        ⠈⢢ ⢸│"
-    "│name:no: Oseania            ││⣗⣋⣑⣄⣀⣈⣒⣆⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣋⣺│"
+    "│class: continent            ▲│⡏⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢹│"
+    "│name: Oceania               █│⡇×               ⢀⣠⠤⠤⠤⡄  ⣠⣴⡏⠒⠤⡀                                    ⢸│"
+    "│name:ar: أوقيانوسيا         █│⡇               ⣴⡊⡁ ⢀⣶⡯⠭⠾⠽⠉⠲⢭⠻⢴⡶     ⢀⡀   ⣀⣀       ⢠⡀              ⢸│"
+    "│name:be: Акіянія            █│⡇           ⢀⡄⣤⣼⣤⣸⠍⢠⣺⡵⠊      ⢉⡟    ⠐⡝⢓⡟⠁  ⠈⠁       ⠱⣱⢄             ⢸│"
+    "│name:ca: Oceania            █│⡇         ⠠⣊⠿⣧⣬⣽⣷⣿⣥⠊⠙⠷⠤⡀     ⢾⡗     ⠙⠋⠋     ⢀⢤⡶   ⢀⡤⡨⠛⠦⡄   ⢀⠤⣀     ⢸│"
+    "│name:cs: Oceánie            █│⡇         ⡰⣳⠯⢽⣧⢿⡿⡿⢽⡧⡀  ⢣⡀   ⢰⣾⠃            ⢠⡟⠁⢠⢤⣄⡖⠋   ⠐⠗⠦⠖⣄⣀⡿⢍⡁    ⢸│"
+    "│name:da: Oceanien           █│⡯⣀⢠⡖⠉⠉⠑⢲⠔⠚⠚⢻⣯⣤⣽⣻⡜⣿⢲⢲⡉⢇⡀⢘⢧  ⣠⡿⠟      ⢀⡴⡾⣟⠢⢄⣤⣀⠭⠖⠺⢹⡅         ⠉⠉  ⠈⠙⠒⠲⠖⢺│"
+    "│name:de: Ozeanien           █│⡗⠻⢝⠿ ⢀ ⢸  ⠘⢛⣄×  ⢠⠼⣷⣒⡧⢽⠃⠈⢿⣠⡞⠉ ⠹⠭⠃  ⢀⡰⡵⣵⠟⢸⣽⠛⠉    ⠉   ×           ⣀⢀ ⢀⣺│"
+    "│name:el: Ωκεανία            █│⡇ ⠈⣙⡶⠞⠉⠙⠺⣆  ⠉⠒⠲⢀⠳⢄⣀⡣⠈⠚⢄⡀⠈⠉      ×⣦⠈⢲⣷⣪⣿⢏⠉     ⣀⣀⡀     ⣀    ⣠⢔⠒⠛⡖⡯⠉⠁⢸│"
+    "│name:en: Oceania            █│⡇        ⠻⢦⡤⠤×⠤⠽⢄⣤⡘⠃⢀⣠⣤⣿⡄       ⠻×××⣽⣦⣿⣞⣓⡢⢰⣖⠒⡛ ⢉⣉⢒×⡒⠖⠾⠥⢤⡜⠹⢄⣌⢿⠄ ⠛⠁  ⢸│"
+    "│name:eo: Oceanio            █│⡇         ⢸ ⠰ ×  ⠘⠛⢻⠽⠙⠋   ×     ×⣹⣖⣻⣻⡿⣿×⣛⣗⣾×⣟⡷⣧⣾⡾⠃ ⠉⠒×⠚⠉⣤×⡞⢊⡾⠃     ⢸│"
+    "│name:es: Oceanía            █│⡇×         ⠙⣶⣒×⣤⠤⠤⣴⣊           ⢠⣮⠟ ⢻⠓⠲×⠚⣿×⠼⣄⣀⣿×⡻×⢤⣤⣠⣄   ⢹⠈⠛⠋⠁      ⢸│"
+    "│name:fi: Oseania            ║│⡇   ⠰       ⠈⠁⠣⢜⢴⣶⡊⠿⠶⠤        ⢰⣟⣸⣉×⡚×⠑⡞⠒×⣧⠤⣬⠿⠉⠘⢳ ⡔⠚⢫⣿×⣶⠊⢽⡀         ⢸│"
+    "│name:fr: Océanie            ║│⡇         ×      ⠈⢓×⢛⣭⣽⣤⣄     ⠈⠙⠻⠿⠿⢼⣻×⠿⢮×⢬⡿⠋   ⠈⠚⠇ ⠠⣿⣝⣁⡴⣟⣿⡀ ×      ⢸│"
+    "│name:fy: Oseaanje           ║│⡇                 ⠘×⢿⣀⡀×⠈⠉⠉⡆       ⠈⢟⠧⣄⣿⣍⣏ ⡀  ×     ⠈⠻⠭⠽⢿⡿⣛×⢷⢶⡓⢤⡀  ⢸│"
+    "│name:ga: An Aigéine         ║│⡇                  ⠈⢹⣦×⢆ ⣀⡜         ⢳⢲×⣯⢿⠜⣎⠇           ⡤⠤⠊×⠉⠊⠣⡀ ⠠⡅ ⢺│"
+    "│name:hi: ओशिआनिया           ║│⡇                   ⢸× ⣯⠜           ⠘⣞⣉⠾⠃ ⠈            ⢣⣀⡤⠤⣤⡀ ⡸   ⣀⢸│" Hidden by multi-width symbols: [(12, " "), (15, " "), (17, " ")]
+    "│name:hr: Oceanija           ║│⡇        ×         ⢀⣟⣰⠎⠁      ×                             ⠑⠿⠁  ⣠⡾⢿│"
+    "│name:hu: Óceánia            ║│⡇                  ⠸⣯⡏⠠⠄                      ⠐⠂                 ⠉ ⢸│"
+    "│name:is: Eyjaálfa           ║│⡇                   ⠉⠉                            ×                ⢸│"
+    "│name:it: Oceania            ║│⡇                    ⢀⡤⠂                   ⢀⣀     ⡀  ⡀⢀⣀⢀⣀⣀⣄       ⢸│"
+    "│name:kn: ಒಷ್ಯಾನಿಯ             ║│⡇                   ⡰⡟⡆         ⣀⣀⣀⡤⣠⠤⣄⡠⠒⠖⠊⠉ ⠉⢩⢦⠴⠉⠉⠉⠉⠈⠁ ⠉  ⠈⠉⠙⠒⠤⣀⣀ ⢸│" Hidden by multi-width symbols: [(13, " ")]
+    "│name:ku: Okyanûsya          ║│⡇      ⣀⣀⣀⣦⣦⢤⡀⣸⡿⠴⠒⠴⠬⠿⠃⡕       ⢠⡎⠉⠉            ⠈⠁                 ⡤⠃⢸│"
+    "│name:la: Oceania            ║│⡇   ⡤⡤⠚      ⠈ ⠁   ⢰⡒⠊  ⢀⣀ ⣀⠔⠒⠁  ×                              ⢸  ⢸│"
+    "│name:latin: Oceania         ║│⡇  ⠹⠕⠒⢄            ⢏⡀⢀⣠⢀⠎⢸ ⠧⢆                                  ⢀⠞⠁ ⢸│"
+    "│name:lt: Okeanija           ║│⡇   ⠐⡗⠁             ⠈⠚⢍⢈⡩⢥⠖⠊⠁                                  ⠈⡆  ⢸│"
+    "│name:nl: Oceanië            ║│⡇ ⡀  ⣇                ⠈⠊                                        ⠈⢢ ⢸│"
+    "│name:no: Oseania            ▼│⣗⣋⣑⣄⣀⣈⣒⣆⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣋⣺│"
     "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
     "#);
 }
@@ -1290,6 +1335,7 @@ fn the_wheel_scrolls_the_panel_under_the_cursor() {
     let areas = render_with_areas(&mut app, screen.0, screen.1);
     let tree = areas.tree.unwrap();
     let props = areas.props.unwrap();
+    let geom = areas.geom.unwrap();
     let mut clicks = MouseState::default();
     let down = MouseEventKind::ScrollDown;
     send(
@@ -1307,11 +1353,31 @@ fn the_wheel_scrolls_the_panel_under_the_cursor() {
         &areas,
         &mut clicks,
         screen,
+        MouseEventKind::ScrollRight,
+        tree.x + 2,
+        tree.y + 2,
+    );
+    assert_eq!(app.tree_hscroll, 4);
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        screen,
         down,
         props.x + 2,
         props.y + 1,
     );
     assert!(app.properties_scroll > 0);
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        screen,
+        down,
+        geom.x + 2,
+        geom.y + 1,
+    );
+    assert!(app.geometry_scroll > 0);
 }
 
 #[test]
@@ -1622,6 +1688,14 @@ fn keys_resize_the_splits_and_page_through_the_tree() {
     assert_eq!(app.features_pct, 45);
     assert!(!handle_key(&mut app, shift('K')));
     assert_eq!(app.features_pct, 50);
+    assert!(!handle_key(
+        &mut app,
+        KeyEvent::new(KeyCode::Left, KeyModifiers::SHIFT)
+    ));
+    assert_eq!(
+        app.tree_hscroll, 0,
+        "sideways scroll saturates at the left edge"
+    );
 
     press(&mut app, KeyCode::Char('*'));
     render_sized(&mut app, 60, 16);
@@ -2133,7 +2207,7 @@ fn layer_view_dividers_tree_hover_and_map_wheel() {
     "│                            ││     ⢸      ⢸                    ⢸       ⢀⠔⠁         ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⡖⠒⠒⠒⠒⠒⠒⢺⠒⠒⠒⠒⠒⡲⡎⠁           ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⡇      ⢸  ⢀⠔⠊ ⡇            ⢸        ⡇     │"
-    "└────────────────────────────┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
+    "└◄██████████════════════════►┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
     "┌Properties (layer water, hov┐│     ⢸⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⢉⠭⢻⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⡇     │"
     "│Features: 2                 ││     ⢸      ⢸             ⡇  ⡠⠔⠁ ⢸      ⡇            ⢸        ⡇     │"
     "│Properties: 2               ││     ⢸      ⢸             ⣇⡠⠊    ⢸      ⡇            ⢸        ⡇     │"
@@ -2225,6 +2299,17 @@ fn layer_view_dividers_tree_hover_and_map_wheel() {
         app.selected_index, before,
         "the wheel over the map does nothing"
     );
+    app.tree_hscroll = 8;
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        MouseEventKind::ScrollLeft,
+        tree.x + 2,
+        tree.y + 2,
+    );
+    assert_eq!(app.tree_hscroll, 4);
 }
 
 #[test]
@@ -2383,7 +2468,7 @@ fn layer_summary_lists_every_value_type_and_skips_unknown_geometries() {
     "│                            ││     ⢸                                                        ⡇     │"
     "│                            ││     ⢸                                                        ⡇     │"
     "│                            ││     ⢸                                                        ⡇     │"
-    "└────────────────────────────┘│     ⢸                                                        ⡇     │"
+    "└◄███████████═══════════════►┘│     ⢸                                                        ⡇     │"
     "┌Properties (layer odd)──────┐│     ⢸                                                        ⡇     │"
     "│Features: 5                 ││     ⢸                                                        ⡇     │"
     "│Properties: 4               ││     ⢸                                                        ⡇     │"
@@ -2441,7 +2526,7 @@ fn tessellated_multipolygon_parts_carry_their_own_triangles() {
     "│                            ││     ⢸                                                        ⡇     │"
     "│                            ││     ⢸                                                        ⡇     │"
     "│                            ││     ⢸                                                        ⡇     │"
-    "└────────────────────────────┘│     ⢸                                                        ⡇     │"
+    "└◄███████████═══════════════►┘│     ⢸                                                        ⡇     │"
     "┌Properties (feat 1)─────────┐│     ⢸                                                        ⡇     │"
     "│(no properties)             ││     ⢸                                                        ⡇     │"
     "│                            ││     ⢸                                                        ⡇     │"


### PR DESCRIPTION
Closes #971.

The rest of the split landed as #1638, #1642, #1643, #1646, #1647, and #1649. Every panel draws a vertical scrollbar when its content does not fit, with the thumb sized to the visible share, and the geometry panel scrolls like the others. The feature tree also scrolls sideways with Shift+Left/Right or a sideways mouse scroll, four columns per step so a long name takes a few presses, with a horizontal scrollbar when a row is wider than the panel.
