### PR TITLE
feat(rust): scan the mlt ui directory in the background

### DIFF
--- a/rust/mlt/README.md
+++ b/rust/mlt/README.md
@@ -52,8 +52,9 @@ cargo run -- ui path/to/directory
 ```
 
 **Directory Mode**:
-- Lists all `.mlt` files found recursively in the directory
-- Use `↑`/`↓` to navigate the file list
+- Lists every `.mlt`, `.mvt`, and `.pbf` file under the directory; the walk and the per-file analysis run in the background, so the list fills in while you browse
+- Use `↑`/`↓` to navigate the file list; the preview, filter, and info panels follow the selection
+- Click a column header to sort once the scan is done; click the filter checkboxes to narrow the list
 - Press `Enter` to open and visualize a file
 - Press `Esc` to go back to file list
 - Press `q` to quit

--- a/rust/mlt/src/ls.rs
+++ b/rust/mlt/src/ls.rs
@@ -357,20 +357,26 @@ pub fn ls(args: &LsArgs) -> AnyResult<bool> {
 pub fn analyze_tile_files(paths: &[PathBuf], base_path: &Path, flags: LsFlags) -> Vec<LsRow> {
     paths
         .par_iter()
-        .map(|path| match analyze_tile_file(path, base_path, flags) {
-            Ok(info) => LsRow::Info {
-                path: path.clone(),
-                info,
-            },
-            Err(e) => LsRow::Error {
-                path: path.clone(),
-                error: e.to_string(),
-                size: fs::metadata(path)
-                    .ok()
-                    .and_then(|m| usize::try_from(m.len()).ok()),
-            },
-        })
+        .map(|path| analyze_tile_row(path, base_path, flags))
         .collect()
+}
+
+/// Analyze one tile file into a row, turning failures into `LsRow::Error`.
+#[must_use]
+pub fn analyze_tile_row(path: &Path, base_path: &Path, flags: LsFlags) -> LsRow {
+    match analyze_tile_file(path, base_path, flags) {
+        Ok(info) => LsRow::Info {
+            path: path.to_path_buf(),
+            info,
+        },
+        Err(e) => LsRow::Error {
+            path: path.to_path_buf(),
+            error: e.to_string(),
+            size: fs::metadata(path)
+                .ok()
+                .and_then(|m| usize::try_from(m.len()).ok()),
+        },
+    }
 }
 
 /// Return cells for UI table display: [File, Size, Enc%, Layers, Features].

--- a/rust/mlt/src/ui/mod.rs
+++ b/rust/mlt/src/ui/mod.rs
@@ -3,12 +3,12 @@ use usize_cast::IntoUsize as _;
 
 pub(crate) mod mbt;
 mod rendering;
+mod scan;
 mod state;
 #[cfg(test)]
 mod tests;
 
 use std::collections::HashSet;
-use std::fs::canonicalize;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
@@ -34,8 +34,8 @@ use ratatui::widgets::{Block, Borders};
 use rstar::{AABB, PointDistance, RTreeObject};
 
 use crate::ls::{
-    FileAlgorithm, FileSortColumn, LsFlags, LsRow, analyze_tile_files, is_mbt_extension,
-    is_mlt_extension, is_tile_extension,
+    FileAlgorithm, FileSortColumn, LsFlags, LsRow, is_mbt_extension, is_mlt_extension,
+    is_tile_extension,
 };
 use crate::ui::mbt::MbtilesState;
 use crate::ui::rendering::files::{
@@ -47,6 +47,7 @@ use crate::ui::rendering::layers::{
     render_mbtiles_hover_panel, render_properties_panel, render_tree_panel,
 };
 use crate::ui::rendering::map::{render_map_panel, render_mbtiles_map_panel};
+use crate::ui::scan::start_scan;
 use crate::ui::state::{App, HoveredInfo, LayerGroup, ResizeHandle, TreeItem, ViewMode};
 
 pub const CLR_POINT: Color = Color::Magenta;
@@ -107,23 +108,8 @@ fn build_app(args: &UiArgs) -> anyhow::Result<App> {
         }
         App::new_mbtiles(mbt, args.path.clone())
     } else if args.path.is_dir() {
-        let paths = find_tile_files(&args.path)?;
-        if paths.is_empty() {
-            bail!(
-                "No tile files found in {}",
-                canonicalize(&args.path)?.display()
-            );
-        }
-        let base = args.path.clone();
-        let files: Vec<LsRow> = paths
-            .iter()
-            .map(|p| LsRow::Loading { path: p.clone() })
-            .collect();
-        let (tx, rx) = mpsc::channel();
-        thread::spawn(move || {
-            let _ = tx.send(analyze_tile_files(&paths, &base, SCAN_FLAGS));
-        });
-        App::new_file_browser(files, Some(rx), args.path.clone())
+        let rx = start_scan(args.path.clone(), SCAN_FLAGS);
+        App::new_file_browser(Vec::new(), Some(rx), args.path.clone())
     } else if args.path.is_file() {
         App::new_single_file(load_fc(&args.path)?, Some(args.path.clone()))
     } else {
@@ -229,26 +215,6 @@ fn auto_expand(groups: &[LayerGroup]) -> Vec<bool> {
     } else {
         vec![false; groups.len()]
     }
-}
-
-fn find_tile_files(dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
-    fn visit(dir: &Path, out: &mut Vec<PathBuf>) -> anyhow::Result<()> {
-        if dir.is_dir() {
-            for entry in fs::read_dir(dir)? {
-                let p = entry?.path();
-                if p.is_dir() {
-                    visit(&p, out)?;
-                } else if is_tile_extension(&p) {
-                    out.push(p);
-                }
-            }
-        }
-        Ok(())
-    }
-    let mut files = Vec::new();
-    visit(dir, &mut files)?;
-    files.sort_unstable();
-    Ok(files)
 }
 
 // --- Hit testing ---
@@ -636,17 +602,7 @@ fn tick(app: &mut App) {
         mbt.prune_tile_cache_if_needed();
     }
 
-    if let Some(rows) = app.analysis_rx.as_ref().and_then(|rx| rx.try_recv().ok()) {
-        if rows.len() == app.files.len() {
-            for (i, row) in rows.into_iter().enumerate() {
-                if let Some(e) = app.files.get_mut(i) {
-                    *e = row;
-                }
-            }
-        }
-        app.analysis_rx = None;
-        app.rebuild_filtered_files();
-    }
+    app.poll_scan();
 
     if let Some((path, result)) = app.preview_rx.as_mut().and_then(|rx| rx.try_recv().ok()) {
         app.preview_rx = None;

--- a/rust/mlt/src/ui/rendering/files.rs
+++ b/rust/mlt/src/ui/rendering/files.rs
@@ -78,6 +78,7 @@ pub fn render_file_browser(f: &mut Frame<'_>, area: Rect, app: &mut App) {
         .map(|&i| Row::new(row_cells_6(&app.files[i], base).map(Cell::from)))
         .collect();
 
+    let status = app.scan_status();
     let sort_hint = if app.data_loaded() {
         " Click header to sort"
     } else {
@@ -90,8 +91,16 @@ pub fn render_file_browser(f: &mut Frame<'_>, area: Rect, app: &mut App) {
     } else {
         total.to_string()
     };
+    let progress = if status.scanning {
+        ", scanning…".to_string()
+    } else if status.pending > 0 {
+        format!(", {} analyzing…", status.pending)
+    } else {
+        String::new()
+    };
+    let count = format!("{count} found{progress}");
     let title =
-        format!("MLT Files ({count} found) - ↑/↓ navigate, Enter open, h help, q quit{sort_hint}");
+        format!("MLT Files ({count}) - ↑/↓ navigate, Enter open, h help, q quit{sort_hint}");
     let table = Table::new(rows, widths)
         .header(header)
         .column_spacing(1)
@@ -186,6 +195,11 @@ pub fn render_file_info_panel(f: &mut Frame<'_>, area: Rect, app: &mut App) {
         LsRow::Info { info, .. } => Some(info),
         LsRow::Error { .. } | LsRow::Loading { .. } => None,
     });
+    let base = app
+        .file_browser_base
+        .as_ref()
+        .map_or_else(String::new, |p| p.display().to_string());
+    let status = app.scan_status();
 
     let lines: Vec<Line<'static>> = if let Some(info) = info {
         let sz = |n: usize| format!("{:.1}B", SizeFormatterSI::new(u64::from_usize(n)));
@@ -241,12 +255,18 @@ pub fn render_file_info_panel(f: &mut Frame<'_>, area: Rect, app: &mut App) {
                 "compression methods",
             ),
         ]
-    } else if app.filtered_file_indices.is_empty() && !app.files.is_empty() {
+    } else if app.files.is_empty() && status.scanning {
+        vec![Line::from(format!("Scanning {base}…"))]
+    } else if app.files.is_empty() {
+        vec![Line::from(format!("No tile files found in {base}"))]
+    } else if app.filtered_file_indices.is_empty() {
         vec![
             Line::from("No files match the current filters."),
             Line::from(""),
             Line::from(Span::styled("[Reset filters]", STYLE_SELECTED)),
         ]
+    } else if matches!(app.get_selected_file(), Some(LsRow::Loading { .. })) {
+        vec![Line::from("Analyzing…")]
     } else {
         vec![Line::from("Select a file to view details")]
     };

--- a/rust/mlt/src/ui/rendering/help.rs
+++ b/rust/mlt/src/ui/rendering/help.rs
@@ -119,7 +119,7 @@ fn help_file_browser() -> Vec<Line<'static>> {
         heading("Mouse"),
         key("Click row", "Select file"),
         key("Double-click row", "Open file"),
-        key("Click header", "Sort by column"),
+        key("Click header", "Sort by column (once the scan is done)"),
         key("Scroll", "Navigate file list"),
         key("Drag divider", "Resize panels"),
         Line::from(""),

--- a/rust/mlt/src/ui/scan.rs
+++ b/rust/mlt/src/ui/scan.rs
@@ -1,0 +1,44 @@
+//! Background directory scan for the file browser.
+//! Files are reported as the walk finds them and analyzed on the rayon pool, so the list fills in early.
+
+use std::path::PathBuf;
+use std::sync::mpsc;
+use std::thread;
+
+use walkdir::WalkDir;
+
+use crate::ls::{LsFlags, LsRow, analyze_tile_row, is_tile_extension};
+
+pub(crate) enum ScanEvent {
+    /// A tile file was found.
+    Found(PathBuf),
+    /// Analysis of the file found at this position finished.
+    Analyzed(usize, Box<LsRow>),
+    /// The directory walk is complete (analyses may still be in flight).
+    Done,
+}
+
+pub(crate) fn start_scan(dir: PathBuf, flags: LsFlags) -> mpsc::Receiver<ScanEvent> {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let entries = WalkDir::new(&dir)
+            .sort_by_file_name()
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_type().is_file() && is_tile_extension(e.path()));
+        for (i, entry) in entries.enumerate() {
+            let path = entry.into_path();
+            if tx.send(ScanEvent::Found(path.clone())).is_err() {
+                return;
+            }
+            let tx = tx.clone();
+            let base = dir.clone();
+            rayon::spawn(move || {
+                let row = Box::new(analyze_tile_row(&path, &base, flags));
+                let _ = tx.send(ScanEvent::Analyzed(i, row));
+            });
+        }
+        let _ = tx.send(ScanEvent::Done);
+    });
+    rx
+}

--- a/rust/mlt/src/ui/state.rs
+++ b/rust/mlt/src/ui/state.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::sync::mpsc;
+use std::sync::mpsc::{self, TryRecvError};
 use std::time::Instant;
 
 use mlt_core::GeometryType;
@@ -13,6 +13,7 @@ use usize_cast::IntoUsize as _;
 
 use crate::ls::{FileAlgorithm, FileSortColumn, LsRow};
 use crate::ui::mbt::MbtilesState;
+use crate::ui::scan::ScanEvent;
 use crate::ui::{
     GeometryIndexEntry, auto_expand, coord_f64, group_by_layer, is_entry_visible, load_fc,
     multi_part_count,
@@ -103,7 +104,12 @@ pub struct App {
     pub(crate) files: Vec<LsRow>,
     pub(crate) selected_file_index: usize,
     pub(crate) file_list_state: TableState,
-    pub(crate) analysis_rx: Option<mpsc::Receiver<Vec<LsRow>>>,
+    /// Directory scan in progress, `None` once every file is analyzed.
+    scan_rx: Option<mpsc::Receiver<ScanEvent>>,
+    scan_done: bool,
+    pending_analysis: usize,
+    /// Rows that were there before the scan started.
+    scan_base: usize,
     /// Base path for file browser; used when drawing to show relative paths.
     pub(crate) file_browser_base: Option<PathBuf>,
     file_sort: Option<(FileSortColumn, bool)>,
@@ -160,7 +166,10 @@ impl Default for App {
             files: Vec::new(),
             selected_file_index: 0,
             file_list_state: TableState::default(),
-            analysis_rx: None,
+            scan_rx: None,
+            scan_done: false,
+            pending_analysis: 0,
+            scan_base: 0,
             file_browser_base: None,
             file_sort: None,
             file_table_area: None,
@@ -213,19 +222,34 @@ impl Default for App {
     }
 }
 
+/// Progress of the directory scan behind the file browser.
+pub(crate) struct ScanStatus {
+    /// Files found but not yet analyzed.
+    pub pending: usize,
+    /// The directory walk is still running.
+    pub scanning: bool,
+}
+
 impl App {
     pub(crate) fn new_file_browser(
         files: Vec<LsRow>,
-        analysis_rx: Option<mpsc::Receiver<Vec<LsRow>>>,
+        scan_rx: Option<mpsc::Receiver<ScanEvent>>,
         base_path: PathBuf,
     ) -> Self {
         let mut file_list_state = TableState::default();
         file_list_state.select(Some(0));
         let filtered_file_indices = (0..files.len()).collect();
+        let scan_base = files.len();
+        let pending_analysis = files
+            .iter()
+            .filter(|r| matches!(r, LsRow::Loading { .. }))
+            .count();
         Self {
             files,
             file_list_state,
-            analysis_rx,
+            scan_rx,
+            pending_analysis,
+            scan_base,
             file_browser_base: Some(base_path),
             filtered_file_indices,
             ..Self::default()
@@ -258,11 +282,87 @@ impl App {
     }
 
     pub(crate) fn data_loaded(&self) -> bool {
-        self.analysis_rx.is_none()
-            && !self
-                .files
-                .iter()
-                .any(|r| matches!(r, LsRow::Loading { .. }))
+        self.scan_rx.is_none()
+    }
+
+    pub(crate) fn scan_status(&self) -> ScanStatus {
+        ScanStatus {
+            pending: self.pending_analysis,
+            scanning: self.scan_rx.is_some() && !self.scan_done,
+        }
+    }
+
+    /// Apply every scan event that has arrived.
+    /// Returns true when the file list changed.
+    pub(crate) fn poll_scan(&mut self) -> bool {
+        let Some(rx) = self.scan_rx.as_ref() else {
+            return false;
+        };
+        let mut events = Vec::new();
+        let mut disconnected = false;
+        loop {
+            match rx.try_recv() {
+                Ok(ev) => events.push(ev),
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => {
+                    disconnected = true;
+                    break;
+                }
+            }
+        }
+        let changed = !events.is_empty() || disconnected;
+        let first_new = self.files.len();
+        for ev in events {
+            self.apply_scan_event(ev);
+        }
+        if disconnected {
+            self.scan_done = true;
+            self.pending_analysis = 0;
+        }
+        self.settle_scan();
+        if changed {
+            self.refresh_filtered_files(first_new);
+        }
+        changed
+    }
+
+    /// Bring `filtered_file_indices` up to date after the scan appended or replaced rows.
+    fn refresh_filtered_files(&mut self, first_new: usize) {
+        if self.has_filters() {
+            self.rebuild_filtered_files();
+        } else {
+            self.filtered_file_indices
+                .extend(first_new..self.files.len());
+            self.invalidate();
+        }
+    }
+
+    fn has_filters(&self) -> bool {
+        !self.ext_filters.is_empty()
+            || !self.geom_filters.is_empty()
+            || !self.algo_filters.is_empty()
+    }
+
+    fn apply_scan_event(&mut self, event: ScanEvent) {
+        match event {
+            ScanEvent::Found(path) => {
+                self.files.push(LsRow::Loading { path });
+                self.pending_analysis += 1;
+            }
+            ScanEvent::Analyzed(i, row) => {
+                if let Some(slot) = self.files.get_mut(self.scan_base + i) {
+                    *slot = *row;
+                }
+                self.pending_analysis = self.pending_analysis.saturating_sub(1);
+            }
+            ScanEvent::Done => self.scan_done = true,
+        }
+    }
+
+    fn settle_scan(&mut self) {
+        if self.scan_done && self.pending_analysis == 0 {
+            self.scan_rx = None;
+        }
     }
 
     pub(crate) fn open_help(&mut self) {
@@ -560,7 +660,7 @@ impl App {
     pub(crate) fn handle_escape(&mut self) -> bool {
         match self.mode {
             ViewMode::FileBrowser | ViewMode::MbtilesMap => true,
-            ViewMode::LayerOverview if self.files.is_empty() => true,
+            ViewMode::LayerOverview if self.file_browser_base.is_none() => true,
             ViewMode::LayerOverview => {
                 self.mode = ViewMode::FileBrowser;
                 self.hovered = None;
@@ -587,7 +687,7 @@ impl App {
                 .position(|t| matches!(t, TreeItem::Layer(l) if *l == layer)),
             TreeItem::Layer(_) => Some(0),
             TreeItem::All => {
-                if !self.files.is_empty() {
+                if self.file_browser_base.is_some() {
                     self.mode = ViewMode::FileBrowser;
                     self.hovered = None;
                 }
@@ -640,9 +740,7 @@ impl App {
 
     pub(crate) fn rebuild_filtered_files(&mut self) {
         let prev = self.selected_file_real_index();
-        let has_filters = !self.ext_filters.is_empty()
-            || !self.geom_filters.is_empty()
-            || !self.algo_filters.is_empty();
+        let has_filters = self.has_filters();
         self.filtered_file_indices = (0..self.files.len())
             .filter(|&i| {
                 if !has_filters {
@@ -936,5 +1034,27 @@ fn geometry_vertices(geom: &Geometry<i32>, part: Option<usize>) -> Vec<[f64; 2]>
             mpoly.0.get(p).map(poly_verts).unwrap_or_default()
         }
         _ => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl App {
+        /// Block until the scan has delivered every file.
+        pub(crate) fn finish_scan(&mut self) {
+            while self.scan_rx.is_some() {
+                let received = self.scan_rx.as_ref().map(mpsc::Receiver::recv);
+                if let Some(Ok(ev)) = received {
+                    self.apply_scan_event(ev);
+                } else {
+                    self.scan_done = true;
+                    self.pending_analysis = 0;
+                }
+                self.settle_scan();
+            }
+            self.rebuild_filtered_files();
+        }
     }
 }

--- a/rust/mlt/src/ui/tests.rs
+++ b/rust/mlt/src/ui/tests.rs
@@ -4,6 +4,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+use mlt_core::GeometryType;
 use mlt_core::geo_types::{
     Coord, Geometry, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
 };
@@ -15,12 +16,12 @@ use serde_json::{Value, json};
 
 use super::{
     MouseState, PanelAreas, SCAN_FLAGS, UiArgs, build_app, collect_extensions,
-    collect_file_algorithms, collect_file_geometries, extent_from_fc, find_tile_files,
-    handle_filter_click, handle_key, handle_mouse, load_fc, parse_center_tile_xyz, render_frame,
-    tick,
+    collect_file_algorithms, collect_file_geometries, extent_from_fc, handle_filter_click,
+    handle_key, handle_mouse, load_fc, parse_center_tile_xyz, render_frame, tick,
 };
-use crate::ls::{FileSortColumn, LsRow, analyze_tile_files};
+use crate::ls::{FileSortColumn, LsRow, analyze_tile_files, analyze_tile_row};
 use crate::ui::mbt::{MbtHoveredInfo, MbtTileData, MbtilesState};
+use crate::ui::scan::{ScanEvent, start_scan};
 use crate::ui::state::{App, HoveredInfo, ResizeHandle, TreeItem, ViewMode};
 
 const WIDTH: u16 = 100;
@@ -138,19 +139,13 @@ fn fixtures_dir() -> PathBuf {
     test_dir("fixtures/simple")
 }
 
-/// File browser over `test/fixtures/simple` with every file analyzed.
+/// File browser over `test/fixtures/simple` with the background scan already finished.
 fn file_browser_app() -> App {
-    browser_over(fixtures_dir())
-}
-
-fn browser_over(base: PathBuf) -> App {
-    let paths = find_tile_files(&base).unwrap();
-    let files = analyze_tile_files(&paths, &base, SCAN_FLAGS);
-    App::new_file_browser(files, None, base)
-}
-
-fn analyze_row(path: PathBuf, base: &std::path::Path) -> LsRow {
-    analyze_tile_files(&[path], base, SCAN_FLAGS).remove(0)
+    let base = fixtures_dir();
+    let rx = start_scan(base.clone(), SCAN_FLAGS);
+    let mut app = App::new_file_browser(Vec::new(), Some(rx), base);
+    app.finish_scan();
+    app
 }
 
 #[test]
@@ -641,6 +636,53 @@ fn enter_opens_a_file_and_escape_returns_to_the_browser() {
     "#);
     press(&mut app, KeyCode::Esc);
     assert_eq!(app.mode, ViewMode::FileBrowser);
+}
+
+#[test]
+fn scan_streams_files_into_the_browser() {
+    let base = fixtures_dir();
+    let rx = start_scan(base.clone(), SCAN_FLAGS);
+    let mut app = App::new_file_browser(Vec::new(), Some(rx), base);
+    assert!(!app.data_loaded());
+    insta::assert_snapshot!(render(&mut app), @r#"
+    "┌MLT Files (0 found, scanning…) - ↑/↓ navigate, Enter open, h help, q┐┌Tile Preview────────────────┐"
+    "│   File     Size   Enc % Layers   Features Notes                    ││Select a tile file (.mlt / .│"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    │└────────────────────────────┘"
+    "│                                                                    │┌Filter (click to toggle)────┐"
+    "│                                                                    ││[Reset filters]             │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    │└────────────────────────────┘"
+    "│                                                                    │┌File Info───────────────────┐"
+    "│                                                                    ││Scanning                    │"
+    "│                                                                    ││../../test/fixtures/simple… │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "└────────────────────────────────────────────────────────────────────┘└────────────────────────────┘"
+    "#);
+    app.finish_scan();
+    assert!(app.data_loaded());
+    assert_eq!(app.files.len(), 6);
+    assert!(
+        app.files.iter().all(|r| matches!(r, LsRow::Info { .. })),
+        "every row should be analyzed"
+    );
 }
 
 fn mbtiles_app() -> App {
@@ -1336,7 +1378,7 @@ fn file_browser_keys_page_and_bad_rows_show_a_popup() {
 
     let base = fixtures_dir();
     let rows = vec![
-        analyze_row(base.join("broken.mvt"), &base),
+        analyze_tile_row(&base.join("broken.mvt"), &base, SCAN_FLAGS),
         LsRow::Loading {
             path: base.join("missing.mvt"),
         },
@@ -1398,7 +1440,7 @@ fn header_clicks_sort_every_column_both_ways() {
         size: Some(9),
         error: "bad".into(),
     });
-    rows.push(analyze_row(base.join("a.mvt"), &base));
+    rows.push(analyze_tile_row(&base.join("a.mvt"), &base, SCAN_FLAGS));
     let mut app = App::new_file_browser(rows, None, base);
     app.handle_file_header_click(FileSortColumn::Size);
     let names: Vec<String> = app
@@ -1417,14 +1459,95 @@ fn header_clicks_sort_every_column_both_ways() {
         "error rows sort after info rows"
     );
 
-    let (tx, rx) = mpsc::channel::<Vec<LsRow>>();
+    let (tx, rx) = mpsc::channel::<ScanEvent>();
     let mut app = App::new_file_browser(Vec::new(), Some(rx), fixtures_dir());
     app.handle_file_header_click(FileSortColumn::Size);
     drop(tx);
 }
 
 #[test]
+fn scan_events_drive_the_browser_through_poll() {
+    let base = fixtures_dir();
+    let (tx, rx) = mpsc::channel();
+    let mut app = App::new_file_browser(Vec::new(), Some(rx), base.clone());
+    assert!(!app.poll_scan());
+    let path = base.join("point-boolean.mvt");
+    tx.send(ScanEvent::Found(path.clone())).unwrap();
+    tx.send(ScanEvent::Done).unwrap();
+    assert!(app.poll_scan());
+    assert_eq!(app.files.len(), 1);
+    assert!(!app.data_loaded());
+    insta::assert_snapshot!(render(&mut app), @r#"
+    "┌MLT Files (1 found, 1 analyzing…) - ↑/↓ navigate, Enter open, h help┐┌Tile Preview────────────────┐"
+    "│   File                  Size   Enc % Layers   Features Notes       ││Select a tile file (.mlt / .│"
+    "│>> point-boolean.mvt …        …       …      …                      ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    │└────────────────────────────┘"
+    "│                                                                    │┌Filter (click to toggle)────┐"
+    "│                                                                    ││[Reset filters]             │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││Extensions:                 │"
+    "│                                                                    ││  [ ] mvt                   │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    │└────────────────────────────┘"
+    "│                                                                    │┌File Info───────────────────┐"
+    "│                                                                    ││Analyzing…                  │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││                            │"
+    "└────────────────────────────────────────────────────────────────────┘└────────────────────────────┘"
+    "#);
+    let row = analyze_tile_row(&path, &base, SCAN_FLAGS);
+    tx.send(ScanEvent::Analyzed(0, Box::new(row))).unwrap();
+    assert!(app.poll_scan());
+    assert!(app.data_loaded());
+    assert!(matches!(app.files[0], LsRow::Info { .. }));
+
+    let (tx, rx) = mpsc::channel();
+    let mut app = App::new_file_browser(Vec::new(), Some(rx), base.clone());
+    app.geom_filters.insert(GeometryType::Point);
+    let line = base.join("line-boolean.mvt");
+    tx.send(ScanEvent::Found(path.clone())).unwrap();
+    tx.send(ScanEvent::Found(line.clone())).unwrap();
+    let line_row = analyze_tile_row(&line, &base, SCAN_FLAGS);
+    let point_row = analyze_tile_row(&path, &base, SCAN_FLAGS);
+    tx.send(ScanEvent::Analyzed(1, Box::new(line_row))).unwrap();
+    tx.send(ScanEvent::Analyzed(0, Box::new(point_row)))
+        .unwrap();
+    assert!(app.poll_scan());
+    assert_eq!(
+        app.filtered_file_indices.len(),
+        1,
+        "an active filter rebuilds the list"
+    );
+    assert!(
+        app.files[1].path().ends_with("line-boolean.mvt"),
+        "rows land where the walk found them"
+    );
+    drop(tx);
+    assert!(app.poll_scan(), "a dropped scanner ends the scan");
+    assert!(app.data_loaded());
+    drop(start_scan(base, SCAN_FLAGS));
+}
+
+#[test]
 fn empty_loading_and_filtered_out_browser_states_render() {
+    let base = fixtures_dir();
+    let mut app = App::new_file_browser(Vec::new(), None, base);
+    assert!(render(&mut app).contains("No tile files found"));
+
     let mut app = file_browser_app();
     let path = app.get_selected_file().unwrap().path().to_path_buf();
     app.preview_load_requested = Some(path);
@@ -1461,7 +1584,10 @@ fn filter_clicks_toggle_extensions_and_algorithms() {
     handle_filter_click(&mut app, 3);
     assert!(app.ext_filters.is_empty(), "a second click toggles it off");
 
-    let mut app = browser_over(test_dir("synthetic/0x01-rust"));
+    let base = test_dir("synthetic/0x01-rust");
+    let rx = start_scan(base.clone(), SCAN_FLAGS);
+    let mut app = App::new_file_browser(Vec::new(), Some(rx), base);
+    app.finish_scan();
     assert!(app.files.len() > 100);
     let algos = collect_file_algorithms(&app.files);
     assert!(!algos.is_empty());
@@ -1888,11 +2014,12 @@ fn enter_and_tree_clicks_drill_through_features_and_parts() {
 fn opening_another_file_drops_the_previous_hover_and_scroll() {
     let base = test_dir("synthetic/0x01");
     let rows = vec![
-        analyze_row(
-            base.join("mix_7_pt_line_poly_polyh_mpt_mline_mpoly.mlt"),
+        analyze_tile_row(
+            &base.join("mix_7_pt_line_poly_polyh_mpt_mline_mpoly.mlt"),
             &base,
+            SCAN_FLAGS,
         ),
-        analyze_row(fixtures_dir().join("point-boolean.mvt"), &base),
+        analyze_tile_row(&fixtures_dir().join("point-boolean.mvt"), &base, SCAN_FLAGS),
     ];
     let mut app = App::new_file_browser(rows, None, base);
     press(&mut app, KeyCode::Enter);


### PR DESCRIPTION
Part 2 of #971 / #1626.

The file browser used to walk the whole directory and analyze every file before drawing anything, so a large tree meant staring at an empty terminal. It now starts empty and fills in as a background walk finds tile files, each file is analyzed on the rayon pool and its row updates when the analysis lands, the title shows the progress, and the header sort waits for the scan to finish. Entries the walk cannot read are skipped instead of failing the whole browser