### PR TITLE
chore(ci): consolidate and properly merge Coverage

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+paths:
+  .github/workflows/**.yml:
+    ignore:
+      # `code-quality: write` is what actions/upload-code-coverage needs, and actionlint does not know the scope yet
+      - 'unknown permission scope "code-quality"'

--- a/.github/actions/mlt-publish-coverage/action.yml
+++ b/.github/actions/mlt-publish-coverage/action.yml
@@ -1,0 +1,24 @@
+name: mlt-publish-coverage
+description: >-
+  Publish a Cobertura report to GitHub code coverage.
+  The calling job needs the `code-quality: write` permission.
+
+inputs:
+  file:
+    description: Cobertura XML report to publish, with repository-relative file names.
+    required: true
+  language:
+    description: Linguist language name the report covers, e.g. "Rust".
+    required: true
+  label:
+    description: Label the report shows up under, e.g. "code-coverage/llvm-cov".
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/upload-code-coverage@d8e329117199404bba6fc81efe8093dc7c015e34 # v1.4.2
+      with:
+        file: ${{ inputs.file }}
+        language: ${{ inputs.language }}
+        label: ${{ inputs.label }}

--- a/.github/actions/mlt-setup-rust/action.yml
+++ b/.github/actions/mlt-setup-rust/action.yml
@@ -6,6 +6,12 @@ inputs:
     description: 'Rust toolchain to install: stable (default), nightly, or msrv'
     required: false
     default: 'stable'
+  coverage:
+    description: >-
+      Instrument the job with cargo-llvm-cov, so every later step records coverage.
+      Collect it with `just rust::coverage-report <suite>` and the mlt-upload-coverage action.
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -41,3 +47,13 @@ runs:
         # dispatching to rustup-init mode), causing maturin-action to fail with
         # "unexpected argument '--print' found / Usage: rustup-init[EXE]".
         cache-bin: false
+        # Instrumented artifacts cannot be reused by the uninstrumented jobs, so they get their own cache
+        key: ${{ inputs.coverage == 'true' && 'coverage' || '' }}
+
+    - if: ${{ inputs.coverage == 'true' }}
+      uses: taiki-e/install-action@v2
+      with: { tool: 'cargo-llvm-cov' }
+    - if: ${{ inputs.coverage == 'true' }}
+      name: Instrument this job with cargo-llvm-cov
+      shell: bash
+      run: just -v rust::coverage-env "$GITHUB_ENV"

--- a/.github/actions/mlt-upload-coverage/action.yml
+++ b/.github/actions/mlt-upload-coverage/action.yml
@@ -1,0 +1,20 @@
+name: mlt-upload-coverage
+description: Upload one suite's coverage report as an artifact, for a `coverage` job to merge.
+
+inputs:
+  suite:
+    description: Test suite this job ran, e.g. "rust-unit". Names the artifact.
+    required: true
+  file:
+    description: Coverage report to upload, in lcov or JaCoCo XML format.
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: coverage-${{ inputs.suite }}
+        path: ${{ inputs.file }}
+        retention-days: 1
+        if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,21 +58,22 @@ jobs:
       run-release: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       run-heavy: ${{ needs.changes.outputs.top-of-stack == 'true' }}
     secrets: inherit
-    permissions: { contents: write, id-token: write }
+    permissions: { contents: write, id-token: write, code-quality: write, pull-requests: read }
 
   java:
     needs: changes
     if: needs.changes.outputs.java == 'true'
     uses: ./.github/workflows/java.yml
     permissions:
-      id-token: write
       contents: read
+      code-quality: write
+      pull-requests: read
 
   ts:
     needs: changes
     if: needs.changes.outputs.ts == 'true'
     uses: ./.github/workflows/ts.yml
-    permissions: { contents: read }
+    permissions: { contents: read, code-quality: write, pull-requests: read }
 
   cpp:
     needs: changes
@@ -81,8 +82,9 @@ jobs:
     with:
       run-heavy: ${{ needs.changes.outputs.top-of-stack == 'true' }}
     permissions:
-      id-token: write
       contents: read
+      code-quality: write
+      pull-requests: read
 
   docs:
     uses: ./.github/workflows/gh-pages.yml

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -13,7 +13,9 @@ jobs:
   cpp-build:
     if: ${{ github.event_name != 'pull_request' || inputs.run-heavy }}
     permissions:
-      id-token: write  # for OIDC Codecov
+      contents: read
+      code-quality: write
+      pull-requests: read
     strategy:
       matrix:
         os: [ macos-15, ubuntu-24.04 ]
@@ -42,15 +44,12 @@ jobs:
       - name: Build, test and generate coverage report
         run: just -v cpp::coverage
 
-      - name: Upload coverage to Codecov
-        if: github.repository_owner == 'maplibre'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - if: runner.os == 'Linux'
+        uses: ./.github/actions/mlt-publish-coverage
         with:
-          use_oidc: true
-          fail_ci_if_error: true
-          disable_file_fixes: true
-          disable_search: true
-          files: cpp/build/coverage.xml
+          file: cpp/build/coverage.xml
+          language: C++
+          label: code-coverage/gcovr
 
       - name: Sanity test for mlt-cpp-json tool
         run: just -v cpp::test-json

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -11,7 +11,9 @@ defaults:
 jobs:
   test-java:
     permissions:
-      id-token: write  # for OIDC Codecov
+      contents: read
+      code-quality: write
+      pull-requests: read
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -27,6 +29,14 @@ jobs:
         run: just -v java::lint
 
       - run: just -v java::test-coverage
+      - if: matrix.os == 'ubuntu-latest'
+        run: just -v java::coverage-report
+      - if: matrix.os == 'ubuntu-latest'
+        uses: ./.github/actions/mlt-publish-coverage
+        with:
+          file: java/build/coverage/cobertura.xml
+          language: Java
+          label: code-coverage/jacoco
 
       - run: just -v java::test-cli
 
@@ -38,11 +48,6 @@ jobs:
       - run: npm run lint
         working-directory: java/encoding-server
       - run: just -v assert-git-is-clean
-
-      - name: Upload coverage to Codecov
-        if: github.repository_owner == 'maplibre'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with: { use_oidc: true, directory: java }
 
       - name: Test synthetic MLT generation
         run: just -v java::ci-check-synthetic-mlts

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/mlt-setup-rust
+        with: { coverage: true }
       - run: just -v rust::ci-test
+      - run: just -v rust::coverage-report unit
+      - uses: ./.github/actions/mlt-upload-coverage
+        with: { suite: rust-unit, file: rust/target/lcov-unit.info }
 
   test-python:
     name: Test mlt-py
@@ -40,31 +44,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/mlt-setup-rust
+        with: { coverage: true }
       - uses: actions/setup-python@v7
         with: { python-version: '3.13' }
       - run: just -v rust::py-test
-
-  coverage:
-    permissions:
-      id-token: write  # for OIDC Codecov
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: ./.github/actions/mlt-setup-rust
-        with: { toolchain: nightly } # because of covs --doctests
-      - uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2.87.0
-        with: { tool: 'cargo-llvm-cov' }
-      - run: just -v rust::ci-coverage
-      - name: Upload coverage to Codecov
-        if: github.repository_owner == 'maplibre'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with:
-          use_oidc: true
-          fail_ci_if_error: true
-          skip_validation: true
-          disable_search: true
-          files: rust/target/llvm-cov/lcov.info
-      - run: just -v assert-git-is-clean
+      - run: just -v rust::coverage-report python
+      - uses: ./.github/actions/mlt-upload-coverage
+        with: { suite: rust-python, file: rust/target/lcov-python.info }
 
   test-wasm:
     name: Test wasm
@@ -110,14 +96,11 @@ jobs:
         run: just -v rust::fuzz-seed ${{ matrix.target }}
       - run: just -v rust::ci-fuzz-run ${{ matrix.target }}
       - name: Generate fuzz coverage
-        if: github.repository_owner == 'maplibre'
         run: just -v rust::ci-fuzz-cov ${{ matrix.target }}
-      - name: Upload fuzz coverage artifact
-        if: github.repository_owner == 'maplibre'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - uses: ./.github/actions/mlt-upload-coverage
         with:
-          name: fuzz-coverage-${{ matrix.target }}
-          path: rust/target/llvm-cov/fuzz-${{ matrix.target }}.lcov
+          suite: rust-fuzz-${{ matrix.target }}
+          file: rust/target/llvm-cov/fuzz-${{ matrix.target }}.lcov
 
   #  MSRV Testing is not really needed at this stage of code completeness
   #  test-msrv:
@@ -231,6 +214,30 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with: { name: 'mlt-wasm-npm', path: 'rust/mlt-wasm/maplibre-mlt-wasm-*.tgz' }
 
+  coverage:
+    name: Merge and publish Rust coverage
+    needs: [ test, test-python, fuzz ]
+    # Publish whatever ran: `fuzz` is skipped for pull requests that are not on top of their stack
+    if: ${{ !cancelled() && needs.test.result == 'success' && needs.test-python.result == 'success' }}
+    permissions:
+      contents: read
+      code-quality: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Download the per-suite lcov reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with: { pattern: 'coverage-rust-*', merge-multiple: true, path: 'rust/target/coverage' }
+      - uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2.87.0
+        with: { tool: 'just,grcov' }
+      - run: just -v coverage-merge rust/target/coverage rust/target/cobertura.xml
+      - uses: ./.github/actions/mlt-publish-coverage
+        with:
+          file: rust/target/cobertura.xml
+          language: Rust
+          label: code-coverage/llvm-cov
+
   # This job checks if any of the previous jobs failed or were canceled.
   # This approach also allows some jobs to be skipped if they are not needed.
   ci-passed-rust:
@@ -305,7 +312,7 @@ jobs:
         shell: bash
         run: just -v rust::ci-get-release-info mlt >> $GITHUB_OUTPUT
       - name: Download all artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v3.1.0-node20
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { path: 'artifacts' }
       - name: Add binaries to GitHub release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
@@ -349,7 +356,7 @@ jobs:
         with: { node-version: '24', registry-url: 'https://registry.npmjs.org' }
 
       - name: Download npm package artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v3.1.0-node20
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: 'mlt-wasm-npm', path: 'mlt-wasm-pkg' }
 
       - name: Release (GitHub) - Create Draft

--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -10,6 +10,10 @@ defaults:
 
 jobs:
   test-js:
+    permissions:
+      contents: read
+      code-quality: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -20,8 +24,10 @@ jobs:
         run: just -v ts::lint
       - run: just -v ts::test
       - run: just -v ts::build
-      - name: Codecov upload
-        if: "github.repository_owner == 'maplibre' && !cancelled()"
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with: { files: 'ts/coverage/coverage-final.json' }
+      - if: ${{ !cancelled() }}
+        uses: ./.github/actions/mlt-publish-coverage
+        with:
+          file: ts/coverage/cobertura-coverage.xml
+          language: TypeScript
+          label: code-coverage/vitest
       - run: just -v assert-git-is-clean

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ MODULE.bazel.lock
 bazel-*
 bin/
 build/
-codecov*
 coverage/
 dist/
 site/

--- a/java/mod.just
+++ b/java/mod.just
@@ -93,6 +93,17 @@ test-cli:
 test-coverage:
     ./gradlew jacocoTestReport
 
+# Merge the per-module JaCoCo reports into `java/build/coverage/cobertura.xml`
+coverage-report:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    rm -rf build/coverage && mkdir -p build/coverage/jacoco
+    shopt -s nullglob
+    for report in */build/reports/jacoco/test/jacocoTestReport.xml; do
+        cp "$report" "build/coverage/jacoco/${report%%/*}.xml"
+    done
+    {{just}} coverage-merge java/build/coverage/jacoco java/build/coverage/cobertura.xml
+
 # Test Maven local publishing
 test-publish:
     ./gradlew publishMavenPublicationToMavenLocal

