### PR TITLE
chore(ci): readjust when release artefacts are getting build

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -29,9 +29,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      # Wheels are only worth building when the bindings changed, or when this
-      # is the top pull request in the stack (i.e. everything below it landed).
-      build: ${{ steps.filter.outputs.python == 'true' || github.event_name != 'pull_request' || (github.event.pull_request.stack != null && github.event.pull_request.stack.position == github.event.pull_request.stack.size) }}
+      build: ${{ steps.filter.outputs.python == 'true' || github.event_name != 'pull_request' || startsWith(github.head_ref, 'release-plz-') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -163,7 +163,7 @@ jobs:
       - run: just -v assert-git-is-clean
 
   build-release-binaries:
-    if: ${{ github.event_name != 'pull_request' || inputs.run-heavy }}
+    if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'release-plz-') }}
     name: Build release binaries for ${{ matrix.target }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
On second thought, maybe not every PR, just release PRs, main and things touching the code for python.
I don't think they have caught significant issues, except for big oopies in the release automation a few times.