### PR TITLE
chore(ci): merge `test-ffi` into one workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -130,27 +130,15 @@ jobs:
   #      - run: just -v rust::ci-test-msrv
 
   test-ffi:
-    name: FFI ${{ matrix.backend }}
+    name: FFI round-trip tests
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - backend: c
-            recipe: test-ffi-c
-          - backend: cpp
-            recipe: test-ffi-cpp
-          - backend: kotlin
-            recipe: test-ffi-kotlin
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/mlt-setup-rust
-      - if: matrix.backend == 'kotlin'
-        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+      - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with: { distribution: 'temurin', java-version: '21' }
-      - if: matrix.backend == 'kotlin'
-        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
-      - run: just -v rust::${{ matrix.recipe }}
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+      - run: just -v rust::ci-test-ffi
 
   test-publish:
     name: Test workspace publishing using --dry-run

--- a/rust/mod.just
+++ b/rust/mod.just
@@ -104,6 +104,9 @@ ci-test: ci-env-info (just 'java::gen-snippets') test
 ci-test-wasm: ci-env-info wasm-test
     {{just}} assert-git-is-clean  # call it explicitly to avoid just optimizing it to just one call
 
+# Run all FFI round-trip tests as expected by CI, building the cdylib once
+ci-test-ffi: ci-env-info test-ffi-c test-ffi-cpp test-ffi-kotlin
+
 # Run minimal subset of tests to ensure compatibility with MSRV
 ci-test-msrv: ci-env-info
     #!/usr/bin/env bash
@@ -359,11 +362,14 @@ sync-ffi-bindings: (just 'cargo-install' 'diplomat-tool') (just 'assert-cmd' 'cl
     clang-format -style=WebKit -i tests/c/*.c tests/cpp/*.cpp generated/c/* generated/cpp/*
     ktlint --format ./**/*.kt
 
+[private]
+_build-ffi-lib:
+    cargo build --release -p mlt-ffi
+
 # Run the C FFI round-trip test (builds cdylib, compiles + runs test)
-test-ffi-c:
+test-ffi-c: _build-ffi-lib
     #!/usr/bin/env bash
     set -euo pipefail
-    cargo build --release -p mlt-ffi
     LIB_DIR="$(pwd)/target/release"
     gcc mlt-ffi/tests/c/test_round_trip.c \
         -I mlt-ffi/generated/c \
@@ -372,10 +378,9 @@ test-ffi-c:
     LD_LIBRARY_PATH="$LIB_DIR" target/test_ffi_c
 
 # Run the C++ FFI round-trip test (builds cdylib, compiles + runs test)
-test-ffi-cpp:
+test-ffi-cpp: _build-ffi-lib
     #!/usr/bin/env bash
     set -euo pipefail
-    cargo build --release -p mlt-ffi
     LIB_DIR="$(pwd)/target/release"
     g++ -std=c++20 mlt-ffi/tests/cpp/test_round_trip.cpp \
         -I mlt-ffi/generated/cpp \
@@ -384,11 +389,9 @@ test-ffi-cpp:
     LD_LIBRARY_PATH="$LIB_DIR" target/test_ffi_cpp
 
 # Run the Kotlin FFI round-trip test (builds cdylib, compiles + runs test)
-test-ffi-kotlin: (just 'assert-cmd' 'java')
+test-ffi-kotlin: _build-ffi-lib (just 'assert-cmd' 'java')
     #!/usr/bin/env bash
     set -euo pipefail
-    cargo build --release -p mlt-ffi
-
     case "$(uname -s)-$(uname -m)" in
         Linux-x86_64)        CLASSIFIER=linux-x86_64;   LIB=libmlt_ffi.so    ;;
         Linux-aarch64)       CLASSIFIER=linux-aarch64;  LIB=libmlt_ffi.so    ;;


### PR DESCRIPTION
even though relatively cheap, this way we don't need so many `cargo build`s