### PR TITLE
fix(rust): stop silently dropping v2 layers when converting a tile

### DIFF
--- a/rust/mlt/src/convert/mod.rs
+++ b/rust/mlt/src/convert/mod.rs
@@ -377,21 +377,19 @@ fn convert_mlt_buffer(buffer: &[u8], cfg: EncoderConfig) -> AnyResult<Vec<u8>> {
     let mut out: Vec<u8> = Vec::new();
 
     for layer in layers {
-        #[expect(clippy::wildcard_enum_match_arm, reason = "Layer is non_exhaustive")]
-        match layer {
-            Layer::Tag01(l) => {
-                let tile = l.into_tile(&mut dec)?;
-                out.extend_from_slice(&tile.encode(cfg)?);
-            }
-            Layer::Unknown(u) => {
-                out.extend(
-                    EncodedUnknown::from(u)
-                        .write_to(Encoder::default())?
-                        .into_raw_bytes(),
-                );
-            }
-            _ => {}
+        if let Layer::Unknown(u) = layer {
+            out.extend(
+                EncodedUnknown::from(u)
+                    .write_to(Encoder::default())?
+                    .into_raw_bytes(),
+            );
+            continue;
         }
+        let tile = layer
+            .into_layer01()
+            .expect("every layer but Unknown holds a Layer01")
+            .into_tile(&mut dec)?;
+        out.extend_from_slice(&tile.encode(cfg)?);
     }
 
     Ok(out)
@@ -414,18 +412,12 @@ fn mlt_buffer_to_tile_layers(buffer: &[u8]) -> AnyResult<Vec<mlt_core::TileLayer
     let mut dec = Decoder::default();
     let mut tiles = Vec::new();
     for layer in layers {
-        #[expect(clippy::wildcard_enum_match_arm, reason = "Layer is non_exhaustive")]
-        match layer {
-            Layer::Tag01(l) => {
-                tiles.push(l.into_tile(&mut dec)?);
-            }
-            Layer::Unknown(_) => {
-                bail!(
-                    "cannot convert MLT tile to MVT: tile contains unknown/extension layers that MVT cannot represent"
-                );
-            }
-            _ => {}
-        }
+        let Some(layer) = layer.into_layer01() else {
+            bail!(
+                "cannot convert MLT tile to MVT: tile contains unknown/extension layers that MVT cannot represent"
+            );
+        };
+        tiles.push(layer.into_tile(&mut dec)?);
     }
     Ok(tiles)
 }
@@ -464,6 +456,47 @@ fn convert_buffer(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "unstable-v2")]
+    const OMT_TILE: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../test/fixtures/omt/0_0_0.mvt"
+    );
+
+    #[cfg(feature = "unstable-v2")]
+    fn round_trip(mvt: Vec<u8>, version: WireVersion, to: TileFormat) -> Vec<u8> {
+        let cfg = EncoderConfig::default().with_wire_version(version);
+        let mlt = convert_buffer(mvt, TileFormat::Mvt, TileFormat::Mlt, cfg).unwrap();
+        convert_buffer(mlt, TileFormat::Mlt, to, cfg).unwrap()
+    }
+
+    /// Feature order is a per-version encoder choice, so only the layers themselves compare.
+    #[cfg(feature = "unstable-v2")]
+    fn layer_shape(mvt: Vec<u8>) -> Vec<(String, usize)> {
+        mvt_to_tile_layers(mvt)
+            .unwrap()
+            .iter()
+            .map(|layer| (layer.name().to_owned(), layer.features().len()))
+            .collect()
+    }
+
+    #[cfg(feature = "unstable-v2")]
+    #[test]
+    fn converting_a_v2_tile_back_to_mvt_keeps_every_layer() {
+        let mvt = std::fs::read(OMT_TILE).unwrap();
+        let back = round_trip(mvt.clone(), WireVersion::V02, TileFormat::Mvt);
+        assert_eq!(layer_shape(back), layer_shape(mvt));
+    }
+
+    #[cfg(feature = "unstable-v2")]
+    #[test]
+    fn re_encoding_a_v2_tile_keeps_every_layer() {
+        let mvt = std::fs::read(OMT_TILE).unwrap();
+        let expected = mvt_to_tile_layers(mvt.clone()).unwrap().len();
+        let mlt = round_trip(mvt, WireVersion::V02, TileFormat::Mlt);
+        let layers = Parser::default().parse_layers(&mlt).unwrap();
+        assert_eq!(layers.len(), expected);
+    }
 
     #[test]
     fn pmtiles_metadata_tracks_tile_compression() {


### PR DESCRIPTION
Fold `Tag02` into both layer-conversion paths so a v2 tile no longer converts to an empty MVT or loses every layer when re-encoded.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>