--- a/justfile
+++ b/justfile
@@ -59,6 +59,15 @@ docs:
 docs-build:
     docker run --rm -v ${PWD}:/docs zensical/zensical:latest build
 
+# Merge the lcov and JaCoCo coverage reports in `dir` into one Cobertura report at `out`
+coverage-merge dir out: (cargo-install 'grcov')
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p "$(dirname {{quote(out)}})"
+    grcov {{quote(dir)}} --source-dir . \
+        --ignore '**/build/**' --ignore '**/target/**' --ignore '**/node_modules/**' \
+        --output-types cobertura --output-path {{quote(out)}}
+
 # Extract version from a tag by removing language prefix and 'v' prefix
 ci-extract-version language tag:
     @echo "{{replace(replace(tag, language + '-', ''), 'v', '')}}"

--- a/rust/mod.just
+++ b/rust/mod.just
@@ -49,11 +49,19 @@ check: (just 'cargo-install' 'cargo-hack')
         --workspace --exclude-no-default-features --exclude-all-features
     cd mlt-core/fuzz && cargo check --all-features
 
-# Generate code coverage report to upload to codecov.io
-ci-coverage: ci-env-info _coverage
-    {{just}} assert-git-is-clean  # call it explicitly to avoid just optimizing it to just one call
-    mkdir -p target/llvm-cov      # the output-path here is used in the CI workflow
-    cargo llvm-cov report --include-build-script --lcov --output-path target/llvm-cov/lcov.info
+# Append the cargo-llvm-cov environment to `file` ($GITHUB_ENV), instrumenting every later CI step
+coverage-env file: (just 'cargo-install' 'cargo-llvm-cov')
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! rustup component list --installed | grep -q llvm-tools; then
+        rustup component add llvm-tools-preview
+    fi
+    cargo llvm-cov clean --profraw-only
+    cargo llvm-cov show-env | sed "s/'//g" >> {{quote(file)}}
+
+# Write the coverage recorded since `coverage-env` to `target/lcov-<suite>.info`
+coverage-report suite:
+    cargo llvm-cov report --include-build-script --lcov --output-path target/lcov-{{suite}}.info
 
 # Run minimal subset of tests to ensure compatibility with MSRV
 ci-check: ci-env-info check
