### PR TITLE
test(rust): drive the mlt ui from tests through TestBackend

### DIFF
--- a/rust/mlt/src/ui/mbt.rs
+++ b/rust/mlt/src/ui/mbt.rs
@@ -461,26 +461,30 @@ impl MbtilesState {
         }
 
         while let Ok(res) = self.result_rx.try_recv() {
-            let key = (res.z, res.x, res.y);
-            self.loading.remove(&key);
-            let entry = match res.data {
-                Err(e) => MbtTileData::Error(e),
-                Ok(None) => MbtTileData::Empty,
-                Ok(Some(raw)) => match decode_and_parse(res.z, res.x, res.y, raw) {
-                    Ok(Some((fc, extent, layer_groups, geo_index))) => MbtTileData::Loaded {
-                        fc,
-                        extent,
-                        layer_groups,
-                        geo_index,
-                    },
-                    Ok(None) => MbtTileData::Empty,
-                    Err(e) => MbtTileData::Error(e.to_string()),
-                },
-            };
-            self.tiles.insert(key, entry);
+            self.apply_result(res);
             changed = true;
         }
         changed
+    }
+
+    fn apply_result(&mut self, res: TileLoadResult) {
+        let key = (res.z, res.x, res.y);
+        self.loading.remove(&key);
+        let entry = match res.data {
+            Err(e) => MbtTileData::Error(e),
+            Ok(None) => MbtTileData::Empty,
+            Ok(Some(raw)) => match decode_and_parse(res.z, res.x, res.y, raw) {
+                Ok(Some((fc, extent, layer_groups, geo_index))) => MbtTileData::Loaded {
+                    fc,
+                    extent,
+                    layer_groups,
+                    geo_index,
+                },
+                Ok(None) => MbtTileData::Empty,
+                Err(e) => MbtTileData::Error(e.to_string()),
+            },
+        };
+        self.tiles.insert(key, entry);
     }
 
     /// Zoom in/out by half a zoom level around `(wx, wy)` (scroll wheel).
