### PR TITLE
chore(ci): only cache on main

### DIFF
--- a/.github/actions/mlt-setup-rust/action.yml
+++ b/.github/actions/mlt-setup-rust/action.yml
@@ -37,6 +37,8 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         workspaces: rust
+        shared-key: mlt
+        save-if: ${{ github.ref == 'refs/heads/main' }}
         # Caching ~/.cargo/bin breaks rustup proxies after restore (they end up
         # dispatching to rustup-init mode), causing maturin-action to fail with
         # "unexpected argument '--print' found / Usage: rustup-init[EXE]".


### PR DESCRIPTION
Our cache utilisation is currently at 0%, because we are saving about 20GB into 9GB of space, so not good.

This tries to improve this, not sure if it is an 100% fix.