@@ -123,7 +131,7 @@ ci-fuzz-build target: (cargo-fuzz 'build' target '--target' 'x86_64-unknown-linu
 # Fuzz the target for 90 seconds (installs `cargo fuzz`)
 ci-fuzz-run target: (cargo-fuzz 'run' target '--target' 'x86_64-unknown-linux-gnu' '--' '-max_total_time=90' '-max_len=300' '-rss_limit_mb=2048')
 
-# Run coverage against a previously generated corpus and export LCOV for Codecov upload.
+# Run coverage against a previously generated corpus and export LCOV for the `coverage` CI job.
 # Output: target/llvm-cov/fuzz-<target>.lcov
 [working-directory: 'mlt-core']
 ci-fuzz-cov target: (just 'cargo-install' 'cargo-fuzz')
@@ -166,20 +174,14 @@ clippy *args: (just 'cargo-install' 'cargo-hack')
     cargo clippy --all-targets --all-features --workspace {{args}}
     cd mlt-core/fuzz && cargo clippy --all-features {{args}}
 
-# Generate code coverage report and open it
-coverage: _coverage
-    cargo llvm-cov report --include-build-script --open
-
-# Generate code coverage report. Installs `cargo llvm-cov`
-_coverage: (just 'cargo-install' 'cargo-hack') (just 'cargo-install' 'cargo-llvm-cov') (just 'java::gen-snippets')
+# Run the test suite under coverage instrumentation and open the report
+coverage *args='--open': (just 'cargo-install' 'cargo-llvm-cov') (just 'java::gen-snippets')
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source <(cargo llvm-cov show-env --sh)
     cargo llvm-cov clean --workspace
-    cargo hack llvm-cov --no-report --all-targets --each-feature {{hack_skip}} \
-        --workspace --exclude-no-default-features --exclude-all-features
-    rm -rf ../test/synthetic/0x01-rust ../test/synthetic/0x02-rust
-    cargo llvm-cov run --no-report -p mlt-synthetics
-    cargo llvm-cov run --no-report -p mlt --features unstable-v2 -- ls --validate-to-json {{validate_excludes}} --details basic ../test/synthetic/
-    rustup toolchain install nightly --profile minimal --component llvm-tools
-    cargo +nightly llvm-cov --no-report --doctests --workspace
+    {{just}} rust::test
+    cargo llvm-cov report --include-build-script {{args}}
 
 # Run the encoder with hotpath profiling (timing + allocation tracking)
 profile *args:

--- a/ts/eslint.config.mjs
+++ b/ts/eslint.config.mjs
@@ -49,6 +49,6 @@ export default tseslint.config(
         },
     },
     {
-        ignores: ["dist", "node_modules", "coverage", "*.config.mjs", "*.config.js", "**/*.js"],
+        ignores: ["dist", "node_modules", "coverage", "*.config.mjs", "*.config.js", "*.config.ts", "**/*.js"],
     },
 );

--- a/ts/package.json
+++ b/ts/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "tsc",
     "bench": "vitest bench --run src",
-    "test": "vitest run --coverage --coverage.reportOnFailure",
+    "test": "vitest run --coverage",
     "lint": "eslint",
     "format": "biome format --write ./src",
     "format:check": "biome format ./src"

--- a/ts/vitest.config.ts
+++ b/ts/vitest.config.ts
@@ -1,0 +1,12 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        coverage: {
+            reportOnFailure: true,
+            // Cobertura file names are relative to `projectRoot`, and must be repository-relative for GitHub code coverage
+            reporter: [["text"], ["cobertura", { projectRoot: path.resolve(import.meta.dirname, "..") }]],
+        },
+    },
+});


### PR DESCRIPTION
Currently, we run CI twice. Once under codecov, once without.
This PR adds an merging of coverage step and reports this to github instead...

Means no good line coverage instrumentation, but since we only intermittently build ("only what changed"), the line coverage is not reliable anyhow. 
Switching to GH means we can add a ruleset for merging on this 🎉 