### PR TITLE
chore(CI): only run heavy jobs on top of the stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
       java: ${{ steps.filter.outputs.java }}
       ts: ${{ steps.filter.outputs.ts }}
       cpp: ${{ steps.filter.outputs.cpp }}
+      # Only the top pull request in a stack runs the expensive artifact and fuzz jobs.
+      top-of-stack: ${{ github.event.pull_request.stack != null && github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
@@ -51,6 +53,7 @@ jobs:
     uses: ./.github/workflows/rust.yml
     with:
       run-release: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      run-heavy: ${{ needs.changes.outputs.top-of-stack == 'true' }}
     secrets: inherit
     permissions: { contents: write, id-token: write }
 
@@ -72,6 +75,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.cpp == 'true'
     uses: ./.github/workflows/cpp.yml
+    with:
+      run-heavy: ${{ needs.changes.outputs.top-of-stack == 'true' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       java: ${{ steps.filter.outputs.java }}
       ts: ${{ steps.filter.outputs.ts }}
       cpp: ${{ steps.filter.outputs.cpp }}
-      # Only the top pull request in a stack runs the expensive artifact and fuzz jobs.
       top-of-stack: ${{ github.event.pull_request.stack != null && github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -2,10 +2,16 @@ name: C++ CI
 
 on:
   workflow_call:
+    inputs:
+      run-heavy:
+        description: Run the expensive artifact/fuzz jobs. Off for pull requests that are not on top of their stack.
+        type: boolean
+        default: true
   workflow_dispatch:
 
 jobs:
   cpp-build:
+    if: ${{ github.event_name != 'pull_request' || inputs.run-heavy }}
     permissions:
       id-token: write  # for OIDC Codecov
     strategy:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -22,7 +22,26 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      # Wheels are only worth building when the bindings changed, or when this
+      # is the top pull request in the stack (i.e. everything below it landed).
+      build: ${{ steps.filter.outputs.python == 'true' || github.event_name != 'pull_request' || (github.event.pull_request.stack != null && github.event.pull_request.stack.position == github.event.pull_request.stack.size) }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            python:
+              - 'rust/mlt-py/**'
+              - '.github/workflows/python-release.yml'
+
   linux:
+    needs: changes
+    if: needs.changes.outputs.build == 'true'
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
@@ -140,6 +159,8 @@ jobs:
   #        path: dist
 
   macos:
+    needs: changes
+    if: needs.changes.outputs.build == 'true'
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
@@ -167,6 +188,8 @@ jobs:
           path: dist
 
   sdist:
+    needs: changes
+    if: needs.changes.outputs.build == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,10 @@ on:
       run-release:
         type: boolean
         default: false
+      run-heavy:
+        description: Run the expensive artifact/fuzz jobs. Off for pull requests that are not on top of their stack.
+        type: boolean
+        default: true
   workflow_dispatch:
 
 jobs:
@@ -78,6 +82,7 @@ jobs:
       - run: just -v rust::ci-test-wasm
 
   fuzz:
+    if: ${{ github.event_name != 'pull_request' || inputs.run-heavy }}
     name: Fuzz ${{ matrix.target }}
     runs-on: ubuntu-latest
     strategy:
@@ -158,6 +163,7 @@ jobs:
       - run: just -v assert-git-is-clean
 
   build-release-binaries:
+    if: ${{ github.event_name != 'pull_request' || inputs.run-heavy }}
     name: Build release binaries for ${{ matrix.target }}
     strategy:
       fail-fast: false
@@ -187,6 +193,7 @@ jobs:
           path: ${{ matrix.artifact_name }}
 
   build-wasm-npm:
+    if: ${{ github.event_name != 'pull_request' || inputs.run-heavy }}
     name: Build @maplibre/mlt-wasm npm package
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Gates the expensive CI jobs — `cpp-build`, `fuzz`, `build-release-binaries`, `build-wasm-npm` and the Python wheel builds — so they only run on the top pull request of a stack.

> [!CAUTION]
> Mid-stack pull requests lose this coverage entirely until they reach the top.
> - A mid-stack change to `cpp/` gets **no** C++ CI at all. No build, no tests, no Bazel, no coverage. 
> - Likewise, no fuzzing runs mid-stack, and
> - a change to `rust/mlt-core` that breaks the PyO3 bindings will not be caught until the top, since the wheel guard only path-matches `rust/mlt-py/**`.
> 
> Most of these are fine since on release we do run full CI. There might need to be some rework though if we merge things without looking at the top of the stack