@@ -700,7 +704,40 @@ fn build_world_geo_index(
 
 #[cfg(test)]
 mod tests {
+    use mlt_core::geo_types::{
+        GeometryCollection, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Rect,
+    };
+
     use super::*;
+
+    fn c(x: i32, y: i32) -> Coord<i32> {
+        Coord { x, y }
+    }
+
+    impl MbtilesState {
+        /// Request the visible tiles and block until every requested tile has arrived.
+        pub(crate) fn wait_for_visible_tiles(&mut self) {
+            loop {
+                for (z, x, y) in self.visible_tiles() {
+                    self.request_tile_with_ancestors(z, x, y);
+                }
+                self.process_results();
+                let pending = self
+                    .tiles
+                    .values()
+                    .any(|t| matches!(t, MbtTileData::Loading));
+                if self.loader_fatal.is_some() || (!pending && self.loader_init_rx.is_none()) {
+                    return;
+                }
+                if let Ok(res) = self.result_rx.recv() {
+                    self.apply_result(res);
+                } else {
+                    self.process_results();
+                    return;
+                }
+            }
+        }
+    }
 
     #[test]
     fn integer_zoom_reached_by_half_steps_loads_that_level() {
@@ -710,5 +747,74 @@ mod tests {
         state.zoom_wheel_at(0.3, 0.3, true);
         assert_eq!(state.zoom_level(), 2);
         assert_eq!(state.center_tile_xyz().0, 2);
+    }
+
+    #[test]
+    fn transform_flattens_every_geometry_kind_into_world_space() {
+        let t = TileTransform::new(1, 1, 0, 4096);
+        let [wx, wy] = t.to_world(c(4096, 0));
+        assert!(
+            (wx - 1.0).abs() < 1e-12 && wy.abs() < 1e-12,
+            "east edge of tile 1/1/0"
+        );
+        let ring = LineString(vec![c(0, 0), c(4, 0), c(4, 4)]);
+        let poly = Polygon::new(ring.clone(), vec![ring.clone()]);
+        assert_eq!(t.geom_verts(&Geometry::Point(Point(c(1, 1)))).len(), 1);
+        assert_eq!(t.geom_verts(&Geometry::LineString(ring.clone())).len(), 3);
+        assert_eq!(
+            t.geom_verts(&Geometry::MultiPoint(MultiPoint(vec![
+                Point(c(0, 0)),
+                Point(c(1, 1))
+            ])))
+            .len(),
+            2
+        );
+        assert_eq!(t.geom_verts(&Geometry::Polygon(poly.clone())).len(), 8);
+        assert_eq!(
+            t.geom_verts(&Geometry::MultiLineString(MultiLineString(vec![
+                ring.clone(),
+                ring
+            ])))
+            .len(),
+            6
+        );
+        assert_eq!(
+            t.geom_verts(&Geometry::MultiPolygon(MultiPolygon(vec![
+                poly.clone(),
+                poly
+            ])))
+            .len(),
+            16
+        );
+        assert!(
+            t.geom_verts(&Geometry::Rect(Rect::new(c(0, 0), c(1, 1))))
+                .is_empty()
+        );
+        assert!(
+            t.geom_verts(&Geometry::GeometryCollection(GeometryCollection(vec![])))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn an_entry_without_vertices_sits_at_the_origin() {
+        let entry = MbtGeoEntry {
+            layer: 0,
+            feat: 0,
+            vertices: Vec::new(),
+        };
+        assert_eq!(entry.envelope(), AABB::from_point([0.0, 0.0]));
+    }
+
+    #[test]
+    fn decompress_passes_plain_bytes_through_and_inflates_gzip() {
+        assert_eq!(decompress(vec![1, 2, 3]).unwrap(), vec![1, 2, 3]);
+        let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        std::io::Write::write_all(&mut gz, b"tile").unwrap();
+        assert_eq!(decompress(gz.finish().unwrap()).unwrap(), b"tile");
+        assert!(
+            decompress(vec![0x28, 0xb5, 0x2f, 0xfd, 1]).is_err(),
+            "truncated zstd is an error"
+        );
     }
 }

--- a/rust/mlt/src/ui/mod.rs
+++ b/rust/mlt/src/ui/mod.rs
@@ -347,7 +347,10 @@ fn stat_line(name: &str, val: &dyn std::fmt::Display) -> Line<'static> {
     ])
 }
 
+/// Columns either side of a vertical divider that start a drag.
 const DIVIDER_GRAB: u16 = 2;
+/// Rows either side of a horizontal divider that start a drag.
+const DIVIDER_GRAB_ROWS: u16 = 1;
 
 fn divider_hit(
     col: u16,
@@ -357,8 +360,8 @@ fn divider_hit(
     geom: Option<Rect>,
 ) -> Option<ResizeHandle> {
     let horiz_hit = |dy: u16| {
-        row >= dy.saturating_sub(DIVIDER_GRAB)
-            && row < dy.saturating_add(DIVIDER_GRAB)
+        row >= dy.saturating_sub(DIVIDER_GRAB_ROWS)
+            && row < dy.saturating_add(DIVIDER_GRAB_ROWS)
             && col >= left.x
             && col < left.x + left.width
     };
@@ -1286,8 +1289,8 @@ fn handle_mouse(
                 }
                 if let (Some(pa), Some(fa)) = (areas.preview, areas.filter) {
                     let mut invalidate = |value: u16, resizer: ResizeHandle| {
-                        if mouse.row >= value.saturating_sub(DIVIDER_GRAB)
-                            && mouse.row < value.saturating_add(DIVIDER_GRAB)
+                        if mouse.row >= value.saturating_sub(DIVIDER_GRAB_ROWS)
+                            && mouse.row < value.saturating_add(DIVIDER_GRAB_ROWS)
                             && areas
                                 .right_col
                                 .is_some_and(|rc| point_in_rect(mouse.column, mouse.row, rc))
@@ -1345,7 +1348,9 @@ fn handle_mouse(
                         mouse.row,
                         area,
                         app.file_list_state.offset(),
-                    ) && row < app.filtered_file_indices.len()
+                    )
+                    .and_then(|r| r.checked_sub(1))
+                        && row < app.filtered_file_indices.len()
                     {
                         let dbl = clicks
                             .file_click

--- a/rust/mlt/src/ui/mod.rs
+++ b/rust/mlt/src/ui/mod.rs
@@ -4,6 +4,8 @@ use usize_cast::IntoUsize as _;
 pub(crate) mod mbt;
 mod rendering;
 mod state;
+#[cfg(test)]
+mod tests;
 
 use std::collections::HashSet;
 use std::fs::canonicalize;
@@ -16,14 +18,15 @@ use std::{fs, thread};
 use anyhow::bail;
 use clap::Args;
 use crossterm::event::{
-    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers,
-    MouseButton, MouseEventKind,
+    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
+    KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
 };
 use crossterm::execute;
 use mlt_core::geo_types::{Coord, Geometry, Polygon};
 use mlt_core::geojson::FeatureCollection;
 use mlt_core::mvt::mvt_to_feature_collection;
 use mlt_core::{Decoder, GeometryType, Parser};
+use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Margin, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -79,7 +82,19 @@ pub struct UiArgs {
     center_tile: Option<String>,
 }
 
+/// Analysis flags for the file browser scan.
+const SCAN_FLAGS: LsFlags = LsFlags {
+    gzip: true,
+    algorithms: true,
+    validate: false,
+};
+
 pub fn ui(args: &UiArgs) -> anyhow::Result<()> {
+    run_app(build_app(args)?)
+}
+
+/// Build the app for the CLI arguments without touching the terminal.
+fn build_app(args: &UiArgs) -> anyhow::Result<App> {
     if args.center_tile.is_some() && !is_mbt_extension(&args.path) {
         bail!("--center-tile is only supported when opening an .mbtiles file");
     }
@@ -106,15 +121,7 @@ pub fn ui(args: &UiArgs) -> anyhow::Result<()> {
             .collect();
         let (tx, rx) = mpsc::channel();
         thread::spawn(move || {
-            let _ = tx.send(analyze_tile_files(
-                &paths,
-                &base,
-                LsFlags {
-                    gzip: true,
-                    algorithms: true,
-                    validate: false,
-                },
-            ));
+            let _ = tx.send(analyze_tile_files(&paths, &base, SCAN_FLAGS));
         });
         App::new_file_browser(files, Some(rx), args.path.clone())
     } else if args.path.is_file() {
@@ -122,7 +129,7 @@ pub fn ui(args: &UiArgs) -> anyhow::Result<()> {
     } else {
         bail!("Path is not a file or directory");
     };
-    run_app(app)
+    Ok(app)
 }
 
 fn parse_center_tile_xyz(spec: &str) -> anyhow::Result<(u8, u32, u32)> {
@@ -429,635 +436,278 @@ fn file_browser_filter_pct_clamped(pct: u16, preview_pct: u16) -> u16 {
     )
 }
 
-fn run_app_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> anyhow::Result<()> {
-    let mut map_area: Option<Rect> = None;
-    let mut tree_area: Option<Rect> = None;
-    let mut props_area: Option<Rect> = None;
-    let mut geom_area: Option<Rect> = None;
-    let mut left_area: Option<Rect> = None;
-    let mut filter_area: Option<Rect> = None;
-    let mut info_area: Option<Rect> = None;
-    let mut preview_area: Option<Rect> = None;
-    let mut right_col: Option<Rect> = None;
-    let mut file_left: Option<Rect> = None;
-    let mut last_tree_click: Option<(Instant, usize)> = None;
-    let mut last_file_click: Option<(Instant, usize)> = None;
-    let mut last_hover_redraw: Option<Instant> = None;
+/// Screen rectangles of the panels drawn by the last frame.
+#[derive(Debug, Default, Clone, Copy)]
+struct PanelAreas {
+    map: Option<Rect>,
+    tree: Option<Rect>,
+    props: Option<Rect>,
+    geom: Option<Rect>,
+    left: Option<Rect>,
+    filter: Option<Rect>,
+    info: Option<Rect>,
+    preview: Option<Rect>,
+    right_col: Option<Rect>,
+    file_left: Option<Rect>,
+}
 
-    loop {
-        // Process incoming mbtiles tile results and request visible tiles.
-        if app.mode == ViewMode::MbtilesMap
-            && let Some(ref mut mbt) = app.mbt_state
-        {
-            if mbt.process_results() {
-                app.needs_redraw = true;
-            }
-            if let Some(msg) = mbt.take_loader_fatal() {
-                let title = app
-                    .current_file
-                    .as_ref()
-                    .map_or_else(|| "MBTiles".to_string(), |p| p.display().to_string());
-                app.error_popup = Some((title, msg));
-                app.needs_redraw = true;
-            }
-            let visible = mbt.visible_tiles();
-            for (z, x, y) in visible {
-                mbt.request_tile_with_ancestors(z, x, y);
-            }
-            mbt.prune_tile_cache_if_needed();
+/// Draw one frame for the current mode and record where each panel landed.
+fn render_frame(f: &mut Frame<'_>, app: &mut App, areas: &mut PanelAreas) {
+    match app.mode {
+        ViewMode::FileBrowser => {
+            refresh_tile_preview(app);
+            let cols = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([
+                    Constraint::Percentage(app.file_left_pct),
+                    Constraint::Percentage(100u16.saturating_sub(app.file_left_pct)),
+                ])
+                .split(f.area());
+            let right_pct =
+                file_browser_preview_pct_clamped(app.file_preview_pct, app.file_filter_pct);
+            let filter_pct = file_browser_filter_pct_clamped(app.file_filter_pct, right_pct);
+            app.file_preview_pct = right_pct;
+            app.file_filter_pct = filter_pct;
+            let right = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Percentage(right_pct),
+                    Constraint::Percentage(filter_pct),
+                    Constraint::Percentage(
+                        100u16.saturating_sub(right_pct).saturating_sub(filter_pct),
+                    ),
+                ])
+                .split(cols[1]);
+            render_file_browser(f, cols[0], app);
+            render_tile_preview_panel(f, right[0], app);
+            render_file_filter_panel(f, right[1], app);
+            render_file_info_panel(f, right[2], app);
+            areas.file_left = Some(cols[0]);
+            areas.right_col = Some(cols[1]);
+            areas.preview = Some(right[0]);
+            areas.filter = Some(right[1]);
+            areas.info = Some(right[2]);
         }
-
-        if let Some(rows) = app.analysis_rx.as_ref().and_then(|rx| rx.try_recv().ok()) {
-            if rows.len() == app.files.len() {
-                for (i, row) in rows.into_iter().enumerate() {
-                    if let Some(e) = app.files.get_mut(i) {
-                        *e = row;
-                    }
-                }
-            }
-            app.analysis_rx = None;
-            app.rebuild_filtered_files();
+        ViewMode::LayerOverview => {
+            let cols = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([
+                    Constraint::Percentage(app.left_pct),
+                    Constraint::Percentage(100u16.saturating_sub(app.left_pct)),
+                ])
+                .split(f.area());
+            let left = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Percentage(app.features_pct),
+                    Constraint::Percentage(100u16.saturating_sub(app.features_pct)),
+                ])
+                .split(cols[0]);
+            render_tree_panel(f, left[0], app);
+            let ga = render_properties_panel(f, left[1], app);
+            render_map_panel(f, cols[1], app);
+            areas.tree = Some(left[0]);
+            areas.props = Some(left[1]);
+            areas.geom = Some(ga);
+            areas.left = Some(cols[0]);
+            areas.map = Some(map_canvas_area(cols[1]));
         }
+        ViewMode::MbtilesMap => {
+            let cols = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([
+                    Constraint::Percentage(app.left_pct),
+                    Constraint::Percentage(100u16.saturating_sub(app.left_pct)),
+                ])
+                .split(f.area());
+            render_mbtiles_hover_panel(f, cols[0], app);
+            render_mbtiles_map_panel(f, cols[1], app);
+            areas.left = Some(cols[0]);
+            areas.map = Some(map_canvas_area(cols[1]));
+        }
+    }
+    if app.error_popup.is_some() {
+        render_error_popup(f, app);
+    } else if app.show_help {
+        render_help_overlay(f, app);
+    }
+}
 
-        if let Some((path, result)) = app.preview_rx.as_mut().and_then(|rx| rx.try_recv().ok()) {
-            app.preview_rx = None;
-            app.preview_load_requested = None;
-            if app.get_selected_file().map(LsRow::path) == Some(path.as_path()) {
-                if let Ok((fc, ext)) = result {
-                    app.preview_tile_path = Some(path);
-                    app.preview_fc = Some(fc);
-                    app.preview_extent = ext;
-                } else {
-                    app.preview_tile_path = Some(path);
-                    app.preview_fc = None;
-                }
+/// Apply a key press to the app.
+/// Returns `true` when the app should quit.
+fn handle_key(app: &mut App, key: KeyEvent) -> bool {
+    if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+        return true;
+    }
+    if app.error_popup.is_some() {
+        app.error_popup = None;
+        app.invalidate();
+        return false;
+    }
+    if app.show_help {
+        #[expect(clippy::wildcard_enum_match_arm, reason = "any other key closes help")]
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                app.help_scroll = app.help_scroll.saturating_sub(1);
             }
+            KeyCode::Down | KeyCode::Char('j') => {
+                app.help_scroll = app.help_scroll.saturating_add(1);
+            }
+            KeyCode::PageUp => {
+                app.help_scroll = app.help_scroll.saturating_sub(10);
+            }
+            KeyCode::PageDown => {
+                app.help_scroll = app.help_scroll.saturating_add(10);
+            }
+            KeyCode::Home => app.help_scroll = 0,
+            KeyCode::End => app.help_scroll = u16::MAX,
+            _ => app.show_help = false,
+        }
+        app.invalidate();
+        return false;
+    }
+    #[expect(clippy::wildcard_enum_match_arm, reason = "unbound keys do nothing")]
+    match key.code {
+        KeyCode::Char('q') => return true,
+        KeyCode::Esc if app.handle_escape() => return true,
+        KeyCode::Char('?') | KeyCode::F(1) => app.open_help(),
+        KeyCode::Char('h') if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.open_help();
+        }
+        KeyCode::Enter => app.handle_enter(),
+        KeyCode::Char('+' | '=') | KeyCode::Right => app.handle_plus(),
+        KeyCode::Char('-') => app.handle_minus(),
+        KeyCode::Char('*') => app.handle_star(),
+        KeyCode::Up | KeyCode::Char('k') => app.move_up_by(1),
+        KeyCode::Down | KeyCode::Char('j') => app.move_down_by(1),
+        KeyCode::Left => app.handle_left_arrow(),
+        KeyCode::PageUp => {
+            app.move_up_by(app.page_size().saturating_sub(1).max(1));
+        }
+        KeyCode::PageDown => {
+            app.move_down_by(app.page_size().saturating_sub(1).max(1));
+        }
+        KeyCode::Home => app.move_to_start(),
+        KeyCode::End => app.move_to_end(),
+        KeyCode::Char('h') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.left_pct = app.left_pct.saturating_sub(5).max(10);
             app.invalidate();
         }
-        if app.mode == ViewMode::FileBrowser
-            && let Some(selected) = app.get_selected_file()
-        {
-            let path = selected.path().to_path_buf();
-            if is_tile_extension(&path)
-                && (app.preview_tile_path.as_ref() != Some(&path) || app.preview_fc.is_none())
-                && app.preview_load_requested.as_ref() != Some(&path)
-            {
-                let (tx, rx) = mpsc::channel();
-                app.preview_rx = Some(rx);
-                app.preview_load_requested = Some(path.clone());
-                let path_spawn = path.clone();
-                thread::spawn(move || {
-                    let result = load_fc(&path_spawn)
-                        .map(|fc| {
-                            let ext = extent_from_fc(&fc);
-                            (fc, ext)
-                        })
-                        .map_err(|_| ());
-                    let _ = tx.send((path_spawn, result));
-                });
+        KeyCode::Char('l') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.left_pct = (app.left_pct + 5).min(90);
+            app.invalidate();
+        }
+        KeyCode::Char('J') if key.modifiers.contains(KeyModifiers::SHIFT) => {
+            app.features_pct = app.features_pct.saturating_sub(5).max(10);
+            app.invalidate();
+        }
+        KeyCode::Char('K') if key.modifiers.contains(KeyModifiers::SHIFT) => {
+            app.features_pct = (app.features_pct + 5).min(90);
+            app.invalidate();
+        }
+        _ => {}
+    }
+    false
+}
+
+/// Pump the background work between frames.
+fn tick(app: &mut App) {
+    if app.mode == ViewMode::MbtilesMap
+        && let Some(ref mut mbt) = app.mbt_state
+    {
+        if mbt.process_results() {
+            app.needs_redraw = true;
+        }
+        if let Some(msg) = mbt.take_loader_fatal() {
+            let title = app
+                .current_file
+                .as_ref()
+                .map_or_else(|| "MBTiles".to_string(), |p| p.display().to_string());
+            app.error_popup = Some((title, msg));
+            app.needs_redraw = true;
+        }
+        let visible = mbt.visible_tiles();
+        for (z, x, y) in visible {
+            mbt.request_tile_with_ancestors(z, x, y);
+        }
+        mbt.prune_tile_cache_if_needed();
+    }
+
+    if let Some(rows) = app.analysis_rx.as_ref().and_then(|rx| rx.try_recv().ok()) {
+        if rows.len() == app.files.len() {
+            for (i, row) in rows.into_iter().enumerate() {
+                if let Some(e) = app.files.get_mut(i) {
+                    *e = row;
+                }
             }
         }
+        app.analysis_rx = None;
+        app.rebuild_filtered_files();
+    }
+
+    if let Some((path, result)) = app.preview_rx.as_mut().and_then(|rx| rx.try_recv().ok()) {
+        app.preview_rx = None;
+        app.preview_load_requested = None;
+        if app.get_selected_file().map(LsRow::path) == Some(path.as_path()) {
+            if let Ok((fc, ext)) = result {
+                app.preview_tile_path = Some(path);
+                app.preview_fc = Some(fc);
+                app.preview_extent = ext;
+            } else {
+                app.preview_tile_path = Some(path);
+                app.preview_fc = None;
+            }
+        }
+        app.invalidate();
+    }
+    if app.mode == ViewMode::FileBrowser
+        && let Some(selected) = app.get_selected_file()
+    {
+        let path = selected.path().to_path_buf();
+        if is_tile_extension(&path)
+            && (app.preview_tile_path.as_ref() != Some(&path) || app.preview_fc.is_none())
+            && app.preview_load_requested.as_ref() != Some(&path)
+        {
+            let (tx, rx) = mpsc::channel();
+            app.preview_rx = Some(rx);
+            app.preview_load_requested = Some(path.clone());
+            let path_spawn = path.clone();
+            thread::spawn(move || {
+                let result = load_fc(&path_spawn)
+                    .map(|fc| {
+                        let ext = extent_from_fc(&fc);
+                        (fc, ext)
+                    })
+                    .map_err(|_| ());
+                let _ = tx.send((path_spawn, result));
+            });
+        }
+    }
+}
+
+fn run_app_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> anyhow::Result<()> {
+    let mut areas = PanelAreas::default();
+    let mut clicks = MouseState::default();
+
+    loop {
+        tick(app);
 
         if app.needs_redraw {
             app.needs_redraw = false;
-            terminal.draw(|f| {
-                match app.mode {
-                    ViewMode::FileBrowser => {
-                        refresh_tile_preview(app);
-                        let cols = Layout::default()
-                            .direction(Direction::Horizontal)
-                            .constraints([
-                                Constraint::Percentage(app.file_left_pct),
-                                Constraint::Percentage(100u16.saturating_sub(app.file_left_pct)),
-                            ])
-                            .split(f.area());
-                        let right_pct = file_browser_preview_pct_clamped(
-                            app.file_preview_pct,
-                            app.file_filter_pct,
-                        );
-                        let filter_pct =
-                            file_browser_filter_pct_clamped(app.file_filter_pct, right_pct);
-                        app.file_preview_pct = right_pct;
-                        app.file_filter_pct = filter_pct;
-                        let right = Layout::default()
-                            .direction(Direction::Vertical)
-                            .constraints([
-                                Constraint::Percentage(right_pct),
-                                Constraint::Percentage(filter_pct),
-                                Constraint::Percentage(
-                                    100u16.saturating_sub(right_pct).saturating_sub(filter_pct),
-                                ),
-                            ])
-                            .split(cols[1]);
-                        render_file_browser(f, cols[0], app);
-                        render_tile_preview_panel(f, right[0], app);
-                        render_file_filter_panel(f, right[1], app);
-                        render_file_info_panel(f, right[2], app);
-                        file_left = Some(cols[0]);
-                        right_col = Some(cols[1]);
-                        preview_area = Some(right[0]);
-                        filter_area = Some(right[1]);
-                        info_area = Some(right[2]);
-                    }
-                    ViewMode::LayerOverview => {
-                        let cols = Layout::default()
-                            .direction(Direction::Horizontal)
-                            .constraints([
-                                Constraint::Percentage(app.left_pct),
-                                Constraint::Percentage(100u16.saturating_sub(app.left_pct)),
-                            ])
-                            .split(f.area());
-                        let left = Layout::default()
-                            .direction(Direction::Vertical)
-                            .constraints([
-                                Constraint::Percentage(app.features_pct),
-                                Constraint::Percentage(100u16.saturating_sub(app.features_pct)),
-                            ])
-                            .split(cols[0]);
-                        render_tree_panel(f, left[0], app);
-                        let ga = render_properties_panel(f, left[1], app);
-                        render_map_panel(f, cols[1], app);
-                        tree_area = Some(left[0]);
-                        props_area = Some(left[1]);
-                        geom_area = Some(ga);
-                        left_area = Some(cols[0]);
-                        map_area = Some(map_canvas_area(cols[1]));
-                    }
-                    ViewMode::MbtilesMap => {
-                        let cols = Layout::default()
-                            .direction(Direction::Horizontal)
-                            .constraints([
-                                Constraint::Percentage(app.left_pct),
-                                Constraint::Percentage(100u16.saturating_sub(app.left_pct)),
-                            ])
-                            .split(f.area());
-                        render_mbtiles_hover_panel(f, cols[0], app);
-                        render_mbtiles_map_panel(f, cols[1], app);
-                        left_area = Some(cols[0]);
-                        map_area = Some(map_canvas_area(cols[1]));
-                    }
-                }
-                if app.error_popup.is_some() {
-                    render_error_popup(f, app);
-                } else if app.show_help {
-                    render_help_overlay(f, app);
-                }
-            })?;
+            terminal.draw(|f| render_frame(f, app, &mut areas))?;
         }
 
         if event::poll(Duration::from_millis(16))? {
             match event::read()? {
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
-                    if key.modifiers.contains(KeyModifiers::CONTROL)
-                        && key.code == KeyCode::Char('c')
-                    {
+                    if handle_key(app, key) {
                         break;
                     }
-                    if app.error_popup.is_some() {
-                        app.error_popup = None;
-                        app.invalidate();
-                        continue;
-                    }
-                    if app.show_help {
-                        #[expect(
-                            clippy::wildcard_enum_match_arm,
-                            reason = "any other key closes help"
-                        )]
-                        match key.code {
-                            KeyCode::Up | KeyCode::Char('k') => {
-                                app.help_scroll = app.help_scroll.saturating_sub(1);
-                            }
-                            KeyCode::Down | KeyCode::Char('j') => {
-                                app.help_scroll = app.help_scroll.saturating_add(1);
-                            }
-                            KeyCode::PageUp => {
-                                app.help_scroll = app.help_scroll.saturating_sub(10);
-                            }
-                            KeyCode::PageDown => {
-                                app.help_scroll = app.help_scroll.saturating_add(10);
-                            }
-                            KeyCode::Home => app.help_scroll = 0,
-                            KeyCode::End => app.help_scroll = u16::MAX,
-                            _ => app.show_help = false,
-                        }
-                        app.invalidate();
-                        continue;
-                    }
-                    #[expect(clippy::wildcard_enum_match_arm, reason = "unbound keys do nothing")]
-                    match key.code {
-                        KeyCode::Char('q') => break,
-                        KeyCode::Esc if app.handle_escape() => break,
-                        KeyCode::Char('?') | KeyCode::F(1) => app.open_help(),
-                        KeyCode::Char('h') if !key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            app.open_help();
-                        }
-                        KeyCode::Enter => app.handle_enter(),
-                        KeyCode::Char('+' | '=') | KeyCode::Right => app.handle_plus(),
-                        KeyCode::Char('-') => app.handle_minus(),
-                        KeyCode::Char('*') => app.handle_star(),
-                        KeyCode::Up | KeyCode::Char('k') => app.move_up_by(1),
-                        KeyCode::Down | KeyCode::Char('j') => app.move_down_by(1),
-                        KeyCode::Left => app.handle_left_arrow(),
-                        KeyCode::PageUp => {
-                            app.move_up_by(app.page_size().saturating_sub(1).max(1));
-                        }
-                        KeyCode::PageDown => {
-                            app.move_down_by(app.page_size().saturating_sub(1).max(1));
-                        }
-                        KeyCode::Home => app.move_to_start(),
-                        KeyCode::End => app.move_to_end(),
-                        KeyCode::Char('h') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            app.left_pct = app.left_pct.saturating_sub(5).max(10);
-                            app.invalidate();
-                        }
-                        KeyCode::Char('l') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            app.left_pct = (app.left_pct + 5).min(90);
-                            app.invalidate();
-                        }
-                        KeyCode::Char('J') if key.modifiers.contains(KeyModifiers::SHIFT) => {
-                            app.features_pct = app.features_pct.saturating_sub(5).max(10);
-                            app.invalidate();
-                        }
-                        KeyCode::Char('K') if key.modifiers.contains(KeyModifiers::SHIFT) => {
-                            app.features_pct = (app.features_pct + 5).min(90);
-                            app.invalidate();
-                        }
-                        _ => {}
-                    }
                 }
-                Event::Mouse(mouse) if app.error_popup.is_some() => {
-                    if matches!(mouse.kind, MouseEventKind::Down(_)) {
-                        app.error_popup = None;
-                        app.invalidate();
-                    }
+                Event::Mouse(mouse) => {
+                    let screen = terminal.get_frame().area();
+                    handle_mouse(app, &areas, screen, mouse, &mut clicks)?;
                 }
-                Event::Mouse(mouse) if app.show_help => match mouse.kind {
-                    MouseEventKind::ScrollUp => {
-                        app.help_scroll = app.help_scroll.saturating_sub(1);
-                        app.invalidate();
-                    }
-                    MouseEventKind::ScrollDown => {
-                        app.help_scroll = app.help_scroll.saturating_add(1);
-                        app.invalidate();
-                    }
-                    MouseEventKind::Down(_)
-                    | MouseEventKind::Up(_)
-                    | MouseEventKind::Drag(_)
-                    | MouseEventKind::Moved
-                    | MouseEventKind::ScrollLeft
-                    | MouseEventKind::ScrollRight => {}
-                },
-                Event::Mouse(mouse) => match mouse.kind {
-                    MouseEventKind::Up(_) => {
-                        if let Some(ref mut mbt) = app.mbt_state {
-                            mbt.map_drag_last = None;
-                        }
-                        if app.resizing.take().is_some() {
-                            app.invalidate();
-                        }
-                    }
-                    MouseEventKind::Moved | MouseEventKind::Drag(_) => {
-                        if let Some(handle) = app.resizing {
-                            let area = terminal.get_frame().area();
-                            let la = left_area.unwrap_or_default();
-                            match handle {
-                                ResizeHandle::LeftRight => {
-                                    app.left_pct = pct_at(mouse.column, area.x, area.width);
-                                }
-                                ResizeHandle::FeaturesProperties => {
-                                    app.features_pct = pct_at(mouse.row, la.y, la.height);
-                                }
-                                ResizeHandle::PropertiesGeometry => {
-                                    if let Some(pa) = props_area {
-                                        app.properties_pct = pct_at(mouse.row, pa.y, pa.height);
-                                    }
-                                }
-                                ResizeHandle::FileBrowserLeftRight => {
-                                    app.file_left_pct = pct_at(mouse.column, area.x, area.width);
-                                }
-                                ResizeHandle::FileBrowserPreviewFilter => {
-                                    if let Some(rc) = right_col {
-                                        app.file_preview_pct = file_browser_preview_pct_clamped(
-                                            pct_at(mouse.row, rc.y, rc.height),
-                                            app.file_filter_pct,
-                                        );
-                                    }
-                                }
-                                ResizeHandle::FileBrowserFilterInfo => {
-                                    if let Some(rc) = right_col {
-                                        app.file_filter_pct = file_browser_filter_pct_clamped(
-                                            pct_at(mouse.row, rc.y, rc.height)
-                                                .saturating_sub(app.file_preview_pct),
-                                            app.file_preview_pct,
-                                        );
-                                    }
-                                }
-                            }
-                            app.invalidate();
-                            continue;
-                        }
-                        if app.mode == ViewMode::MbtilesMap
-                            && let MouseEventKind::Drag(MouseButton::Left) = mouse.kind
-                            && let (Some(area), Some(ref mut mbt)) =
-                                (map_area, app.mbt_state.as_mut())
-                            && let Some((lc, lr)) = mbt.map_drag_last
-                        {
-                            let dc = i32::from(mouse.column) - i32::from(lc);
-                            let dr = i32::from(mouse.row) - i32::from(lr);
-                            if dc != 0 || dr != 0 {
-                                mbt.pan_by_pixels(area.width, area.height, dc, dr);
-                                mbt.map_drag_last = Some((mouse.column, mouse.row));
-                                app.needs_redraw = true;
-                            }
-                        }
-                        let prev = app.hovered.clone();
-                        app.hovered = None;
-
-                        if app.mode == ViewMode::LayerOverview {
-                            let hover_ok = !matches!(
-                                app.tree_items.get(app.selected_index),
-                                Some(TreeItem::Feature { layer, feat })
-                                    if !app.expanded_features.contains(&(*layer, *feat))
-                            );
-                            if hover_ok
-                                && let Some(area) = tree_area
-                                && let Some(row) = click_row_in_area(
-                                    mouse.column,
-                                    mouse.row,
-                                    area,
-                                    app.tree_scroll.into_usize(),
-                                )
-                                && let Some((l, f, p)) =
-                                    app.tree_items.get(row).and_then(TreeItem::layer_feat_part)
-                            {
-                                app.hovered = Some(HoveredInfo::new(row, l, f, p));
-                            }
-                            if app.hovered.is_none()
-                                && let Some(area) = map_area
-                                && point_in_rect(mouse.column, mouse.row, area)
-                            {
-                                let b = app.get_bounds();
-                                let rx = f64::from(mouse.column - area.x) / f64::from(area.width);
-                                let ry = f64::from(mouse.row - area.y) / f64::from(area.height);
-                                let cx = b.0 + rx * (b.2 - b.0);
-                                let cy = b.3 - ry * (b.3 - b.1);
-                                app.find_hovered_feature(cx, cy, b);
-                            }
-                        }
-                        if app.hovered != prev {
-                            let allow = last_hover_redraw
-                                .is_none_or(|t| t.elapsed() >= HOVER_REDRAW_THROTTLE);
-                            if allow {
-                                last_hover_redraw = Some(Instant::now());
-                                app.invalidate();
-                            }
-                        }
-
-                        // MbtilesMap: update hover on mouse move over the map.
-                        if app.mode == ViewMode::MbtilesMap
-                            && let Some(area) = map_area
-                            && point_in_rect(mouse.column, mouse.row, area)
-                            && let Some(ref mut mbt) = app.mbt_state
-                        {
-                            let rx = f64::from(mouse.column - area.x) / f64::from(area.width);
-                            let ry = f64::from(mouse.row - area.y) / f64::from(area.height);
-                            let (wx, wy) = mbt.viewport_world_at_fracs(rx, ry);
-                            let prev_hov = mbt.hovered.clone();
-                            mbt.find_hovered(wx, wy);
-                            if mbt.hovered != prev_hov {
-                                let allow = last_hover_redraw
-                                    .is_none_or(|t| t.elapsed() >= HOVER_REDRAW_THROTTLE);
-                                if allow {
-                                    last_hover_redraw = Some(Instant::now());
-                                    app.invalidate();
-                                }
-                            }
-                        }
-                    }
-                    MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
-                        let up = matches!(mouse.kind, MouseEventKind::ScrollUp);
-                        let s = app.scroll_step();
-                        let step = u16::try_from(s)?;
-
-                        // MbtilesMap: scroll zooms in/out centred on the cursor.
-                        if app.mode == ViewMode::MbtilesMap
-                            && let (Some(area), Some(ref mut mbt)) =
-                                (map_area, app.mbt_state.as_mut())
-                        {
-                            if point_in_rect(mouse.column, mouse.row, area) {
-                                let rx = f64::from(mouse.column - area.x) / f64::from(area.width);
-                                let ry = f64::from(mouse.row - area.y) / f64::from(area.height);
-                                let (wx, wy) = mbt.viewport_world_at_fracs(rx, ry);
-                                mbt.zoom_wheel_at(wx, wy, up);
-                                app.needs_redraw = true;
-                                continue;
-                            }
-                            // Properties panel scroll
-                            if left_area.is_some_and(|a| point_in_rect(mouse.column, mouse.row, a))
-                            {
-                                app.properties_scroll = scroll_by(app.properties_scroll, step, up);
-                                app.invalidate();
-                                continue;
-                            }
-                        }
-
-                        if app.mode == ViewMode::FileBrowser {
-                            if filter_area
-                                .is_some_and(|a| point_in_rect(mouse.column, mouse.row, a))
-                            {
-                                app.filter_scroll = scroll_by(app.filter_scroll, step, up);
-                                app.invalidate();
-                                continue;
-                            }
-                            if info_area.is_some_and(|a| point_in_rect(mouse.column, mouse.row, a))
-                            {
-                                app.file_info_scroll = scroll_by(app.file_info_scroll, step, up);
-                                app.invalidate();
-                                continue;
-                            }
-                        }
-                        if app.mode == ViewMode::LayerOverview {
-                            if props_area.is_some_and(|a| point_in_rect(mouse.column, mouse.row, a))
-                            {
-                                app.properties_scroll = scroll_by(app.properties_scroll, step, up);
-                                app.invalidate();
-                                continue;
-                            }
-                            if let Some(area) = tree_area
-                                && point_in_rect(mouse.column, mouse.row, area)
-                            {
-                                if up {
-                                    app.tree_scroll = app.tree_scroll.saturating_sub(step);
-                                } else {
-                                    let inner = area.height.saturating_sub(2).into_usize();
-                                    let max =
-                                        u16::try_from(app.tree_items.len().saturating_sub(inner))?;
-                                    app.tree_scroll = app.tree_scroll.saturating_add(step).min(max);
-                                }
-                                app.invalidate();
-                                continue;
-                            }
-                            if map_area.is_some_and(|a| point_in_rect(mouse.column, mouse.row, a)) {
-                                continue;
-                            }
-                        }
-                        if up {
-                            app.move_up_by(s);
-                        } else {
-                            app.move_down_by(s);
-                        }
-                    }
-                    MouseEventKind::Down(btn) => {
-                        if app.mode == ViewMode::MbtilesMap
-                            && btn == MouseButton::Left
-                            && let (Some(area), Some(ref mut mbt)) =
-                                (map_area, app.mbt_state.as_mut())
-                            && point_in_rect(mouse.column, mouse.row, area)
-                        {
-                            mbt.map_drag_last = Some((mouse.column, mouse.row));
-                            continue;
-                        }
-                        if app.mode == ViewMode::FileBrowser {
-                            if let Some(fl) = file_left {
-                                let dx = fl.x + fl.width;
-                                if mouse.column >= dx.saturating_sub(DIVIDER_GRAB)
-                                    && mouse.column < dx.saturating_add(DIVIDER_GRAB)
-                                    && mouse.row >= fl.y
-                                    && mouse.row < fl.y + fl.height
-                                {
-                                    app.resizing = Some(ResizeHandle::FileBrowserLeftRight);
-                                    app.invalidate();
-                                    continue;
-                                }
-                            }
-                            if let (Some(pa), Some(fa)) = (preview_area, filter_area) {
-                                let mut invalidate = |value: u16, resizer: ResizeHandle| {
-                                    if mouse.row >= value.saturating_sub(DIVIDER_GRAB)
-                                        && mouse.row < value.saturating_add(DIVIDER_GRAB)
-                                        && right_col.is_some_and(|rc| {
-                                            point_in_rect(mouse.column, mouse.row, rc)
-                                        })
-                                    {
-                                        app.resizing = Some(resizer);
-                                        app.invalidate();
-                                        true
-                                    } else {
-                                        false
-                                    }
-                                };
-
-                                let dy_preview = pa.y + pa.height;
-                                if invalidate(dy_preview, ResizeHandle::FileBrowserPreviewFilter) {
-                                    continue;
-                                }
-                                let dy_filter = fa.y + fa.height;
-                                if invalidate(dy_filter, ResizeHandle::FileBrowserFilterInfo) {
-                                    continue;
-                                }
-                            }
-                            if let Some(fa) = filter_area
-                                && point_in_rect(mouse.column, mouse.row, fa)
-                            {
-                                let row = mouse.row.saturating_sub(fa.y + 1).into_usize()
-                                    + app.filter_scroll.into_usize();
-                                handle_filter_click(app, row);
-                                continue;
-                            }
-                            if let Some(ia) = info_area
-                                && point_in_rect(mouse.column, mouse.row, ia)
-                                && app.filtered_file_indices.is_empty()
-                                && !app.files.is_empty()
-                            {
-                                let row = mouse.row.saturating_sub(ia.y + 1).into_usize();
-                                if row == 2 {
-                                    app.ext_filters.clear();
-                                    app.geom_filters.clear();
-                                    app.algo_filters.clear();
-                                    app.rebuild_filtered_files();
-                                }
-                                continue;
-                            }
-                            if let Some(area) = app.file_table_area {
-                                if app.data_loaded()
-                                    && let Some(widths) = app.file_table_widths
-                                    && let Some(c) = file_header_click_column(
-                                        area,
-                                        &widths,
-                                        mouse.column,
-                                        mouse.row,
-                                    )
-                                {
-                                    app.handle_file_header_click(c);
-                                    continue;
-                                }
-                                if let Some(row) = click_row_in_area(
-                                    mouse.column,
-                                    mouse.row,
-                                    area,
-                                    app.file_list_state.offset(),
-                                ) && row < app.filtered_file_indices.len()
-                                {
-                                    let dbl = last_file_click.is_some_and(|(t, prev)| {
-                                        prev == row && t.elapsed().as_millis() < 400
-                                    });
-                                    last_file_click = Some((Instant::now(), row));
-                                    app.selected_file_index = row;
-                                    app.file_list_state.select(Some(row));
-                                    app.invalidate_bounds();
-                                    if dbl {
-                                        app.handle_enter();
-                                    }
-                                }
-                            }
-                        } else if app.mode == ViewMode::LayerOverview {
-                            if let (Some(la), Some(ta)) = (left_area, tree_area)
-                                && let Some(h) =
-                                    divider_hit(mouse.column, mouse.row, la, ta, geom_area)
-                            {
-                                app.resizing = Some(h);
-                                app.invalidate();
-                                continue;
-                            }
-                            if let Some(area) = tree_area
-                                && let Some(row) = click_row_in_area(
-                                    mouse.column,
-                                    mouse.row,
-                                    area,
-                                    app.tree_scroll.into_usize(),
-                                )
-                                && row < app.tree_items.len()
-                            {
-                                let dbl = last_tree_click.is_some_and(|(t, prev)| {
-                                    prev == row && t.elapsed().as_millis() < 400
-                                });
-                                last_tree_click = Some((Instant::now(), row));
-                                if let Some((l, f, p)) =
-                                    app.tree_items.get(row).and_then(TreeItem::layer_feat_part)
-                                {
-                                    app.handle_feature_click(l, f, p, area.height);
-                                } else {
-                                    app.selected_index = row;
-                                    app.scroll_selected_into_view(
-                                        area.height.saturating_sub(2).into_usize(),
-                                    );
-                                }
-                                app.invalidate_bounds();
-                                if dbl {
-                                    app.handle_enter();
-                                }
-                            }
-                            if let Some(ref h) = app.hovered
-                                && let Some(ta) = tree_area
-                                && map_area
-                                    .is_some_and(|m| point_in_rect(mouse.column, mouse.row, m))
-                            {
-                                app.handle_feature_click(h.layer, h.feat, h.part, ta.height);
-                                app.invalidate_bounds();
-                            }
-                        }
-                    }
-                    MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => {}
-                },
                 Event::Resize(_, _) => app.invalidate(),
                 Event::FocusGained | Event::FocusLost | Event::Key(_) | Event::Paste(_) => {}
             }
@@ -1359,4 +1009,402 @@ impl PointDistance for GeometryIndexEntry {
 #[must_use]
 pub fn coord_f64(c: Coord<i32>) -> [f64; 2] {
     [f64::from(c.x), f64::from(c.y)]
+}
+
+/// Timestamps the mouse handling keeps between events.
+#[derive(Default)]
+struct MouseState {
+    tree_click: Option<(Instant, usize)>,
+    file_click: Option<(Instant, usize)>,
+    hover_redraw: Option<Instant>,
+}
+
+/// Apply a mouse event against the panels drawn by the last frame.
+fn handle_mouse(
+    app: &mut App,
+    areas: &PanelAreas,
+    screen: Rect,
+    mouse: MouseEvent,
+    clicks: &mut MouseState,
+) -> anyhow::Result<()> {
+    if app.error_popup.is_some() {
+        if matches!(mouse.kind, MouseEventKind::Down(_)) {
+            app.error_popup = None;
+            app.invalidate();
+        }
+        return Ok(());
+    }
+    if app.show_help {
+        match mouse.kind {
+            MouseEventKind::ScrollUp => {
+                app.help_scroll = app.help_scroll.saturating_sub(1);
+                app.invalidate();
+            }
+            MouseEventKind::ScrollDown => {
+                app.help_scroll = app.help_scroll.saturating_add(1);
+                app.invalidate();
+            }
+            MouseEventKind::Down(_)
+            | MouseEventKind::Up(_)
+            | MouseEventKind::Drag(_)
+            | MouseEventKind::Moved
+            | MouseEventKind::ScrollLeft
+            | MouseEventKind::ScrollRight => {}
+        }
+        return Ok(());
+    }
+    match mouse.kind {
+        MouseEventKind::Up(_) => {
+            if let Some(ref mut mbt) = app.mbt_state {
+                mbt.map_drag_last = None;
+            }
+            if app.resizing.take().is_some() {
+                app.invalidate();
+            }
+        }
+        MouseEventKind::Moved | MouseEventKind::Drag(_) => {
+            if let Some(handle) = app.resizing {
+                let area = screen;
+                let la = areas.left.unwrap_or_default();
+                match handle {
+                    ResizeHandle::LeftRight => {
+                        app.left_pct = pct_at(mouse.column, area.x, area.width);
+                    }
+                    ResizeHandle::FeaturesProperties => {
+                        app.features_pct = pct_at(mouse.row, la.y, la.height);
+                    }
+                    ResizeHandle::PropertiesGeometry => {
+                        if let Some(pa) = areas.props {
+                            app.properties_pct = pct_at(mouse.row, pa.y, pa.height);
+                        }
+                    }
+                    ResizeHandle::FileBrowserLeftRight => {
+                        app.file_left_pct = pct_at(mouse.column, area.x, area.width);
+                    }
+                    ResizeHandle::FileBrowserPreviewFilter => {
+                        if let Some(rc) = areas.right_col {
+                            app.file_preview_pct = file_browser_preview_pct_clamped(
+                                pct_at(mouse.row, rc.y, rc.height),
+                                app.file_filter_pct,
+                            );
+                        }
+                    }
+                    ResizeHandle::FileBrowserFilterInfo => {
+                        if let Some(rc) = areas.right_col {
+                            app.file_filter_pct = file_browser_filter_pct_clamped(
+                                pct_at(mouse.row, rc.y, rc.height)
+                                    .saturating_sub(app.file_preview_pct),
+                                app.file_preview_pct,
+                            );
+                        }
+                    }
+                }
+                app.invalidate();
+                return Ok(());
+            }
+            if app.mode == ViewMode::MbtilesMap
+                && let MouseEventKind::Drag(MouseButton::Left) = mouse.kind
+                && let (Some(area), Some(ref mut mbt)) = (areas.map, app.mbt_state.as_mut())
+                && let Some((lc, lr)) = mbt.map_drag_last
+            {
+                let dc = i32::from(mouse.column) - i32::from(lc);
+                let dr = i32::from(mouse.row) - i32::from(lr);
+                if dc != 0 || dr != 0 {
+                    mbt.pan_by_pixels(area.width, area.height, dc, dr);
+                    mbt.map_drag_last = Some((mouse.column, mouse.row));
+                    app.needs_redraw = true;
+                }
+            }
+            let prev = app.hovered.clone();
+            app.hovered = None;
+
+            if app.mode == ViewMode::LayerOverview {
+                let hover_ok = !matches!(
+                    app.tree_items.get(app.selected_index),
+                    Some(TreeItem::Feature { layer, feat })
+                        if !app.expanded_features.contains(&(*layer, *feat))
+                );
+                if hover_ok
+                    && let Some(area) = areas.tree
+                    && let Some(row) = click_row_in_area(
+                        mouse.column,
+                        mouse.row,
+                        area,
+                        app.tree_scroll.into_usize(),
+                    )
+                    && let Some((l, f, p)) =
+                        app.tree_items.get(row).and_then(TreeItem::layer_feat_part)
+                {
+                    app.hovered = Some(HoveredInfo::new(row, l, f, p));
+                }
+                if app.hovered.is_none()
+                    && let Some(area) = areas.map
+                    && point_in_rect(mouse.column, mouse.row, area)
+                {
+                    let b = app.get_bounds();
+                    let rx = f64::from(mouse.column - area.x) / f64::from(area.width);
+                    let ry = f64::from(mouse.row - area.y) / f64::from(area.height);
+                    let cx = b.0 + rx * (b.2 - b.0);
+                    let cy = b.3 - ry * (b.3 - b.1);
+                    app.find_hovered_feature(cx, cy, b);
+                }
+            }
+            if app.hovered != prev {
+                let allow = clicks
+                    .hover_redraw
+                    .is_none_or(|t| t.elapsed() >= HOVER_REDRAW_THROTTLE);
+                if allow {
+                    clicks.hover_redraw = Some(Instant::now());
+                    app.invalidate();
+                }
+            }
+
+            // MbtilesMap: update hover on mouse move over the map.
+            if app.mode == ViewMode::MbtilesMap
+                && let Some(area) = areas.map
+                && point_in_rect(mouse.column, mouse.row, area)
+                && let Some(ref mut mbt) = app.mbt_state
+            {
+                let rx = f64::from(mouse.column - area.x) / f64::from(area.width);
+                let ry = f64::from(mouse.row - area.y) / f64::from(area.height);
+                let (wx, wy) = mbt.viewport_world_at_fracs(rx, ry);
+                let prev_hov = mbt.hovered.clone();
+                mbt.find_hovered(wx, wy);
+                if mbt.hovered != prev_hov {
+                    let allow = clicks
+                        .hover_redraw
+                        .is_none_or(|t| t.elapsed() >= HOVER_REDRAW_THROTTLE);
+                    if allow {
+                        clicks.hover_redraw = Some(Instant::now());
+                        app.invalidate();
+                    }
+                }
+            }
+        }
+        MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
+            let up = matches!(mouse.kind, MouseEventKind::ScrollUp);
+            let s = app.scroll_step();
+            let step = u16::try_from(s)?;
+
+            // MbtilesMap: scroll zooms in/out centred on the cursor.
+            if app.mode == ViewMode::MbtilesMap
+                && let (Some(area), Some(ref mut mbt)) = (areas.map, app.mbt_state.as_mut())
+            {
+                if point_in_rect(mouse.column, mouse.row, area) {
+                    let rx = f64::from(mouse.column - area.x) / f64::from(area.width);
+                    let ry = f64::from(mouse.row - area.y) / f64::from(area.height);
+                    let (wx, wy) = mbt.viewport_world_at_fracs(rx, ry);
+                    mbt.zoom_wheel_at(wx, wy, up);
+                    app.needs_redraw = true;
+                    return Ok(());
+                }
+                // Properties panel scroll
+                if areas
+                    .left
+                    .is_some_and(|a| point_in_rect(mouse.column, mouse.row, a))
+                {
+                    app.properties_scroll = scroll_by(app.properties_scroll, step, up);
+                    app.invalidate();
+                    return Ok(());
+                }
+            }
+
+            if app.mode == ViewMode::FileBrowser {
+                if areas
+                    .filter
+                    .is_some_and(|a| point_in_rect(mouse.column, mouse.row, a))
+                {
+                    app.filter_scroll = scroll_by(app.filter_scroll, step, up);
+                    app.invalidate();
+                    return Ok(());
+                }
+                if areas
+                    .info
+                    .is_some_and(|a| point_in_rect(mouse.column, mouse.row, a))
+                {
+                    app.file_info_scroll = scroll_by(app.file_info_scroll, step, up);
+                    app.invalidate();
+                    return Ok(());
+                }
+            }
+            if app.mode == ViewMode::LayerOverview {
+                if areas
+                    .props
+                    .is_some_and(|a| point_in_rect(mouse.column, mouse.row, a))
+                {
+                    app.properties_scroll = scroll_by(app.properties_scroll, step, up);
+                    app.invalidate();
+                    return Ok(());
+                }
+                if let Some(area) = areas.tree
+                    && point_in_rect(mouse.column, mouse.row, area)
+                {
+                    if up {
+                        app.tree_scroll = app.tree_scroll.saturating_sub(step);
+                    } else {
+                        let inner = area.height.saturating_sub(2).into_usize();
+                        let max = u16::try_from(app.tree_items.len().saturating_sub(inner))?;
+                        app.tree_scroll = app.tree_scroll.saturating_add(step).min(max);
+                    }
+                    app.invalidate();
+                    return Ok(());
+                }
+                if areas
+                    .map
+                    .is_some_and(|a| point_in_rect(mouse.column, mouse.row, a))
+                {
+                    return Ok(());
+                }
+            }
+            if up {
+                app.move_up_by(s);
+            } else {
+                app.move_down_by(s);
+            }
+        }
+        MouseEventKind::Down(btn) => {
+            if app.mode == ViewMode::MbtilesMap
+                && btn == MouseButton::Left
+                && let (Some(area), Some(ref mut mbt)) = (areas.map, app.mbt_state.as_mut())
+                && point_in_rect(mouse.column, mouse.row, area)
+            {
+                mbt.map_drag_last = Some((mouse.column, mouse.row));
+                return Ok(());
+            }
+            if app.mode == ViewMode::FileBrowser {
+                if let Some(fl) = areas.file_left {
+                    let dx = fl.x + fl.width;
+                    if mouse.column >= dx.saturating_sub(DIVIDER_GRAB)
+                        && mouse.column < dx.saturating_add(DIVIDER_GRAB)
+                        && mouse.row >= fl.y
+                        && mouse.row < fl.y + fl.height
+                    {
+                        app.resizing = Some(ResizeHandle::FileBrowserLeftRight);
+                        app.invalidate();
+                        return Ok(());
+                    }
+                }
+                if let (Some(pa), Some(fa)) = (areas.preview, areas.filter) {
+                    let mut invalidate = |value: u16, resizer: ResizeHandle| {
+                        if mouse.row >= value.saturating_sub(DIVIDER_GRAB)
+                            && mouse.row < value.saturating_add(DIVIDER_GRAB)
+                            && areas
+                                .right_col
+                                .is_some_and(|rc| point_in_rect(mouse.column, mouse.row, rc))
+                        {
+                            app.resizing = Some(resizer);
+                            app.invalidate();
+                            true
+                        } else {
+                            false
+                        }
+                    };
+
+                    let dy_preview = pa.y + pa.height;
+                    if invalidate(dy_preview, ResizeHandle::FileBrowserPreviewFilter) {
+                        return Ok(());
+                    }
+                    let dy_filter = fa.y + fa.height;
+                    if invalidate(dy_filter, ResizeHandle::FileBrowserFilterInfo) {
+                        return Ok(());
+                    }
+                }
+                if let Some(fa) = areas.filter
+                    && point_in_rect(mouse.column, mouse.row, fa)
+                {
+                    let row = mouse.row.saturating_sub(fa.y + 1).into_usize()
+                        + app.filter_scroll.into_usize();
+                    handle_filter_click(app, row);
+                    return Ok(());
+                }
+                if let Some(ia) = areas.info
+                    && point_in_rect(mouse.column, mouse.row, ia)
+                    && app.filtered_file_indices.is_empty()
+                    && !app.files.is_empty()
+                {
+                    let row = mouse.row.saturating_sub(ia.y + 1).into_usize();
+                    if row == 2 {
+                        app.ext_filters.clear();
+                        app.geom_filters.clear();
+                        app.algo_filters.clear();
+                        app.rebuild_filtered_files();
+                    }
+                    return Ok(());
+                }
+                if let Some(area) = app.file_table_area {
+                    if app.data_loaded()
+                        && let Some(widths) = app.file_table_widths
+                        && let Some(c) =
+                            file_header_click_column(area, &widths, mouse.column, mouse.row)
+                    {
+                        app.handle_file_header_click(c);
+                        return Ok(());
+                    }
+                    if let Some(row) = click_row_in_area(
+                        mouse.column,
+                        mouse.row,
+                        area,
+                        app.file_list_state.offset(),
+                    ) && row < app.filtered_file_indices.len()
+                    {
+                        let dbl = clicks
+                            .file_click
+                            .is_some_and(|(t, prev)| prev == row && t.elapsed().as_millis() < 400);
+                        clicks.file_click = Some((Instant::now(), row));
+                        app.selected_file_index = row;
+                        app.file_list_state.select(Some(row));
+                        app.invalidate_bounds();
+                        if dbl {
+                            app.handle_enter();
+                        }
+                    }
+                }
+            } else if app.mode == ViewMode::LayerOverview {
+                if let (Some(la), Some(ta)) = (areas.left, areas.tree)
+                    && let Some(h) = divider_hit(mouse.column, mouse.row, la, ta, areas.geom)
+                {
+                    app.resizing = Some(h);
+                    app.invalidate();
+                    return Ok(());
+                }
+                if let Some(area) = areas.tree
+                    && let Some(row) = click_row_in_area(
+                        mouse.column,
+                        mouse.row,
+                        area,
+                        app.tree_scroll.into_usize(),
+                    )
+                    && row < app.tree_items.len()
+                {
+                    let dbl = clicks
+                        .tree_click
+                        .is_some_and(|(t, prev)| prev == row && t.elapsed().as_millis() < 400);
+                    clicks.tree_click = Some((Instant::now(), row));
+                    if let Some((l, f, p)) =
+                        app.tree_items.get(row).and_then(TreeItem::layer_feat_part)
+                    {
+                        app.handle_feature_click(l, f, p, area.height);
+                    } else {
+                        app.selected_index = row;
+                        app.scroll_selected_into_view(area.height.saturating_sub(2).into_usize());
+                    }
+                    app.invalidate_bounds();
+                    if dbl {
+                        app.handle_enter();
+                    }
+                }
+                if let Some(ref h) = app.hovered
+                    && let Some(ta) = areas.tree
+                    && areas
+                        .map
+                        .is_some_and(|m| point_in_rect(mouse.column, mouse.row, m))
+                {
+                    app.handle_feature_click(h.layer, h.feat, h.part, ta.height);
+                    app.invalidate_bounds();
+                }
+            }
+        }
+        MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => {}
+    }
+    Ok(())
 }

--- a/rust/mlt/src/ui/state.rs
+++ b/rust/mlt/src/ui/state.rs
@@ -61,7 +61,7 @@ impl TreeItem {
     }
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HoveredInfo {
     pub(crate) tree_idx: usize,
     pub(crate) layer: usize,

--- a/rust/mlt/src/ui/state.rs
+++ b/rust/mlt/src/ui/state.rs
@@ -301,6 +301,8 @@ impl App {
         self.build_geometry_index();
         self.build_tree_items();
         self.selected_index = 0;
+        self.hovered = None;
+        self.tree_scroll = 0;
         self.invalidate_bounds();
         Ok(())
     }
@@ -561,6 +563,7 @@ impl App {
             ViewMode::LayerOverview if self.files.is_empty() => true,
             ViewMode::LayerOverview => {
                 self.mode = ViewMode::FileBrowser;
+                self.hovered = None;
                 self.invalidate_bounds();
                 false
             }
@@ -586,6 +589,7 @@ impl App {
             TreeItem::All => {
                 if !self.files.is_empty() {
                     self.mode = ViewMode::FileBrowser;
+                    self.hovered = None;
                 }
                 return;
             }

--- a/rust/mlt/src/ui/tests.rs
+++ b/rust/mlt/src/ui/tests.rs
@@ -1,0 +1,1786 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::mpsc;
+use std::time::Duration;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+use mlt_core::geo_types::{
+    Coord, Geometry, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
+};
+use mlt_core::geojson::{Feature, FeatureCollection};
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use ratatui::layout::Rect;
+use serde_json::{Value, json};
+
+use super::{
+    MouseState, PanelAreas, SCAN_FLAGS, UiArgs, build_app, collect_extensions,
+    collect_file_algorithms, collect_file_geometries, extent_from_fc, find_tile_files,
+    handle_filter_click, handle_key, handle_mouse, load_fc, parse_center_tile_xyz, render_frame,
+    tick,
+};
+use crate::ls::{FileSortColumn, LsRow, analyze_tile_files};
+use crate::ui::mbt::{MbtHoveredInfo, MbtTileData, MbtilesState};
+use crate::ui::state::{App, HoveredInfo, ResizeHandle, TreeItem, ViewMode};
+
+const WIDTH: u16 = 100;
+const HEIGHT: u16 = 30;
+
+fn render(app: &mut App) -> String {
+    render_sized(app, WIDTH, HEIGHT)
+}
+
+fn render_sized(app: &mut App, width: u16, height: u16) -> String {
+    let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+    let mut areas = PanelAreas::default();
+    terminal.draw(|f| render_frame(f, app, &mut areas)).unwrap();
+    terminal.backend().to_string()
+}
+
+fn press(app: &mut App, code: KeyCode) {
+    assert!(
+        !handle_key(app, KeyEvent::new(code, KeyModifiers::NONE)),
+        "{code:?} should not quit"
+    );
+}
+
+fn quits(app: &mut App, code: KeyCode) -> bool {
+    handle_key(app, KeyEvent::new(code, KeyModifiers::NONE))
+}
+
+fn c(x: i32, y: i32) -> Coord<i32> {
+    Coord { x, y }
+}
+
+fn square(x0: i32, y0: i32, x1: i32, y1: i32) -> LineString<i32> {
+    LineString(vec![c(x0, y0), c(x1, y0), c(x1, y1), c(x0, y1)])
+}
+
+fn feature(layer: &str, geometry: impl Into<Geometry<i32>>, props: &[(&str, Value)]) -> Feature {
+    let mut properties: BTreeMap<String, Value> = props
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), v.clone()))
+        .collect();
+    properties.insert("_layer".into(), json!(layer));
+    properties.insert("_extent".into(), json!(4096));
+    Feature {
+        geometry: geometry.into(),
+        id: None,
+        properties,
+        ty: "Feature".into(),
+    }
+}
+
+/// Three layers covering every geometry type, with a hole in the first polygon.
+fn sample_fc() -> FeatureCollection {
+    let features = vec![
+        feature(
+            "water",
+            Polygon::new(
+                square(500, 500, 3500, 3500),
+                vec![LineString(vec![
+                    c(1500, 1500),
+                    c(1500, 2500),
+                    c(2500, 2500),
+                    c(2500, 1500),
+                ])],
+            ),
+            &[("class", json!("lake")), ("name", json!("Loch"))],
+        ),
+        feature(
+            "water",
+            MultiPolygon(vec![
+                Polygon::new(square(200, 200, 800, 800), vec![]),
+                Polygon::new(square(3300, 3300, 3900, 3900), vec![]),
+            ]),
+            &[("class", json!("pond"))],
+        ),
+        feature(
+            "roads",
+            LineString(vec![c(0, 2048), c(4096, 2048)]),
+            &[("class", json!("primary")), ("oneway", json!(true))],
+        ),
+        feature(
+            "roads",
+            MultiLineString(vec![
+                LineString(vec![c(2048, 0), c(2048, 4096)]),
+                LineString(vec![c(0, 0), c(4096, 4096)]),
+            ]),
+            &[("class", json!("path"))],
+        ),
+        feature(
+            "poi",
+            Point(c(1000, 3000)),
+            &[("name", json!("Cafe")), ("rank", json!(3))],
+        ),
+        feature(
+            "poi",
+            MultiPoint(vec![Point(c(3000, 1000)), Point(c(3200, 1200))]),
+            &[("name", json!("Twin peaks"))],
+        ),
+    ];
+    FeatureCollection {
+        features,
+        ty: "FeatureCollection".into(),
+    }
+}
+
+fn sample_app() -> App {
+    App::new_single_file(sample_fc(), Some(PathBuf::from("sample.mlt")))
+}
+
+/// Fixture paths relative to the package directory, where cargo runs unit tests.
+fn test_dir(rel: &str) -> PathBuf {
+    PathBuf::from("../../test").join(rel)
+}
+
+fn fixtures_dir() -> PathBuf {
+    test_dir("fixtures/simple")
+}
+
+/// File browser over `test/fixtures/simple` with every file analyzed.
+fn file_browser_app() -> App {
+    browser_over(fixtures_dir())
+}
+
+fn browser_over(base: PathBuf) -> App {
+    let paths = find_tile_files(&base).unwrap();
+    let files = analyze_tile_files(&paths, &base, SCAN_FLAGS);
+    App::new_file_browser(files, None, base)
+}
+
+fn analyze_row(path: PathBuf, base: &std::path::Path) -> LsRow {
+    analyze_tile_files(&[path], base, SCAN_FLAGS).remove(0)
+}
+
+#[test]
+fn layer_overview_starts_on_all_layers() {
+    let mut app = sample_app();
+    insta::assert_snapshot!(render(&mut app), @r#"
+    "┌sample.mlt - Enter/+/-:expan┐┌Map View────────────────────────────────────────────────────────────┐"
+    "│>> All                      ││                                                                    │"
+    "│     Layer: water (2 feature││                                                                    │"
+    "│     Layer: roads (2 feature││     ⢰⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⢲⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⢒⡲⡆     │"
+    "│     Layer: poi (2 features,││     ⢸                           ⢸                 ⡤⠤⠤⠤⠤⠤⠤⢤⡔⠁ ⡇     │"
+    "│                            ││     ⢸                           ⢸                 ⡇    ⡠⠊⠁⡇  ⡇     │"
+    "│                            ││     ⢸      ⢀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣸⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣇⣀⣀⠔⠊   ⡇  ⡇     │"
+    "│                            ││     ⢸      ⢸                    ⢸                 ⣧⣒⣹⣀⣀⣀⣀⣀⡇  ⡇     │"
+    "│                            ││     ⢸      ⢸                    ⢸              ⢀⠤⠊  ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸      ×             ⢸            ⣀⠔⠁    ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸                    ⢸         ⢀⡠⠊       ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸                    ⢸       ⢀⠔⠁         ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸             ⡖⠒⠒⠒⠒⠒⠒⢺⠒⠒⠒⠒⠒⡲⡎⠁           ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸             ⡇      ⢸  ⢀⠔⠊ ⡇            ⢸        ⡇     │"
+    "└────────────────────────────┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
+    "┌Properties──────────────────┐│     ⢸⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⢉⠭⢻⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⡇     │"
+    "│Select or hover over a      ││     ⢸      ⢸             ⡇  ⡠⠔⠁ ⢸      ⡇            ⢸        ⡇     │"
+    "│feature to view properties  ││     ⢸      ⢸             ⣇⡠⠊    ⢸      ⡇            ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸           ⢀⠔⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠁            ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸         ⡠⠊⠁        ⢸               ×   ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸      ⢀⠔⠉           ⢸            ×      ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸    ⡠⠒⠁             ⢸                   ⢸        ⡇     │"
+    "└────────────────────────────┘│     ⢸  ⢸⠉⠉⠉⢹⠉⢉⠭⢻                ⢸                   ⢸        ⡇     │"
+    "┌Geometry────────────────────┐│     ⢸  ⢸   ⡸⠴⠥⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼        ⡇     │"
+    "│Select or hover over a      ││     ⢸  ⢸⢀⡠⠊    ⢸                ⢸                            ⡇     │"
+    "│feature to view geometry    ││     ⢸ ⢀⠜⠓⠒⠒⠒⠒⠒⠒⠚                ⢸                            ⡇     │"
+    "│info                        ││     ⠸⠮⠥⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
+    "│                            ││                                                                    │"
+    "│                            ││                                                                    │"
+    "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
+    "#);
+}
+
+#[test]
+fn keys_expand_a_layer_and_select_a_feature() {
+    let mut app = sample_app();
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Enter);
+    press(&mut app, KeyCode::Down);
+    insta::assert_snapshot!(render(&mut app), @r#"
+    "┌sample.mlt - Enter/+/-:expan┐┌Map View────────────────────────────────────────────────────────────┐"
+    "│   All                      ││                                                                    │"
+    "│     Layer: water (2 feature││                                                                    │"
+    "│>>     Feat 0: Polygon (10v,││     ⢰⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⡆     │"
+    "│       Feat 1: MultiPolygon ││     ⢸                                                        ⡇     │"
+    "│     Layer: roads (2 feature││     ⢸                                                        ⡇     │"
+    "│     Layer: poi (2 features,││     ⢸      ⢀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀        ⡇     │"
+    "│                            ││     ⢸      ⢸                                        ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸                                        ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸                                        ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸                                        ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸                                        ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸             ⡖⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⡆            ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸             ⡇             ⡇            ⢸        ⡇     │"
+    "└────────────────────────────┘│     ⢸      ⢸             ⡇             ⡇            ⢸        ⡇     │"
+    "┌Properties (feat 0)─────────┐│     ⢸      ⢸             ⡇             ⡇            ⢸        ⡇     │"
+    "│class: lake                 ││     ⢸      ⢸             ⡇             ⡇            ⢸        ⡇     │"
+    "│name: Loch                  ││     ⢸      ⢸             ⡇             ⡇            ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸             ⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠁            ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸                                        ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸                                        ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸                                        ⢸        ⡇     │"
+    "└────────────────────────────┘│     ⢸      ⢸                                        ⢸        ⡇     │"
+    "┌Geometry────────────────────┐│     ⢸      ⠸⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼        ⡇     │"
+    "│Type: Polygon               ││     ⢸                                                        ⡇     │"
+    "│Vertices: 10                ││     ⢸                                                        ⡇     │"
+    "│Rings: 2                    ││     ⠸⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
+    "│  Ring 0: 5v, CCW           ││                                                                    │"
+    "│  Ring 1: 5v, CW            ││                                                                    │"
+    "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
+    "#);
+}
+
+#[test]
+fn keys_drill_into_a_multipolygon_part() {
+    let mut app = sample_app();
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Char('+'));
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Char('+'));
+    press(&mut app, KeyCode::Down);
+    insta::assert_snapshot!(render(&mut app), @r#"
+    "┌sample.mlt - Enter/+/-:expan┐┌Map View────────────────────────────────────────────────────────────┐"
+    "│   All                      ││                                                                    │"
+    "│     Layer: water (2 feature││                                                                    │"
+    "│       Feat 0: Polygon (10v,││     ⢰⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⡆     │"
+    "│       Feat 1: MultiPolygon ││     ⢸                                             ⡤⠤⠤⠤⠤⠤⠤⠤⡄  ⡇     │"
+    "│>>       Part 0: Polygon (5v││     ⢸                                             ⡇       ⡇  ⡇     │"
+    "│         Part 1: Polygon (5v││     ⢸                                             ⡇       ⡇  ⡇     │"
+    "│     Layer: roads (2 feature││     ⢸                                             ⣇⣀⣀⣀⣀⣀⣀⣀⡇  ⡇     │"
+    "│     Layer: poi (2 features,││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "└────────────────────────────┘│     ⢸                                                        ⡇     │"
+    "┌Properties (feat 1)─────────┐│     ⢸                                                        ⡇     │"
+    "│class: pond                 ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "└────────────────────────────┘│     ⢸  ⢸⠉⠉⠉⠉⠉⠉⠉⢹                                             ⡇     │"
+    "┌Geometry────────────────────┐│     ⢸  ⢸       ⢸                                             ⡇     │"
+    "│Component: part #0 of a     ││     ⢸  ⢸       ⢸                                             ⡇     │"
+    "│MultiPolygon                ││     ⢸  ⠘⠒⠒⠒⠒⠒⠒⠒⠚                                             ⡇     │"
+    "│Type: Polygon               ││     ⠸⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
+    "│Vertices: 5                 ││                                                                    │"
+    "│Rings: 1                    ││                                                                    │"
+    "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
+    "#);
+}
+
+#[test]
+fn star_expands_every_layer_and_end_jumps_to_the_last_row() {
+    let mut app = sample_app();
+    press(&mut app, KeyCode::Char('*'));
+    press(&mut app, KeyCode::End);
+    insta::assert_snapshot!(render(&mut app), @r#"
+    "┌sample.mlt - Enter/+/-:expan┐┌Map View────────────────────────────────────────────────────────────┐"
+    "│   All                      ││                                                                    │"
+    "│     Layer: water (2 feature││                                                                    │"
+    "│       Feat 0: Polygon (10v,││     ⢰⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⡆     │"
+    "│       Feat 1: MultiPolygon ││     ⢸                                                        ⡇     │"
+    "│     Layer: roads (2 feature││     ⢸                                                        ⡇     │"
+    "│       Feat 0: LineString (2││     ⢸                                                        ⡇     │"
+    "│       Feat 1: MultiLineStri││     ⢸                                                        ⡇     │"
+    "│     Layer: poi (2 features,││     ⢸                                                        ⡇     │"
+    "│       Feat 0: Point        ││     ⢸                                                        ⡇     │"
+    "│>>     Feat 1: MultiPoint (2││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "└────────────────────────────┘│     ⢸                                                        ⡇     │"
+    "┌Properties (feat 1)─────────┐│     ⢸                                                        ⡇     │"
+    "│name: Twin peaks            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                           ×            ⡇     │"
+    "│                            ││     ⢸                                        ×               ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "└────────────────────────────┘│     ⢸                                                        ⡇     │"
+    "┌Geometry────────────────────┐│     ⢸                                                        ⡇     │"
+    "│Type: MultiPoint            ││     ⢸                                                        ⡇     │"
+    "│Points: 2                   ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⠸⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
+    "│                            ││                                                                    │"
+    "│                            ││                                                                    │"
+    "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
+    "#);
+}
+
+#[test]
+fn hovering_the_map_highlights_the_nearest_feature() {
+    let mut app = sample_app();
+    let bounds = app.get_bounds();
+    app.find_hovered_feature(1000.0, 3000.0, bounds);
+    insta::assert_snapshot!(render(&mut app), @r#"
+    "┌sample.mlt - Enter/+/-:expan┐┌Map View────────────────────────────────────────────────────────────┐"
+    "│>> All                      ││                                                                    │"
+    "│     Layer: water (2 feature││                                                                    │"
+    "│     Layer: roads (2 feature││     ⢰⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⢲⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⢒⡲⡆     │"
+    "│     Layer: poi (2 features,││     ⢸                           ⢸                 ⡤⠤⠤⠤⠤⠤⠤⢤⡔⠁ ⡇     │"
+    "│                            ││     ⢸                           ⢸                 ⡇    ⡠⠊⠁⡇  ⡇     │"
+    "│                            ││     ⢸      ⢀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣸⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣇⣀⣀⠔⠊   ⡇  ⡇     │"
+    "│                            ││     ⢸      ⢸                    ⢸                 ⣧⣒⣹⣀⣀⣀⣀⣀⡇  ⡇     │"
+    "│                            ││     ⢸      ⢸                    ⢸              ⢀⠤⠊  ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸      ×             ⢸            ⣀⠔⠁    ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸                    ⢸         ⢀⡠⠊       ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸                    ⢸       ⢀⠔⠁         ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸             ⡖⠒⠒⠒⠒⠒⠒⢺⠒⠒⠒⠒⠒⡲⡎⠁           ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸             ⡇      ⢸  ⢀⠔⠊ ⡇            ⢸        ⡇     │"
+    "└────────────────────────────┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
+    "┌Properties (feat 0, hover)──┐│     ⢸⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⢉⠭⢻⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⡇     │"
+    "│name: Cafe                  ││     ⢸      ⢸             ⡇  ⡠⠔⠁ ⢸      ⡇            ⢸        ⡇     │"
+    "│rank: 3                     ││     ⢸      ⢸             ⣇⡠⠊    ⢸      ⡇            ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸           ⢀⠔⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠁            ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸         ⡠⠊⠁        ⢸               ×   ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸      ⢀⠔⠉           ⢸            ×      ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸    ⡠⠒⠁             ⢸                   ⢸        ⡇     │"
+    "└────────────────────────────┘│     ⢸  ⢸⠉⠉⠉⢹⠉⢉⠭⢻                ⢸                   ⢸        ⡇     │"
+    "┌Geometry────────────────────┐│     ⢸  ⢸   ⡸⠴⠥⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼        ⡇     │"
+    "│Type: Point                 ││     ⢸  ⢸⢀⡠⠊    ⢸                ⢸                            ⡇     │"
+    "│Coords: [1000, 3000]        ││     ⢸ ⢀⠜⠓⠒⠒⠒⠒⠒⠒⠚                ⢸                            ⡇     │"
+    "│                            ││     ⠸⠮⠥⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
+    "│                            ││                                                                    │"
+    "│                            ││                                                                    │"
+    "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
+    "#);
+}
+
+#[test]
+fn help_overlay_lists_the_layer_overview_keys() {
+    let mut app = sample_app();
+    press(&mut app, KeyCode::Char('?'));
+    insta::assert_snapshot!(render(&mut app), @r#"
+    "┌sample.mlt - Enter/+/-:expan┐┌Map View────────────────────────────────────────────────────────────┐"
+    "│>> All            ┌Help (↑/↓/scroll to navigate, any other key to close)───────┐                  │"
+    "│     Layer: water │Keyboard                                                    │                  │"
+    "│     Layer: roads │  ?  h  F1            Toggle this help                      │⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⢒⡲⡆     │"
+    "│     Layer: poi (2│  q  Ctrl+c           Quit                                  │ ⡤⠤⠤⠤⠤⠤⠤⢤⡔⠁ ⡇     │"
+    "│                  │  Esc                 Back to file browser                  │ ⡇    ⡠⠊⠁⡇  ⡇     │"
+    "│                  │  Up/Down  j/k        Navigate feature tree                 │⣀⣇⣀⣀⠔⠊   ⡇  ⡇     │"
+    "│                  │  PageUp/PageDown     Scroll by page                        │ ⣧⣒⣹⣀⣀⣀⣀⣀⡇  ⡇     │"
+    "│                  │  Home/End            Jump to first/last                    │⠊  ⢸        ⡇     │"
+    "│                  │  Enter               Expand/collapse layer or feature      │   ⢸        ⡇     │"
+    "│                  │  +  =  Right         Expand selected node                  │   ⢸        ⡇     │"
+    "│                  │  -                   Collapse (or jump to parent)          │   ⢸        ⡇     │"
+    "│                  │  *                   Expand/collapse all layers            │   ⢸        ⡇     │"
+    "│                  │  Left                Jump to parent node                   │   ⢸        ⡇     │"
+    "└──────────────────│  Ctrl+h / Ctrl+l     Resize left/right split               │   ⢸        ⡇     │"
+    "┌Properties────────│  Shift+J / Shift+K   Resize top/bottom split               │⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⡇     │"
+    "│Select or hover ov│                                                            │   ⢸        ⡇     │"
+    "│feature to view pr│Mouse                                                       │   ⢸        ⡇     │"
+    "│                  │  Click tree item     Select (drill into level)             │   ⢸        ⡇     │"
+    "│                  │  Double-click        Expand/collapse                       │   ⢸        ⡇     │"
+    "│                  │  Hover tree/map      Highlight geometry                    │   ⢸        ⡇     │"
+    "│                  │  Click on map        Select hovered feature                │   ⢸        ⡇     │"
+    "└──────────────────│  Scroll panels       Scroll tree/properties                │   ⢸        ⡇     │"
+    "┌Geometry──────────│  Drag dividers       Resize panels                         │⠤⠤⠤⠼        ⡇     │"
+    "│Select or hover ov│                                                            │            ⡇     │"
+    "│feature to view ge│Map Colors                                                  │            ⡇     │"
+    "│info              │  Magenta             Point                                 │⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
+    "│                  │  Light magenta       MultiPoint                            │                  │"
+    "│                  └────────────────────────────────────────────────────────────┘                  │"
+    "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
+    "#);
+    press(&mut app, KeyCode::Char('x'));
+    assert!(!app.show_help);
+}
+
+#[test]
+fn error_popup_shows_the_message_until_a_key_is_pressed() {
+    let mut app = sample_app();
+    app.error_popup = Some(("broken.mlt".into(), "unexpected end of buffer".into()));
+    insta::assert_snapshot!(render(&mut app), @r#"
+    "┌sample.mlt - Enter/+/-:expan┐┌Map View────────────────────────────────────────────────────────────┐"
+    "│>> All                      ││                                                                    │"
+    "│     Layer: water (2 feature││                                                                    │"
+    "│     Layer: roads (2 feature││     ⢰⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⢲⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⢒⡲⡆     │"
+    "│     Layer: poi (2 features,││     ⢸                           ⢸                 ⡤⠤⠤⠤⠤⠤⠤⢤⡔⠁ ⡇     │"
+    "│                            ││     ⢸                           ⢸                 ⡇    ⡠⠊⠁⡇  ⡇     │"
+    "│                            ││     ⢸      ⢀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣸⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣇⣀⣀⠔⠊   ⡇  ⡇     │"
+    "│                            ││     ⢸      ⢸                    ⢸                 ⣧⣒⣹⣀⣀⣀⣀⣀⡇  ⡇     │"
+    "│                            ││     ⢸      ⢸                    ⢸              ⢀⠤⠊  ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸      ×             ⢸            ⣀⠔⠁    ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸                    ⢸         ⢀⡠⠊       ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸                    ⢸       ⢀⠔⠁         ⢸        ⡇     │"
+    "│         ┌ Unable to open broken.mlt ───────────────────────────────────────────────────┐   ⡇     │"
+    "│         │                                                                              │   ⡇     │"
+    "└─────────│                           unexpected end of buffer                           │   ⡇     │"
+    "┌Propertie│                                                                              │⠉⠉⠉⡇     │"
+    "│Select or│                                                                              │   ⡇     │"
+    "│feature t└──────────────────────────────────────────────────────────────any key to close┘   ⡇     │"
+    "│                            ││     ⢸      ⢸           ⢀⠔⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠁            ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸         ⡠⠊⠁        ⢸               ×   ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸      ⢀⠔⠉           ⢸            ×      ⢸        ⡇     │"
+    "│                            ││     ⢸      ⢸    ⡠⠒⠁             ⢸                   ⢸        ⡇     │"
+    "└────────────────────────────┘│     ⢸  ⢸⠉⠉⠉⢹⠉⢉⠭⢻                ⢸                   ⢸        ⡇     │"
+    "┌Geometry────────────────────┐│     ⢸  ⢸   ⡸⠴⠥⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼        ⡇     │"
+    "│Select or hover over a      ││     ⢸  ⢸⢀⡠⠊    ⢸                ⢸                            ⡇     │"
+    "│feature to view geometry    ││     ⢸ ⢀⠜⠓⠒⠒⠒⠒⠒⠒⠚                ⢸                            ⡇     │"
+    "│info                        ││     ⠸⠮⠥⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
+    "│                            ││                                                                    │"
+    "│                            ││                                                                    │"
+    "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
+    "#);
+    press(&mut app, KeyCode::Enter);
+    assert!(app.error_popup.is_none());
+}
+
+#[test]
+fn quit_keys() {
+    let mut app = sample_app();
+    assert!(
+        quits(&mut app, KeyCode::Esc),
+        "Esc quits without a file list"
+    );
+    assert!(quits(&mut app, KeyCode::Char('q')));
+    assert!(handle_key(
+        &mut app,
+        KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)
+    ));
+}
+
+#[test]
+fn file_browser_lists_the_directory() {
+    let mut app = file_browser_app();
+    insta::assert_snapshot!(render(&mut app), @r#"
+    "┌MLT Files (6 found) - ↑/↓ navigate, Enter open, h help, q quit Click┐┌Tile Preview────────────────┐"
+    "│   File                         Size   Enc % Layers   Features Notes││Select a tile file (.mlt / .│"
+    "│>> line-boolean.mvt              40B      -       1          1      ││                            │"
+    "│   multiline-boolean.mvt         46B      -       1          1      ││                            │"
+    "│   multipoint-boolean.mvt        37B      -       1          1      ││                            │"
+    "│   multipolygon-boolean.mvt      65B      -       1          1      ││                            │"
+    "│   point-boolean.mvt             35B      -       1          1      ││                            │"
+    "│   polygon-boolean.mvt           41B      -       1          1      ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    │└────────────────────────────┘"
+    "│                                                                    │┌Filter (click to toggle)────┐"
+    "│                                                                    ││[Reset filters]             │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││Extensions:                 │"
+    "│                                                                    ││  [ ] mvt                   │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││Geometry Types:             │"
+    "│                                                                    ││  [ ] Point                 │"
+    "│                                                                    ││  [ ] LineString            │"
+    "│                                                                    │└────────────────────────────┘"
+    "│                                                                    │┌File Info───────────────────┐"
+    "│                                                                    ││File: line-boolean.mvt      │"
+    "│                                                                    ││Size: 40B  raw MLT file size│"
+    "│                                                                    ││Encoding: -  MLT / (data +  │"
+    "│                                                                    ││metadata)                   │"
+    "│                                                                    ││Data: -  decoded payload    │"
+    "│                                                                    ││size                        │"
+    "│                                                                    ││Metadata: -  encoding       │"
+    "│                                                                    ││overhead                    │"
+    "└────────────────────────────────────────────────────────────────────┘└────────────────────────────┘"
+    "#);
+}
+
+#[test]
+fn file_browser_previews_the_selected_tile() {
+    let mut app = file_browser_app();
+    press(&mut app, KeyCode::Down);
+    let path = app.get_selected_file().unwrap().path().to_path_buf();
+    let fc = load_fc(&path).unwrap();
+    app.preview_extent = extent_from_fc(&fc);
+    app.preview_fc = Some(fc);
+    app.preview_tile_path = Some(path);
+    insta::assert_snapshot!(render(&mut app), @r#"
+    "┌MLT Files (6 found) - ↑/↓ navigate, Enter open, h help, q quit Click┐┌Tile Preview────────────────┐"
+    "│   File                         Size   Enc % Layers   Features Notes││⡏⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢹│"
+    "│   line-boolean.mvt              40B      -       1          1      ││⡇                          ⢸│"
+    "│>> multiline-boolean.mvt         46B      -       1          1      ││⡇                          ⢸│"
+    "│   multipoint-boolean.mvt        37B      -       1          1      ││⡇                          ⢸│"
+    "│   multipolygon-boolean.mvt      65B      -       1          1      ││⡇                          ⢸│"
+    "│   point-boolean.mvt             35B      -       1          1      ││⡇                          ⢸│"
+    "│   polygon-boolean.mvt           41B      -       1          1      ││⡇                          ⢸│"
+    "│                                                                    ││⣇⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣸│"
+    "│                                                                    │└────────────────────────────┘"
+    "│                                                                    │┌Filter (click to toggle)────┐"
+    "│                                                                    ││[Reset filters]             │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││Extensions:                 │"
+    "│                                                                    ││  [ ] mvt                   │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││Geometry Types:             │"
+    "│                                                                    ││  [ ] Point                 │"
+    "│                                                                    ││  [ ] LineString            │"
+    "│                                                                    │└────────────────────────────┘"
+    "│                                                                    │┌File Info───────────────────┐"
+    "│                                                                    ││File: multiline-boolean.mvt │"
+    "│                                                                    ││Size: 46B  raw MLT file size│"
+    "│                                                                    ││Encoding: -  MLT / (data +  │"
+    "│                                                                    ││metadata)                   │"
+    "│                                                                    ││Data: -  decoded payload    │"
+    "│                                                                    ││size                        │"
+    "│                                                                    ││Metadata: -  encoding       │"
+    "│                                                                    ││overhead                    │"
+    "└────────────────────────────────────────────────────────────────────┘└────────────────────────────┘"
+    "#);
+}
+
+#[test]
+fn file_browser_sorts_by_a_clicked_header() {
+    let mut app = file_browser_app();
+    app.handle_file_header_click(FileSortColumn::Size);
+    insta::assert_snapshot!(render(&mut app), @r#"
+    "┌MLT Files (6 found) - ↑/↓ navigate, Enter open, h help, q quit Click┐┌Tile Preview────────────────┐"
+    "│   File                         Size   Enc % Layers   Features Notes││Select a tile file (.mlt / .│"
+    "│   point-boolean.mvt             35B      -       1          1      ││                            │"
+    "│   multipoint-boolean.mvt        37B      -       1          1      ││                            │"
+    "│>> line-boolean.mvt              40B      -       1          1      ││                            │"
+    "│   polygon-boolean.mvt           41B      -       1          1      ││                            │"
+    "│   multiline-boolean.mvt         46B      -       1          1      ││                            │"
+    "│   multipolygon-boolean.mvt      65B      -       1          1      ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    │└────────────────────────────┘"
+    "│                                                                    │┌Filter (click to toggle)────┐"
+    "│                                                                    ││[Reset filters]             │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││Extensions:                 │"
+    "│                                                                    ││  [ ] mvt                   │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││Geometry Types:             │"
+    "│                                                                    ││  [ ] Point                 │"
+    "│                                                                    ││  [ ] LineString            │"
+    "│                                                                    │└────────────────────────────┘"
+    "│                                                                    │┌File Info───────────────────┐"
+    "│                                                                    ││File: line-boolean.mvt      │"
+    "│                                                                    ││Size: 40B  raw MLT file size│"
+    "│                                                                    ││Encoding: -  MLT / (data +  │"
+    "│                                                                    ││metadata)                   │"
+    "│                                                                    ││Data: -  decoded payload    │"
+    "│                                                                    ││size                        │"
+    "│                                                                    ││Metadata: -  encoding       │"
+    "│                                                                    ││overhead                    │"
+    "└────────────────────────────────────────────────────────────────────┘└────────────────────────────┘"
+    "#);
+}
+
+#[test]
+fn filter_click_narrows_the_file_list() {
+    let mut app = file_browser_app();
+    let first_geometry_row = 3 + collect_extensions(&app.files).len() + 2;
+    handle_filter_click(&mut app, first_geometry_row);
+    insta::assert_snapshot!(render(&mut app), @r#"
+    "┌MLT Files (1/6 found) - ↑/↓ navigate, Enter open, h help, q quit Cli┐┌Tile Preview────────────────┐"
+    "│   File                         Size   Enc % Layers   Features Notes││Select a tile file (.mlt / .│"
+    "│>> point-boolean.mvt             35B      -       1          1      ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    │└────────────────────────────┘"
+    "│                                                                    │┌Filter (click to toggle)────┐"
+    "│                                                                    ││[Reset filters]             │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││Extensions:                 │"
+    "│                                                                    ││  [ ] mvt                   │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││Geometry Types:             │"
+    "│                                                                    ││  [x] Point                 │"
+    "│                                                                    ││  [ ] LineString            │"
+    "│                                                                    │└────────────────────────────┘"
+    "│                                                                    │┌File Info───────────────────┐"
+    "│                                                                    ││File: point-boolean.mvt     │"
+    "│                                                                    ││Size: 35B  raw MLT file size│"
+    "│                                                                    ││Encoding: -  MLT / (data +  │"
+    "│                                                                    ││metadata)                   │"
+    "│                                                                    ││Data: -  decoded payload    │"
+    "│                                                                    ││size                        │"
+    "│                                                                    ││Metadata: -  encoding       │"
+    "│                                                                    ││overhead                    │"
+    "└────────────────────────────────────────────────────────────────────┘└────────────────────────────┘"
+    "#);
+}
+
+#[test]
+fn enter_opens_a_file_and_escape_returns_to_the_browser() {
+    let mut app = file_browser_app();
+    press(&mut app, KeyCode::Enter);
+    assert_eq!(app.mode, ViewMode::LayerOverview);
+    insta::assert_snapshot!(render(&mut app), @r#"
+    "┌line-boolean.mvt - Enter/+/-┐┌Map View────────────────────────────────────────────────────────────┐"
+    "│>> All                      ││                                                                    │"
+    "│     Layer: layer (1 LineStr││                                                                    │"
+    "│       Feat 0: LineString (3││     ⢰⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⡆     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "└────────────────────────────┘│     ⢸                                                        ⡇     │"
+    "┌Properties──────────────────┐│     ⢸                                                        ⡇     │"
+    "│Select or hover over a      ││     ⢸                                                        ⡇     │"
+    "│feature to view properties  ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "└────────────────────────────┘│     ⢸                                                        ⡇     │"
+    "┌Geometry────────────────────┐│     ⢸                                                        ⡇     │"
+    "│Select or hover over a      ││     ⢸                                                        ⡇     │"
+    "│feature to view geometry    ││     ⢸                                                        ⡇     │"
+    "│info                        ││     ⠸⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
+    "│                            ││                                                                    │"
+    "│                            ││                                                                    │"
+    "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
+    "#);
+    press(&mut app, KeyCode::Esc);
+    assert_eq!(app.mode, ViewMode::FileBrowser);
+}
+
+fn mbtiles_app() -> App {
+    let path = test_dir("fixtures/omt.max1.mbtiles");
+    let mbt = MbtilesState::new(path.clone());
+    App::new_mbtiles(mbt, path)
+}
+
+fn mbt(app: &mut App) -> &mut MbtilesState {
+    app.mbt_state.as_mut().unwrap()
+}
+
+#[test]
+fn mbtiles_map_renders_the_world_tile() {
+    let mut app = mbtiles_app();
+    mbt(&mut app).wait_for_visible_tiles();
+    assert!(mbt(&mut app).take_loader_fatal().is_none());
+    assert!(matches!(
+        mbt(&mut app).tiles.get(&(0, 0, 0)),
+        Some(MbtTileData::Loaded { .. })
+    ));
+    insta::assert_snapshot!(render(&mut app), @r#"
+    "┌Properties──────────────────┐┌World Map - 0/0/0 - zoom 0.0  drag=pan  hover=info  q/Esc quit──────┐"
+    "│Hover over a feature to     ││⡏⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢹│"
+    "│inspect properties          ││⡇×               ⢀⣠⠤⠤⠤⡄  ⣠⣴⡏⠒⠤⡀                                    ⢸│"
+    "│                            ││⡇               ⣴⡊⡁ ⢀⣶⡯⠭⠾⠽⠉⠲⢭⠻⢴⡶     ⢀⡀   ⣀⣀       ⢠⡀              ⢸│"
+    "│                            ││⡇           ⢀⡄⣤⣼⣤⣸⠍⢠⣺⡵⠊      ⢉⡟    ⠐⡝⢓⡟⠁  ⠈⠁       ⠱⣱⢄             ⢸│"
+    "│                            ││⡇         ⠠⣊⠿⣧⣬⣽⣷⣿⣥⠊⠙⠷⠤⡀     ⢾⡗     ⠙⠋⠋     ⢀⢤⡶   ⢀⡤⡨⠛⠦⡄   ⢀⠤⣀     ⢸│"
+    "│                            ││⡇         ⡰⣳⠯⢽⣧⢿⡿⡿⢽⡧⡀  ⢣⡀   ⢰⣾⠃            ⢠⡟⠁⢠⢤⣄⡖⠋   ⠐⠗⠦⠖⣄⣀⡿⢍⡁    ⢸│"
+    "│                            ││⡯⣀⢠⡖⠉⠉⠑⢲⠔⠚⠚⢻⣯⣤⣽⣻⡜⣿⢲⢲⡉⢇⡀⢘⢧  ⣠⡿⠟      ⢀⡴⡾⣟⠢⢄⣤⣀⠭⠖⠺⢹⡅         ⠉⠉  ⠈⠙⠒⠲⠖⢺│"
+    "│                            ││⡗⠻⢝⠿ ⢀ ⢸  ⠘⢛⣄×  ⢠⠼⣷⣒⡧⢽⠃⠈⢿⣠⡞⠉ ⠹⠭⠃  ⢀⡰⡵⣵⠟⢸⣽⠛⠉    ⠉   ×           ⣀⢀ ⢀⣺│"
+    "│                            ││⡇ ⠈⣙⡶⠞⠉⠙⠺⣆  ⠉⠒⠲⢀⠳⢄⣀⡣⠈⠚⢄⡀⠈⠉      ×⣦⠈⢲⣷⣪⣿⢏⠉     ⣀⣀⡀     ⣀    ⣠⢔⠒⠛⡖⡯⠉⠁⢸│"
+    "│                            ││⡇        ⠻⢦⡤⠤×⠤⠽⢄⣤⡘⠃⢀⣠⣤⣿⡄       ⠻×××⣽⣦⣿⣞⣓⡢⢰⣖⠒⡛ ⢉⣉⢒×⡒⠖⠾⠥⢤⡜⠹⢄⣌⢿⠄ ⠛⠁  ⢸│"
+    "│                            ││⡇         ⢸ ⠰ ×  ⠘⠛⢻⠽⠙⠋   ×     ×⣹⣖⣻⣻⡿⣿×⣛⣗⣾×⣟⡷⣧⣾⡾⠃ ⠉⠒×⠚⠉⣤×⡞⢊⡾⠃     ⢸│"
+    "│                            ││⡇×         ⠙⣶⣒×⣤⠤⠤⣴⣊           ⢠⣮⠟ ⢻⠓⠲×⠚⣿×⠼⣄⣀⣿×⡻×⢤⣤⣠⣄   ⢹⠈⠛⠋⠁      ⢸│"
+    "│                            ││⡇   ⠰       ⠈⠁⠣⢜⢴⣶⡊⠿⠶⠤        ⢰⣟⣸⣉×⡚×⠑⡞⠒×⣧⠤⣬⠿⠉⠘⢳ ⡔⠚⢫⣿×⣶⠊⢽⡀         ⢸│"
+    "│                            ││⡇         ×      ⠈⢓×⢛⣭⣽⣤⣄     ⠈⠙⠻⠿⠿⢼⣻×⠿⢮×⢬⡿⠋   ⠈⠚⠇ ⠠⣿⣝⣁⡴⣟⣿⡀ ×      ⢸│"
+    "│                            ││⡇                 ⠘×⢿⣀⡀×⠈⠉⠉⡆       ⠈⢟⠧⣄⣿⣍⣏ ⡀  ×     ⠈⠻⠭⠽⢿⡿⣛×⢷⢶⡓⢤⡀  ⢸│"
+    "│                            ││⡇                  ⠈⢹⣦×⢆ ⣀⡜         ⢳⢲×⣯⢿⠜⣎⠇           ⡤⠤⠊×⠉⠊⠣⡀ ⠠⡅ ⢺│"
+    "│                            ││⡇                   ⢸× ⣯⠜           ⠘⣞⣉⠾⠃ ⠈            ⢣⣀⡤⠤⣤⡀ ⡸   ⣀⢸│"
+    "│                            ││⡇        ×         ⢀⣟⣰⠎⠁      ×                             ⠑⠿⠁  ⣠⡾⢿│"
+    "│                            ││⡇                  ⠸⣯⡏⠠⠄                      ⠐⠂                 ⠉ ⢸│"
+    "│                            ││⡇                   ⠉⠉                            ×                ⢸│"
+    "│                            ││⡇                    ⢀⡤⠂                   ⢀⣀     ⡀  ⡀⢀⣀⢀⣀⣀⣄       ⢸│"
+    "│                            ││⡇                   ⡰⡟⡆         ⣀⣀⣀⡤⣠⠤⣄⡠⠒⠖⠊⠉ ⠉⢩⢦⠴⠉⠉⠉⠉⠈⠁ ⠉  ⠈⠉⠙⠒⠤⣀⣀ ⢸│"
+    "│                            ││⡇      ⣀⣀⣀⣦⣦⢤⡀⣸⡿⠴⠒⠴⠬⠿⠃⡕       ⢠⡎⠉⠉            ⠈⠁                 ⡤⠃⢸│"
+    "│                            ││⡇   ⡤⡤⠚      ⠈ ⠁   ⢰⡒⠊  ⢀⣀ ⣀⠔⠒⠁  ×                              ⢸  ⢸│"
+    "│                            ││⡇  ⠹⠕⠒⢄            ⢏⡀⢀⣠⢀⠎⢸ ⠧⢆                                  ⢀⠞⠁ ⢸│"
+    "│                            ││⡇   ⠐⡗⠁             ⠈⠚⢍⢈⡩⢥⠖⠊⠁                                  ⠈⡆  ⢸│"
+    "│                            ││⡇ ⡀  ⣇                ⠈⠊                                        ⠈⢢ ⢸│"
+    "│                            ││⣗⣋⣑⣄⣀⣈⣒⣆⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣋⣺│"
+    "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
+    "#);
+}
+
+#[test]
+fn mbtiles_hover_describes_the_nearest_feature() {
+    let mut app = mbtiles_app();
+    mbt(&mut app).wait_for_visible_tiles();
+    let vertex = {
+        let Some(MbtTileData::Loaded { geo_index, .. }) = mbt(&mut app).tiles.get(&(0, 0, 0))
+        else {
+            panic!("world tile should be loaded");
+        };
+        geo_index.iter().next().unwrap().vertices[0]
+    };
+    mbt(&mut app).find_hovered(vertex[0], vertex[1]);
+    assert!(mbt(&mut app).hovered.is_some());
+    insta::assert_snapshot!(render(&mut app), @r#"
+    "┌Properties - place feat 5 (t┐┌World Map - 0/0/0 - zoom 0.0  drag=pan  hover=info  q/Esc quit──────┐"
+    "│class: continent            ││⡏⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢹│"
+    "│name: Oceania               ││⡇×               ⢀⣠⠤⠤⠤⡄  ⣠⣴⡏⠒⠤⡀                                    ⢸│"
+    "│name:ar: أوقيانوسيا         ││⡇               ⣴⡊⡁ ⢀⣶⡯⠭⠾⠽⠉⠲⢭⠻⢴⡶     ⢀⡀   ⣀⣀       ⢠⡀              ⢸│"
+    "│name:be: Акіянія            ││⡇           ⢀⡄⣤⣼⣤⣸⠍⢠⣺⡵⠊      ⢉⡟    ⠐⡝⢓⡟⠁  ⠈⠁       ⠱⣱⢄             ⢸│"
+    "│name:ca: Oceania            ││⡇         ⠠⣊⠿⣧⣬⣽⣷⣿⣥⠊⠙⠷⠤⡀     ⢾⡗     ⠙⠋⠋     ⢀⢤⡶   ⢀⡤⡨⠛⠦⡄   ⢀⠤⣀     ⢸│"
+    "│name:cs: Oceánie            ││⡇         ⡰⣳⠯⢽⣧⢿⡿⡿⢽⡧⡀  ⢣⡀   ⢰⣾⠃            ⢠⡟⠁⢠⢤⣄⡖⠋   ⠐⠗⠦⠖⣄⣀⡿⢍⡁    ⢸│"
+    "│name:da: Oceanien           ││⡯⣀⢠⡖⠉⠉⠑⢲⠔⠚⠚⢻⣯⣤⣽⣻⡜⣿⢲⢲⡉⢇⡀⢘⢧  ⣠⡿⠟      ⢀⡴⡾⣟⠢⢄⣤⣀⠭⠖⠺⢹⡅         ⠉⠉  ⠈⠙⠒⠲⠖⢺│"
+    "│name:de: Ozeanien           ││⡗⠻⢝⠿ ⢀ ⢸  ⠘⢛⣄×  ⢠⠼⣷⣒⡧⢽⠃⠈⢿⣠⡞⠉ ⠹⠭⠃  ⢀⡰⡵⣵⠟⢸⣽⠛⠉    ⠉   ×           ⣀⢀ ⢀⣺│"
+    "│name:el: Ωκεανία            ││⡇ ⠈⣙⡶⠞⠉⠙⠺⣆  ⠉⠒⠲⢀⠳⢄⣀⡣⠈⠚⢄⡀⠈⠉      ×⣦⠈⢲⣷⣪⣿⢏⠉     ⣀⣀⡀     ⣀    ⣠⢔⠒⠛⡖⡯⠉⠁⢸│"
+    "│name:en: Oceania            ││⡇        ⠻⢦⡤⠤×⠤⠽⢄⣤⡘⠃⢀⣠⣤⣿⡄       ⠻×××⣽⣦⣿⣞⣓⡢⢰⣖⠒⡛ ⢉⣉⢒×⡒⠖⠾⠥⢤⡜⠹⢄⣌⢿⠄ ⠛⠁  ⢸│"
+    "│name:eo: Oceanio            ││⡇         ⢸ ⠰ ×  ⠘⠛⢻⠽⠙⠋   ×     ×⣹⣖⣻⣻⡿⣿×⣛⣗⣾×⣟⡷⣧⣾⡾⠃ ⠉⠒×⠚⠉⣤×⡞⢊⡾⠃     ⢸│"
+    "│name:es: Oceanía            ││⡇×         ⠙⣶⣒×⣤⠤⠤⣴⣊           ⢠⣮⠟ ⢻⠓⠲×⠚⣿×⠼⣄⣀⣿×⡻×⢤⣤⣠⣄   ⢹⠈⠛⠋⠁      ⢸│"
+    "│name:fi: Oseania            ││⡇   ⠰       ⠈⠁⠣⢜⢴⣶⡊⠿⠶⠤        ⢰⣟⣸⣉×⡚×⠑⡞⠒×⣧⠤⣬⠿⠉⠘⢳ ⡔⠚⢫⣿×⣶⠊⢽⡀         ⢸│"
+    "│name:fr: Océanie            ││⡇         ×      ⠈⢓×⢛⣭⣽⣤⣄     ⠈⠙⠻⠿⠿⢼⣻×⠿⢮×⢬⡿⠋   ⠈⠚⠇ ⠠⣿⣝⣁⡴⣟⣿⡀ ×      ⢸│"
+    "│name:fy: Oseaanje           ││⡇                 ⠘×⢿⣀⡀×⠈⠉⠉⡆       ⠈⢟⠧⣄⣿⣍⣏ ⡀  ×     ⠈⠻⠭⠽⢿⡿⣛×⢷⢶⡓⢤⡀  ⢸│"
+    "│name:ga: An Aigéine         ││⡇                  ⠈⢹⣦×⢆ ⣀⡜         ⢳⢲×⣯⢿⠜⣎⠇           ⡤⠤⠊×⠉⠊⠣⡀ ⠠⡅ ⢺│"
+    "│name:hi: ओशिआनिया           ││⡇                   ⢸× ⣯⠜           ⠘⣞⣉⠾⠃ ⠈            ⢣⣀⡤⠤⣤⡀ ⡸   ⣀⢸│" Hidden by multi-width symbols: [(12, " "), (15, " "), (17, " ")]
+    "│name:hr: Oceanija           ││⡇        ×         ⢀⣟⣰⠎⠁      ×                             ⠑⠿⠁  ⣠⡾⢿│"
+    "│name:hu: Óceánia            ││⡇                  ⠸⣯⡏⠠⠄                      ⠐⠂                 ⠉ ⢸│"
+    "│name:is: Eyjaálfa           ││⡇                   ⠉⠉                            ×                ⢸│"
+    "│name:it: Oceania            ││⡇                    ⢀⡤⠂                   ⢀⣀     ⡀  ⡀⢀⣀⢀⣀⣀⣄       ⢸│"
+    "│name:kn: ಒಷ್ಯಾನಿಯ             ││⡇                   ⡰⡟⡆         ⣀⣀⣀⡤⣠⠤⣄⡠⠒⠖⠊⠉ ⠉⢩⢦⠴⠉⠉⠉⠉⠈⠁ ⠉  ⠈⠉⠙⠒⠤⣀⣀ ⢸│" Hidden by multi-width symbols: [(13, " ")]
+    "│name:ku: Okyanûsya          ││⡇      ⣀⣀⣀⣦⣦⢤⡀⣸⡿⠴⠒⠴⠬⠿⠃⡕       ⢠⡎⠉⠉            ⠈⠁                 ⡤⠃⢸│"
+    "│name:la: Oceania            ││⡇   ⡤⡤⠚      ⠈ ⠁   ⢰⡒⠊  ⢀⣀ ⣀⠔⠒⠁  ×                              ⢸  ⢸│"
+    "│name:latin: Oceania         ││⡇  ⠹⠕⠒⢄            ⢏⡀⢀⣠⢀⠎⢸ ⠧⢆                                  ⢀⠞⠁ ⢸│"
+    "│name:lt: Okeanija           ││⡇   ⠐⡗⠁             ⠈⠚⢍⢈⡩⢥⠖⠊⠁                                  ⠈⡆  ⢸│"
+    "│name:nl: Oceanië            ││⡇ ⡀  ⣇                ⠈⠊                                        ⠈⢢ ⢸│"
+    "│name:no: Oseania            ││⣗⣋⣑⣄⣀⣈⣒⣆⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣋⣺│"
+    "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
+    "#);
+}
+
+#[test]
+fn mbtiles_center_tile_zoom_and_pan_move_the_viewport() {
+    let mut app = mbtiles_app();
+    mbt(&mut app).set_viewport_to_tile(1, 0, 0).unwrap();
+    assert_eq!(mbt(&mut app).zoom_level(), 1);
+    mbt(&mut app).zoom_wheel_at(0.25, 0.25, true);
+    mbt(&mut app).zoom_wheel_at(0.25, 0.25, true);
+    assert_eq!(mbt(&mut app).zoom_level(), 2);
+    mbt(&mut app).pan_by_pixels(100, 50, -50, 0);
+    assert!(
+        mbt(&mut app).vp_x0 > 0.0,
+        "panning left moves the viewport east"
+    );
+    mbt(&mut app).wait_for_visible_tiles();
+    insta::assert_snapshot!(render(&mut app), @r#"
+    "┌Properties──────────────────┐┌World Map - 2/1/1 - zoom 2.0  drag=pan  hover=info  q/Esc quit──────┐"
+    "│Hover over a feature to     ││⡇⢠⡪⠜      ⠰⡁  ⣀⠤⠒⡡⠊                                 ⣼⠃             ⢸│"
+    "│inspect properties          ││⡧⠓⡣⡄     ⢀⠔⠁⢰⠭⣤⠒⠊                                  ⡰⢹              ⢸│"
+    "│                            ││⡇⢸⠈⠙⠄   ⡠⠊   ⠉⠒⠭⣶⣤⣀                              ⢀ ⡇⠸⡀             ⢸│"
+    "│                            ││⣷⠊     ⠈⢒⠆    ⠲⡛⠫⡍                              ⢰⠙⣤⡣⠔⠓             ⢸│"
+    "│                            ││⡏⠉⠒⠒⠊⠉⠑⠊⠁      ⠑⠼⠶⠖⠚⠛⠭⣒⢄                        ⠸⠊⢈⠎⢢              ⢸│"
+    "│                            ││⡏⠉⠒⠊⠉⠉⠉⢢               ⢹⢆                         ⢸ ⡬⠆             ⢸│"
+    "│                            ││⡗⠤⠤⠔⠒⠒⠤⠊                ⠹⣆                    ⢀⣀⡀⢠⠼⢀⡸⠄             ⢸│"
+    "│                            ││⡇⡤⢔⠆⡠⠔⡄⡖⠒⢢               ⠹⣆                   ⠸⡀⠈⠁⣀⡨⠆              ⢸│"
+    "│                            ││⡟ ⠘⠜  ⠈⡎⣒⠶⢗               ⢹⢆⢀                  ⢧ ⣠⣘⡄               ⢸│"
+    "│                            ││⣇⡀     ⠉   ⠉⣆⢤           ⠠⣃⢌⠛⡄               ⢀⠖⠉⢠⡀⠑⡅               ⢸│"
+    "│                            ││⡗⠥⣀⣀    ⢀     ⠉⠒⢄          ⡖⠳⢼               ⢠⠃⢀⣜⣑⣤⡃               ⢸│"
+    "│                            ││⣇  ⢸⠉⠛⢖⠊⠁⠑⢄     ⠈⣆        ⠘⠢⠔⣺               ⡬⢍⡹⡻⠝⠉                ⢸│"
+    "│                            ││⡇⢱⢀⠎  ⡜   ⡭⡒⢄   ⠉⠒⠤⡀       ⢀⠔⠁⡇            ⡷⠴⠕⠒⠉                   ⢸│"
+    "│                            ││⡇⠈⠊⣀ ⢀⡸  ⠘⠴⠁⢀⠇     ⠘⠤⡄     ⢎  ⡇        ⢀⠤⣀⡼⠁                       ⢸│"
+    "│                            ││⡏⠉⢹⡭⡉⠉⠉⠉⠉⣉⣉⣉⡏⠉⠉⠉⠹⡉⠫⡉⡩⠋⠉⠉⠉⠉⠉⠫⡉⢝⠋⠉⠉⠉⠉⠉⠉⢉⡽⠝⠛⠉⠉⠉⠉⠉⠉⠉⠉⠽⢍⡙⠝⠉⠛⠉⠹⡉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢹│"
+    "│                            ││⣇⡠⢳⠁⠈⡑⢢⡀⠐⠥⠤⠴⠤⡀   ⠈⢢⠈        ⠸⡈⢢     ⢠⠇           ⠈⢛⣅⡀ ⢀⣀⠤⠊         ⢸│"
+    "│                            ││⡇ ⠉⠣⢊⢬⠍⢉ ⢀⣀ ⡀⠘⠤⣀⡑⡦⢄⠇         ⢣⡱    ⢠⠏               ⠈⠉⠁            ⢸│"
+    "│                            ││⡇    ⠁ ⠘⠃⡇ ⠉⠈⠢⣀⣀⠈⠙⠂           ⠫⢕⣤⣄⡀⣼                               ⢸│"
+    "│                            ││⡇        ⡸     ⢸  ⢠⢢             ⠈⠚⠃                               ⢸│"
+    "│                            ││⡇       ⠈⢢     ⠈⠣⠒⠁ ⠣⡀                                         ⢰⢒⣖⡀⢸│"
+    "│                            ││⡗⠤⢄⡀     ⢈⠆          ⠵⣀                                        ⢇×⣰⡁⢸│"
+    "│                            ││⡇  ⠈⠉⠑⡆⠠⡔⠊             ⠑⠢⡀                                  ⣀⠤⣖⣪⠒⢄⠘⣼│"
+    "│                            ││⡇     ⢇ ⢱                ⢱                                  ⣱ ⣠⢃⣏⠁ ⢸│"
+    "│                            ││⡇      ⠑⠁        ⢀⣀⣀⣀⣀⣀⠤⡪⣳⡁                                  ⠉ ⣨⠽⡡⣤⢼│"
+    "│                            ││⣧⠴⣢⣀⡀          ⣠⡴⠕⢒⠖⠉⠂ ⢴⠁⠈⠉⣽                                    ⣤⠒⠵⢹│"
+    "│                            ││⡗⠙⣤⠿⣷⡢⢄⡀      ⢊⠏⢱ ⠈⠶⣖⣄⢆⠉⠉⠙⠋⠓⠁                                    ⠉⢢⢸│"
+    "│                            ││⡇⢐⢯⠊⢠⣻⡜⢙⣠⣤⡤⠊⠉⠉⠁⡤⠒⠉⣟⡡⠔⠊⠁                                      ⡠⠤⠤⣀⣀⣎⢸│"
+    "│                            ││⡇⠈⠦⠃ ⠾⠶⠟⠋   ⢀⣀⠼⠄                                            ⠘⡶⢴    ⢹│"
+    "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
+    "#);
+}
+
+fn render_with_areas(app: &mut App, width: u16, height: u16) -> PanelAreas {
+    let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+    let mut areas = PanelAreas::default();
+    terminal.draw(|f| render_frame(f, app, &mut areas)).unwrap();
+    areas
+}
+
+/// Feed one mouse event against the panels of a `width` x `height` screen.
+fn send(
+    app: &mut App,
+    areas: &PanelAreas,
+    clicks: &mut MouseState,
+    (width, height): (u16, u16),
+    kind: MouseEventKind,
+    column: u16,
+    row: u16,
+) {
+    let event = MouseEvent {
+        kind,
+        column,
+        row,
+        modifiers: KeyModifiers::NONE,
+    };
+    handle_mouse(app, areas, Rect::new(0, 0, width, height), event, clicks).unwrap();
+}
+
+/// Screen cell that shows tile coordinate `(x, y)` on the map.
+fn map_cell(map: Rect, bounds: (f64, f64, f64, f64), x: f64, y: f64) -> (u16, u16) {
+    let rx = (x - bounds.0) / (bounds.2 - bounds.0);
+    let ry = (bounds.3 - y) / (bounds.3 - bounds.1);
+    #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let col = map.x + (rx * f64::from(map.width)) as u16;
+    #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let row = map.y + (ry * f64::from(map.height)) as u16;
+    (col, row)
+}
+
+const SCREEN: (u16, u16) = (WIDTH, HEIGHT);
+const LEFT: MouseEventKind = MouseEventKind::Down(MouseButton::Left);
+
+#[test]
+fn clicking_a_tree_row_selects_it_and_a_double_click_expands_it() {
+    let mut app = sample_app();
+    let areas = render_with_areas(&mut app, WIDTH, HEIGHT);
+    let tree = areas.tree.unwrap();
+    let mut clicks = MouseState::default();
+    let row = tree.y + 1 + 2;
+    send(&mut app, &areas, &mut clicks, SCREEN, LEFT, tree.x + 4, row);
+    assert_eq!(app.selected_item(), &TreeItem::Layer(1));
+    let rows_before = app.tree_items.len();
+    send(&mut app, &areas, &mut clicks, SCREEN, LEFT, tree.x + 4, row);
+    assert!(
+        app.tree_items.len() > rows_before,
+        "double-click expands the layer"
+    );
+}
+
+#[test]
+fn moving_over_the_map_hovers_and_clicking_selects() {
+    let mut app = sample_app();
+    let screen = (160, 100);
+    let areas = render_with_areas(&mut app, screen.0, screen.1);
+    let map = areas.map.unwrap();
+    let (col, row) = map_cell(map, app.get_bounds(), 1000.0, 3000.0);
+    let mut clicks = MouseState::default();
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        screen,
+        MouseEventKind::Moved,
+        col,
+        row,
+    );
+    assert_eq!(
+        app.hovered.as_ref().map(|h| (h.layer, h.feat, h.part)),
+        Some((2, 0, None))
+    );
+    send(&mut app, &areas, &mut clicks, screen, LEFT, col, row);
+    assert_eq!(app.selected_item(), &TreeItem::Layer(2));
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        screen,
+        MouseEventKind::Moved,
+        map.x + 1,
+        map.y + 1,
+    );
+    assert!(app.hovered.is_none(), "empty map space clears the hover");
+}
+
+#[test]
+fn the_wheel_scrolls_the_panel_under_the_cursor() {
+    let mut app = sample_app();
+    press(&mut app, KeyCode::Char('*'));
+    let screen = (60, 16);
+    let areas = render_with_areas(&mut app, screen.0, screen.1);
+    let tree = areas.tree.unwrap();
+    let props = areas.props.unwrap();
+    let mut clicks = MouseState::default();
+    let down = MouseEventKind::ScrollDown;
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        screen,
+        down,
+        tree.x + 2,
+        tree.y + 2,
+    );
+    assert!(app.tree_scroll > 0);
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        screen,
+        down,
+        props.x + 2,
+        props.y + 1,
+    );
+    assert!(app.properties_scroll > 0);
+}
+
+#[test]
+fn dragging_the_divider_resizes_the_split() {
+    let mut app = sample_app();
+    let areas = render_with_areas(&mut app, WIDTH, HEIGHT);
+    let left = areas.left.unwrap();
+    let mut clicks = MouseState::default();
+    let x = left.x + left.width;
+    send(&mut app, &areas, &mut clicks, SCREEN, LEFT, x, left.y + 5);
+    assert_eq!(app.resizing, Some(ResizeHandle::LeftRight));
+    let drag = MouseEventKind::Drag(MouseButton::Left);
+    send(&mut app, &areas, &mut clicks, SCREEN, drag, 50, left.y + 5);
+    assert_eq!(app.left_pct, 50);
+    let up = MouseEventKind::Up(MouseButton::Left);
+    send(&mut app, &areas, &mut clicks, SCREEN, up, 50, left.y + 5);
+    assert!(app.resizing.is_none());
+}
+
+#[test]
+fn mbtiles_mouse_pans_and_zooms() {
+    let mut app = mbtiles_app();
+    let areas = render_with_areas(&mut app, WIDTH, HEIGHT);
+    let map = areas.map.unwrap();
+    let mut clicks = MouseState::default();
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        LEFT,
+        map.x + 10,
+        map.y + 10,
+    );
+    assert!(mbt(&mut app).map_drag_last.is_some());
+    let drag = MouseEventKind::Drag(MouseButton::Left);
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        drag,
+        map.x + 20,
+        map.y + 10,
+    );
+    assert!(
+        mbt(&mut app).vp_x0 < 0.0,
+        "dragging east moves the viewport west"
+    );
+    let up = MouseEventKind::Up(MouseButton::Left);
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        up,
+        map.x + 20,
+        map.y + 10,
+    );
+    assert!(mbt(&mut app).map_drag_last.is_none());
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        MouseEventKind::ScrollUp,
+        map.x + 10,
+        map.y + 10,
+    );
+    assert!((mbt(&mut app).zoom_f - 0.5).abs() < 1e-9);
+}
+
+#[test]
+fn help_and_error_popup_take_the_mouse() {
+    let mut app = sample_app();
+    let areas = render_with_areas(&mut app, WIDTH, HEIGHT);
+    let mut clicks = MouseState::default();
+    press(&mut app, KeyCode::Char('?'));
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        MouseEventKind::ScrollDown,
+        10,
+        10,
+    );
+    assert_eq!(app.help_scroll, 1);
+    press(&mut app, KeyCode::Char('x'));
+    app.error_popup = Some(("broken.mlt".into(), "nope".into()));
+    send(&mut app, &areas, &mut clicks, SCREEN, LEFT, 10, 10);
+    assert!(app.error_popup.is_none());
+}
+
+fn ui_args(path: PathBuf, center_tile: Option<&str>) -> UiArgs {
+    UiArgs {
+        path,
+        center_tile: center_tile.map(str::to_string),
+    }
+}
+
+#[test]
+fn build_app_picks_the_mode_from_the_path() {
+    let browser = build_app(&ui_args(fixtures_dir(), None)).unwrap();
+    assert_eq!(browser.mode, ViewMode::FileBrowser);
+    let file = build_app(&ui_args(fixtures_dir().join("line-boolean.mvt"), None)).unwrap();
+    assert_eq!(file.mode, ViewMode::LayerOverview);
+    let archive = test_dir("fixtures/omt.max1.mbtiles");
+    let mut map = build_app(&ui_args(archive.clone(), Some("1/1/0"))).unwrap();
+    assert_eq!(map.mode, ViewMode::MbtilesMap);
+    assert_eq!(mbt(&mut map).center_tile_xyz(), (1, 1, 0));
+    assert!(build_app(&ui_args(fixtures_dir(), Some("1/0/0"))).is_err());
+    assert!(build_app(&ui_args(archive, Some("1/9/0"))).is_err());
+    assert!(build_app(&ui_args(test_dir("nope"), None)).is_err());
+}
+
+#[test]
+fn center_tile_specs_are_validated() {
+    assert_eq!(parse_center_tile_xyz(" 3 / 2 / 1 ").unwrap(), (3, 2, 1));
+    for bad in ["1/2", "z/0/0", "1/x/0", "1/0/y", "40/0/0", "1/2/0"] {
+        assert!(parse_center_tile_xyz(bad).is_err(), "{bad}");
+    }
+}
+
+fn tick_until(app: &mut App, done: impl Fn(&App) -> bool) {
+    for _ in 0..500 {
+        tick(app);
+        if done(app) {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    panic!("condition not reached");
+}
+
+#[test]
+fn tick_loads_previews() {
+    let mut app = file_browser_app();
+    tick_until(&mut app, |a| a.preview_fc.is_some());
+    let first = app.preview_tile_path.clone().unwrap();
+    press(&mut app, KeyCode::Down);
+    tick_until(&mut app, |a| a.preview_tile_path.as_ref() != Some(&first));
+    assert!(app.preview_fc.is_some());
+}
+
+#[test]
+fn tick_surfaces_a_loader_failure_as_a_popup() {
+    let path = test_dir("missing.mbtiles");
+    let mut app = App::new_mbtiles(MbtilesState::new(path.clone()), path);
+    tick_until(&mut app, |a| a.error_popup.is_some());
+    let (title, msg) = app.error_popup.clone().unwrap();
+    assert!(title.ends_with("missing.mbtiles"));
+    assert!(msg.contains("failed"), "{msg}");
+    let state = mbt(&mut app);
+    state.request_tile(1, 0, 0);
+    assert!(
+        matches!(state.tiles.get(&(1, 0, 0)), Some(MbtTileData::Error(_))),
+        "a request after the loader died is an error, not a hang"
+    );
+}
+
+#[test]
+fn tick_pumps_mbtiles_results() {
+    let mut app = mbtiles_app();
+    tick_until(&mut app, |a| {
+        a.mbt_state
+            .as_ref()
+            .is_some_and(|m| matches!(m.tiles.get(&(0, 0, 0)), Some(MbtTileData::Loaded { .. })))
+    });
+    assert!(app.needs_redraw);
+}
+
+#[test]
+fn help_scrolls_with_the_keyboard() {
+    let mut app = sample_app();
+    press(&mut app, KeyCode::Char('?'));
+    press(&mut app, KeyCode::Down);
+    assert_eq!(app.help_scroll, 1);
+    press(&mut app, KeyCode::PageDown);
+    assert_eq!(app.help_scroll, 11);
+    press(&mut app, KeyCode::Up);
+    assert_eq!(app.help_scroll, 10);
+    press(&mut app, KeyCode::PageUp);
+    assert_eq!(app.help_scroll, 0);
+    press(&mut app, KeyCode::End);
+    assert_eq!(app.help_scroll, u16::MAX);
+    press(&mut app, KeyCode::Home);
+    assert_eq!(app.help_scroll, 0);
+    assert!(app.show_help);
+}
+
+#[test]
+fn keys_resize_the_splits_and_page_through_the_tree() {
+    let mut app = sample_app();
+    let ctrl = |c| KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL);
+    let shift = |c| KeyEvent::new(KeyCode::Char(c), KeyModifiers::SHIFT);
+    assert!(!handle_key(&mut app, ctrl('h')));
+    assert_eq!(app.left_pct, 25);
+    assert!(!handle_key(&mut app, ctrl('l')));
+    assert_eq!(app.left_pct, 30);
+    assert!(!handle_key(&mut app, shift('J')));
+    assert_eq!(app.features_pct, 45);
+    assert!(!handle_key(&mut app, shift('K')));
+    assert_eq!(app.features_pct, 50);
+
+    press(&mut app, KeyCode::Char('*'));
+    render_sized(&mut app, 60, 16);
+    press(&mut app, KeyCode::PageDown);
+    assert!(app.selected_index > 0);
+    press(&mut app, KeyCode::End);
+    assert_eq!(app.selected_index, app.tree_items.len() - 1);
+    assert!(app.tree_scroll > 0, "the selection scrolls into view");
+    press(&mut app, KeyCode::PageUp);
+    press(&mut app, KeyCode::Home);
+    assert_eq!(app.selected_index, 0);
+    assert_eq!(app.tree_scroll, 0);
+}
+
+#[test]
+fn plus_minus_and_left_walk_the_tree() {
+    let mut app = sample_app();
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Char('+'));
+    assert!(app.tree_items.len() > 4, "+ expands the layer");
+    press(&mut app, KeyCode::Char('+'));
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Char('+'));
+    assert!(app.expanded_features.contains(&(0, 1)));
+    press(&mut app, KeyCode::Down);
+    assert_eq!(
+        app.selected_item(),
+        &TreeItem::SubFeature {
+            layer: 0,
+            feat: 1,
+            part: 0
+        }
+    );
+    press(&mut app, KeyCode::Char('-'));
+    assert_eq!(
+        app.selected_item(),
+        &TreeItem::Feature { layer: 0, feat: 1 }
+    );
+    assert!(
+        !app.expanded_features.contains(&(0, 1)),
+        "- on a part collapses the feature"
+    );
+    press(&mut app, KeyCode::Char('-'));
+    assert_eq!(
+        app.selected_item(),
+        &TreeItem::Layer(0),
+        "- on a feature collapses the layer"
+    );
+    press(&mut app, KeyCode::Char('-'));
+    assert_eq!(
+        app.selected_item(),
+        &TreeItem::Layer(0),
+        "- on a collapsed layer is a no-op"
+    );
+
+    press(&mut app, KeyCode::Char('+'));
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Char('+'));
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Left);
+    assert_eq!(
+        app.selected_item(),
+        &TreeItem::Feature { layer: 0, feat: 1 }
+    );
+    press(&mut app, KeyCode::Left);
+    assert_eq!(app.selected_item(), &TreeItem::Layer(0));
+    press(&mut app, KeyCode::Left);
+    assert_eq!(app.selected_item(), &TreeItem::All);
+    press(&mut app, KeyCode::Left);
+    assert_eq!(
+        app.mode,
+        ViewMode::LayerOverview,
+        "no browser to go back to"
+    );
+    press(&mut app, KeyCode::Char('+'));
+    assert_eq!(app.selected_item(), &TreeItem::All, "+ on All is a no-op");
+
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Char('-'));
+    assert_eq!(
+        app.selected_item(),
+        &TreeItem::Feature { layer: 0, feat: 1 }
+    );
+    assert!(
+        !app.expanded_features.contains(&(0, 1)),
+        "- collapses expanded parts first"
+    );
+    press(&mut app, KeyCode::Char('*'));
+    press(&mut app, KeyCode::Char('*'));
+    assert_eq!(app.tree_items.len(), 4, "* twice collapses every layer");
+
+    let mut app = file_browser_app();
+    press(&mut app, KeyCode::Enter);
+    press(&mut app, KeyCode::Left);
+    assert_eq!(
+        app.mode,
+        ViewMode::FileBrowser,
+        "Left on All returns to the browser"
+    );
+}
+
+#[test]
+fn file_browser_keys_page_and_bad_rows_show_a_popup() {
+    let mut app = file_browser_app();
+    render(&mut app);
+    press(&mut app, KeyCode::PageDown);
+    assert_eq!(app.selected_file_index, 5);
+    press(&mut app, KeyCode::PageUp);
+    assert_eq!(app.selected_file_index, 0);
+    press(&mut app, KeyCode::End);
+    assert_eq!(app.selected_file_index, 5);
+    press(&mut app, KeyCode::Home);
+    assert_eq!(app.selected_file_index, 0);
+
+    let base = fixtures_dir();
+    let rows = vec![
+        analyze_row(base.join("broken.mvt"), &base),
+        LsRow::Loading {
+            path: base.join("missing.mvt"),
+        },
+    ];
+    let mut app = App::new_file_browser(rows, None, base);
+    assert!(matches!(app.files[0], LsRow::Error { size: None, .. }));
+    let screen = render(&mut app);
+    assert!(screen.contains("Select a file to view"), "{screen}");
+    press(&mut app, KeyCode::Enter);
+    assert!(app.error_popup.is_some(), "an error row opens its message");
+    app.error_popup = None;
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Enter);
+    assert!(
+        app.error_popup.is_some(),
+        "a file that fails to decode opens its message"
+    );
+}
+
+#[test]
+fn header_clicks_sort_every_column_both_ways() {
+    let mut app = file_browser_app();
+    let first = |app: &App| {
+        app.files[0]
+            .path()
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .to_string()
+    };
+    app.handle_file_header_click(FileSortColumn::File);
+    assert_eq!(first(&app), "line-boolean.mvt");
+    app.handle_file_header_click(FileSortColumn::File);
+    assert_eq!(first(&app), "polygon-boolean.mvt");
+    app.handle_file_header_click(FileSortColumn::Size);
+    assert_eq!(first(&app), "point-boolean.mvt");
+    app.handle_file_header_click(FileSortColumn::Size);
+    assert_eq!(first(&app), "multipolygon-boolean.mvt");
+    for col in [
+        FileSortColumn::EncPct,
+        FileSortColumn::Layers,
+        FileSortColumn::Features,
+    ] {
+        app.handle_file_header_click(col);
+        assert_eq!(app.filtered_file_indices.len(), 6, "{col:?}");
+    }
+
+    let base = fixtures_dir();
+    let mut rows = analyze_tile_files(
+        &[
+            base.join("line-boolean.mvt"),
+            base.join("point-boolean.mvt"),
+        ],
+        &base,
+        SCAN_FLAGS,
+    );
+    rows.push(LsRow::Error {
+        path: base.join("b.mvt"),
+        size: Some(9),
+        error: "bad".into(),
+    });
+    rows.push(analyze_row(base.join("a.mvt"), &base));
+    let mut app = App::new_file_browser(rows, None, base);
+    app.handle_file_header_click(FileSortColumn::Size);
+    let names: Vec<String> = app
+        .files
+        .iter()
+        .map(|r| r.path().file_name().unwrap().to_string_lossy().to_string())
+        .collect();
+    assert_eq!(
+        names,
+        ["point-boolean.mvt", "line-boolean.mvt", "a.mvt", "b.mvt"]
+    );
+    app.handle_file_header_click(FileSortColumn::File);
+    app.handle_file_header_click(FileSortColumn::Layers);
+    assert!(
+        matches!(app.files[2], LsRow::Error { .. }),
+        "error rows sort after info rows"
+    );
+
+    let (tx, rx) = mpsc::channel::<Vec<LsRow>>();
+    let mut app = App::new_file_browser(Vec::new(), Some(rx), fixtures_dir());
+    app.handle_file_header_click(FileSortColumn::Size);
+    drop(tx);
+}
+
+#[test]
+fn empty_loading_and_filtered_out_browser_states_render() {
+    let mut app = file_browser_app();
+    let path = app.get_selected_file().unwrap().path().to_path_buf();
+    app.preview_load_requested = Some(path);
+    assert!(render(&mut app).contains("Loading…"));
+
+    app.ext_filters.insert("xyz".into());
+    app.rebuild_filtered_files();
+    let areas = render_with_areas(&mut app, WIDTH, HEIGHT);
+    assert!(render(&mut app).contains("No files match"));
+    let info = areas.info.unwrap();
+    let mut clicks = MouseState::default();
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        LEFT,
+        info.x + 2,
+        info.y + 3,
+    );
+    assert_eq!(
+        app.filtered_file_indices.len(),
+        6,
+        "[Reset filters] in the info panel"
+    );
+}
+
+#[test]
+fn filter_clicks_toggle_extensions_and_algorithms() {
+    let mut app = file_browser_app();
+    handle_filter_click(&mut app, 3);
+    assert!(app.ext_filters.contains("mvt"));
+    assert_eq!(app.filtered_file_indices.len(), 6);
+    handle_filter_click(&mut app, 3);
+    assert!(app.ext_filters.is_empty(), "a second click toggles it off");
+
+    let mut app = browser_over(test_dir("synthetic/0x01-rust"));
+    assert!(app.files.len() > 100);
+    let algos = collect_file_algorithms(&app.files);
+    assert!(!algos.is_empty());
+    let geoms = collect_file_geometries(&app.files).len();
+    let exts = collect_extensions(&app.files).len();
+    let first_algo_row = 3 + exts + 2 + geoms + 2;
+    handle_filter_click(&mut app, first_algo_row);
+    assert_eq!(app.algo_filters.len(), 1);
+    assert!(app.filtered_file_indices.len() < app.files.len());
+    render(&mut app);
+    press(&mut app, KeyCode::Enter);
+    assert_eq!(
+        app.mode,
+        ViewMode::LayerOverview,
+        "an MLT opens from the browser"
+    );
+}
+
+#[test]
+fn file_browser_dividers_and_side_panels_take_the_mouse() {
+    let mut app = file_browser_app();
+    let areas = render_with_areas(&mut app, WIDTH, HEIGHT);
+    let mut clicks = MouseState::default();
+    let drag = MouseEventKind::Drag(MouseButton::Left);
+    let up = MouseEventKind::Up(MouseButton::Left);
+    let fl = areas.file_left.unwrap();
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        LEFT,
+        fl.x + fl.width,
+        fl.y + 5,
+    );
+    assert_eq!(app.resizing, Some(ResizeHandle::FileBrowserLeftRight));
+    send(&mut app, &areas, &mut clicks, SCREEN, drag, 60, fl.y + 5);
+    assert_eq!(app.file_left_pct, 60);
+    send(&mut app, &areas, &mut clicks, SCREEN, up, 60, fl.y + 5);
+
+    let pa = areas.preview.unwrap();
+    let fa = areas.filter.unwrap();
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        LEFT,
+        pa.x + 2,
+        pa.y + pa.height,
+    );
+    assert_eq!(app.resizing, Some(ResizeHandle::FileBrowserPreviewFilter));
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        drag,
+        pa.x + 2,
+        pa.y + pa.height + 4,
+    );
+    assert_ne!(app.file_preview_pct, 33);
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        up,
+        pa.x + 2,
+        pa.y + pa.height + 4,
+    );
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        LEFT,
+        fa.x + 2,
+        fa.y + fa.height,
+    );
+    assert_eq!(app.resizing, Some(ResizeHandle::FileBrowserFilterInfo));
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        drag,
+        fa.x + 2,
+        fa.y + fa.height - 3,
+    );
+    assert_ne!(app.file_filter_pct, 33);
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        up,
+        fa.x + 2,
+        fa.y + fa.height - 3,
+    );
+
+    let down = MouseEventKind::ScrollDown;
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        down,
+        fa.x + 2,
+        fa.y + 3,
+    );
+    assert!(app.filter_scroll > 0);
+    let info = areas.info.unwrap();
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        down,
+        info.x + 2,
+        info.y + 3,
+    );
+    assert!(app.file_info_scroll > 0);
+    let table = app.file_table_area.unwrap();
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        down,
+        table.x + 5,
+        table.y + 5,
+    );
+    assert!(
+        app.selected_file_index > 0,
+        "the wheel over the table moves the selection"
+    );
+}
+
+#[test]
+fn layer_view_dividers_tree_hover_and_map_wheel() {
+    let mut app = sample_app();
+    press(&mut app, KeyCode::Char('*'));
+    let areas = render_with_areas(&mut app, WIDTH, HEIGHT);
+    let tree = areas.tree.unwrap();
+    let geom = areas.geom.unwrap();
+    let map = areas.map.unwrap();
+    let mut clicks = MouseState::default();
+    let drag = MouseEventKind::Drag(MouseButton::Left);
+    let up = MouseEventKind::Up(MouseButton::Left);
+
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        MouseEventKind::Moved,
+        tree.x + 4,
+        tree.y + 3,
+    );
+    assert_eq!(app.hovered, Some(HoveredInfo::new(2, 0, 0, None)));
+    assert!(render(&mut app).contains("Properties (feat 0, hover)"));
+
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        LEFT,
+        tree.x + 2,
+        tree.y + tree.height,
+    );
+    assert_eq!(app.resizing, Some(ResizeHandle::FeaturesProperties));
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        drag,
+        tree.x + 2,
+        tree.y + tree.height + 3,
+    );
+    assert_ne!(app.features_pct, 50);
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        up,
+        tree.x + 2,
+        tree.y + tree.height + 3,
+    );
+
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        LEFT,
+        geom.x + 2,
+        geom.y,
+    );
+    assert_eq!(app.resizing, Some(ResizeHandle::PropertiesGeometry));
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        drag,
+        geom.x + 2,
+        geom.y + 3,
+    );
+    assert_ne!(app.properties_pct, 50);
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        up,
+        geom.x + 2,
+        geom.y + 3,
+    );
+
+    let before = app.selected_index;
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        MouseEventKind::ScrollDown,
+        map.x + 5,
+        map.y + 5,
+    );
+    assert_eq!(
+        app.selected_index, before,
+        "the wheel over the map does nothing"
+    );
+}
+
+#[test]
+fn mbtiles_hover_and_side_panel_wheel_through_the_mouse() {
+    let mut app = mbtiles_app();
+    mbt(&mut app).wait_for_visible_tiles();
+    let screen = (160, 100);
+    let areas = render_with_areas(&mut app, screen.0, screen.1);
+    let map = areas.map.unwrap();
+    let left = areas.left.unwrap();
+    let mut clicks = MouseState::default();
+    let vertex = {
+        let Some(MbtTileData::Loaded { geo_index, .. }) = mbt(&mut app).tiles.get(&(0, 0, 0))
+        else {
+            panic!("world tile");
+        };
+        geo_index.iter().next().unwrap().vertices[0]
+    };
+    #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let col = map.x + (vertex[0] * f64::from(map.width)) as u16;
+    #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let row = map.y + (vertex[1] * f64::from(map.height)) as u16;
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        screen,
+        MouseEventKind::Moved,
+        col,
+        row,
+    );
+    assert!(mbt(&mut app).hovered.is_some());
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        screen,
+        MouseEventKind::ScrollDown,
+        left.x + 2,
+        left.y + 2,
+    );
+    assert!(app.properties_scroll > 0);
+}
+
+#[test]
+fn mbtiles_hover_panel_explains_every_tile_state() {
+    let mut app = mbtiles_app();
+    let hover = |tile, layer_idx, feat_idx| MbtHoveredInfo {
+        tile,
+        layer_idx,
+        feat_idx,
+    };
+    mbt(&mut app).hovered = Some(hover((5, 0, 0), 0, 0));
+    assert!(render(&mut app).contains("Tile loading"));
+    mbt(&mut app).tiles.insert((5, 0, 0), MbtTileData::Empty);
+    assert!(render(&mut app).contains("Tile empty"));
+    mbt(&mut app)
+        .tiles
+        .insert((5, 0, 0), MbtTileData::Error("boom".into()));
+    assert!(render(&mut app).contains("Tile error: boom"));
+    mbt(&mut app).request_tile_with_ancestors(0, 0, 0);
+    mbt(&mut app).hovered = None;
+    render(&mut app);
+    mbt(&mut app).wait_for_visible_tiles();
+    mbt(&mut app).hovered = Some(hover((0, 0, 0), 99, 0));
+    assert!(render(&mut app).contains("(feature not found)"));
+    mbt(&mut app).hovered = Some(hover((0, 0, 0), 0, 99_999));
+    assert!(render(&mut app).contains("(feature not found)"));
+    press(&mut app, KeyCode::Char('?'));
+    assert!(render(&mut app).contains("Zoom ±0.5 levels"));
+}
+
+#[test]
+fn mbtiles_viewport_edges_and_pruning_at_depth() {
+    let mut app = mbtiles_app();
+    let state = mbt(&mut app);
+    assert!(state.set_viewport_to_tile(1, 5, 0).is_err());
+    assert!(state.set_viewport_to_tile(40, 0, 0).is_err());
+    state.zoom_wheel_at(0.5, 0.5, false);
+    assert!(state.zoom_f.abs() < 1e-9, "cannot zoom out past the world");
+    state.pan_by_pixels(0, 0, 5, 5);
+    assert!(state.vp_x0.abs() < 1e-9, "a zero-sized map does not pan");
+    state.set_viewport_to_tile(2, 1, 1).unwrap();
+    state.wait_for_visible_tiles();
+    state.find_hovered(0.3, 0.3);
+    for x in 0..300u32 {
+        state.tiles.insert((9, x, 511), MbtTileData::Empty);
+    }
+    state.tiles.insert((5, 31, 31), MbtTileData::Empty);
+    state.hovered = Some(MbtHoveredInfo {
+        tile: (5, 31, 31),
+        layer_idx: 0,
+        feat_idx: 0,
+    });
+    state.prune_tile_cache_if_needed();
+    assert!(
+        state.hovered.is_none(),
+        "a hover on a pruned tile is dropped"
+    );
+    assert!(state.tiles.contains_key(&(0, 0, 0)), "ancestors survive");
+    assert!(!state.tiles.contains_key(&(5, 31, 31)));
+}
+
+#[test]
+fn help_renders_for_the_file_browser() {
+    let mut app = file_browser_app();
+    press(&mut app, KeyCode::Char('?'));
+    assert!(render(&mut app).contains("Double-click row"));
+}
+
+#[test]
+fn enter_and_tree_clicks_drill_through_features_and_parts() {
+    let mut app = sample_app();
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Char('+'));
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Enter);
+    assert!(
+        app.expanded_features.contains(&(0, 1)),
+        "Enter expands a multi feature"
+    );
+    press(&mut app, KeyCode::Enter);
+    assert!(
+        !app.expanded_features.contains(&(0, 1)),
+        "Enter again collapses it"
+    );
+    press(&mut app, KeyCode::Up);
+    press(&mut app, KeyCode::Enter);
+    assert_eq!(
+        app.tree_items.len(),
+        6,
+        "Enter on a plain polygon is a no-op"
+    );
+
+    press(&mut app, KeyCode::Left);
+    assert_eq!(app.selected_item(), &TreeItem::Layer(0));
+    let areas = render_with_areas(&mut app, WIDTH, HEIGHT);
+    let tree = areas.tree.unwrap();
+    let mut clicks = MouseState::default();
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        LEFT,
+        tree.x + 6,
+        tree.y + 1 + 3,
+    );
+    assert_eq!(
+        app.selected_item(),
+        &TreeItem::Feature { layer: 0, feat: 1 }
+    );
+    assert!(
+        app.expanded_features.contains(&(0, 1)),
+        "clicking a multi feature opens its parts"
+    );
+    let areas = render_with_areas(&mut app, WIDTH, HEIGHT);
+    std::thread::sleep(Duration::from_millis(450));
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        LEFT,
+        tree.x + 8,
+        tree.y + 1 + 4,
+    );
+    assert_eq!(
+        app.selected_item(),
+        &TreeItem::SubFeature {
+            layer: 0,
+            feat: 1,
+            part: 0
+        }
+    );
+    assert_eq!(app.tree_items[4].layer_feat_part(), Some((0, 1, Some(0))));
+
+    let mut app = mbtiles_app();
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::PageDown);
+    press(&mut app, KeyCode::Enter);
+    assert_eq!(app.selected_index, 0, "the map view has no tree to move in");
+}

--- a/rust/mlt/src/ui/tests.rs
+++ b/rust/mlt/src/ui/tests.rs
@@ -933,6 +933,105 @@ fn dragging_the_divider_resizes_the_split() {
 }
 
 #[test]
+fn file_browser_mouse_sorts_selects_opens_and_filters() {
+    let mut app = file_browser_app();
+    let areas = render_with_areas(&mut app, WIDTH, HEIGHT);
+    let table = app.file_table_area.unwrap();
+    let mut clicks = MouseState::default();
+
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        LEFT,
+        table.x + 32,
+        table.y + 1,
+    );
+    let first = app.get_selected_file().unwrap().path().to_path_buf();
+    assert!(
+        app.files[0].path().ends_with("point-boolean.mvt"),
+        "header click sorts by size"
+    );
+    assert!(
+        first.ends_with("line-boolean.mvt"),
+        "the selection follows its file"
+    );
+
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        LEFT,
+        table.x + 6,
+        table.y + 3,
+    );
+    assert!(
+        app.get_selected_file()
+            .unwrap()
+            .path()
+            .ends_with("multipoint-boolean.mvt")
+    );
+
+    let filter = areas.filter.unwrap();
+    let first_geometry_row = 3 + collect_extensions(&app.files).len() + 2;
+    let row = filter.y + 1 + u16::try_from(first_geometry_row).unwrap();
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        LEFT,
+        filter.x + 4,
+        row,
+    );
+    assert_eq!(
+        app.filtered_file_indices.len(),
+        1,
+        "geometry filter narrows the list"
+    );
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        LEFT,
+        filter.x + 4,
+        filter.y + 1,
+    );
+    assert_eq!(
+        app.filtered_file_indices.len(),
+        6,
+        "[Reset filters] clears it"
+    );
+
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        LEFT,
+        table.x + 6,
+        table.y + 2,
+    );
+    send(
+        &mut app,
+        &areas,
+        &mut clicks,
+        SCREEN,
+        LEFT,
+        table.x + 6,
+        table.y + 2,
+    );
+    assert_eq!(
+        app.mode,
+        ViewMode::LayerOverview,
+        "double-click opens the file"
+    );
+}
+
+#[test]
 fn mbtiles_mouse_pans_and_zooms() {
     let mut app = mbtiles_app();
     let areas = render_with_areas(&mut app, WIDTH, HEIGHT);
@@ -1783,4 +1882,38 @@ fn enter_and_tree_clicks_drill_through_features_and_parts() {
     press(&mut app, KeyCode::PageDown);
     press(&mut app, KeyCode::Enter);
     assert_eq!(app.selected_index, 0, "the map view has no tree to move in");
+}
+
+#[test]
+fn opening_another_file_drops_the_previous_hover_and_scroll() {
+    let base = test_dir("synthetic/0x01");
+    let rows = vec![
+        analyze_row(
+            base.join("mix_7_pt_line_poly_polyh_mpt_mline_mpoly.mlt"),
+            &base,
+        ),
+        analyze_row(fixtures_dir().join("point-boolean.mvt"), &base),
+    ];
+    let mut app = App::new_file_browser(rows, None, base);
+    press(&mut app, KeyCode::Enter);
+    render_sized(&mut app, 60, 12);
+    press(&mut app, KeyCode::End);
+    assert!(app.tree_scroll > 0, "the tree scrolled to the last feature");
+    let last = app.tree_items.len() - 1;
+    let (layer, feat, part) = app.tree_items[last].layer_feat_part().unwrap();
+    app.hovered = Some(HoveredInfo::new(last, layer, feat, part));
+
+    press(&mut app, KeyCode::Esc);
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Enter);
+    assert_eq!(app.mode, ViewMode::LayerOverview);
+    render(&mut app);
+    assert!(
+        app.hovered.is_none(),
+        "the hover belonged to the previous file"
+    );
+    assert_eq!(
+        app.tree_scroll, 0,
+        "a new file starts at the top of the tree"
+    );
 }


### PR DESCRIPTION
Part of #971.

First piece of #1626, split out as requested; the rest stack on this one. The event loop's frame drawing, key handling, mouse handling, and between-frame pump move into functions that tests can drive, so the screens get insta snapshots through `TestBackend` and the handlers get unit tests. Three small fixes the tests turned up ride along in their own commit: the file table selected the row below the one clicked, the rows next to a horizontal divider grabbed the divider instead of their content, and opening another file kept the previous file's hover, which could index past the new file's layers and panic.
