### PR TITLE
feat(rust): cache decoded tiles in the mlt ui

### DIFF
--- a/rust/mlt/README.md
+++ b/rust/mlt/README.md
@@ -58,7 +58,6 @@ cargo run -- ui path/to/directory
 - Press `Enter` to open and visualize a file
 - Press `Esc` to go back to file list
 - Press `q` to quit
-- Decoded tiles stay in an LRU cache (256 MB by default, `--cache-mb` changes it), so moving between files does not decode them again; the `.mbtiles` map keeps its decoded tiles within the same budget, dropping the ones farthest from the viewport first
 
 Features:
 - **Tree View Panel (left)**: Browse layers and features in a hierarchical tree

--- a/rust/mlt/README.md
+++ b/rust/mlt/README.md
@@ -58,6 +58,7 @@ cargo run -- ui path/to/directory
 - Press `Enter` to open and visualize a file
 - Press `Esc` to go back to file list
 - Press `q` to quit
+- Decoded tiles stay in an LRU cache (256 MB by default, `--cache-mb` changes it), so moving between files does not decode them again; the `.mbtiles` map keeps its decoded tiles within the same budget, dropping the ones farthest from the viewport first
 
 Features:
 - **Tree View Panel (left)**: Browse layers and features in a hierarchical tree

--- a/rust/mlt/src/ui/mbt.rs
+++ b/rust/mlt/src/ui/mbt.rs
@@ -14,7 +14,7 @@ use rstar::{AABB, PointDistance, RTree, RTreeObject};
 
 use super::group_by_layer;
 use super::state::LayerGroup;
-use super::tile::fc_memory_estimate;
+use super::tile::{CACHE_BYTES, fc_memory_estimate};
 
 type DecodedTile = (FeatureCollection, u32, Vec<LayerGroup>, RTree<MbtGeoEntry>);
 type BestHover = Option<(f64, (u8, u32, u32), usize, usize)>;
@@ -228,7 +228,7 @@ pub(crate) struct MbtilesState {
 }
 
 impl MbtilesState {
-    pub(crate) fn new(path: PathBuf, cache_bytes: u64) -> Self {
+    pub(crate) fn new(path: PathBuf) -> Self {
         let (req_tx, req_rx) = mpsc::sync_channel::<TileLoadRequest>(200);
         let (res_tx, res_rx) = mpsc::sync_channel::<TileLoadResult>(200);
         let (init_tx, init_rx) = mpsc::sync_channel::<Result<(), String>>(1);
@@ -285,7 +285,7 @@ impl MbtilesState {
             hovered: None,
             zoom_f: 0.0,
             map_drag_last: None,
-            cache_bytes,
+            cache_bytes: CACHE_BYTES,
             loading: HashSet::new(),
             request_tx: req_tx,
             result_rx: res_rx,
@@ -740,7 +740,6 @@ mod tests {
     };
 
     use super::*;
-    use crate::ui::tile::{DEFAULT_CACHE_MB, cache_bytes};
 
     fn c(x: i32, y: i32) -> Coord<i32> {
         Coord { x, y }
@@ -773,10 +772,7 @@ mod tests {
 
     #[test]
     fn integer_zoom_reached_by_half_steps_loads_that_level() {
-        let mut state = MbtilesState::new(
-            PathBuf::from("missing.mbtiles"),
-            cache_bytes(DEFAULT_CACHE_MB),
-        );
+        let mut state = MbtilesState::new(PathBuf::from("missing.mbtiles"));
         state.set_viewport_to_tile(1, 0, 0).unwrap();
         state.zoom_wheel_at(0.3, 0.3, true);
         state.zoom_wheel_at(0.3, 0.3, true);

--- a/rust/mlt/src/ui/mbt.rs
+++ b/rust/mlt/src/ui/mbt.rs
@@ -14,6 +14,7 @@ use rstar::{AABB, PointDistance, RTree, RTreeObject};
 
 use super::group_by_layer;
 use super::state::LayerGroup;
+use super::tile::fc_memory_estimate;
 
 type DecodedTile = (FeatureCollection, u32, Vec<LayerGroup>, RTree<MbtGeoEntry>);
 type BestHover = Option<(f64, (u8, u32, u32), usize, usize)>;
@@ -158,7 +159,29 @@ pub(crate) enum MbtTileData {
         extent: u32,
         layer_groups: Vec<LayerGroup>,
         geo_index: RTree<MbtGeoEntry>,
+        /// Rough size of the decoded data, computed once when the tile arrives.
+        bytes: u64,
     },
+}
+
+impl MbtTileData {
+    /// Rough number of bytes this entry holds, for the memory budget.
+    fn memory_estimate(&self) -> u64 {
+        match self {
+            Self::Loading | Self::Empty => 64,
+            Self::Error(e) => 64 + u64::try_from(e.len()).unwrap_or(u64::MAX),
+            Self::Loaded { bytes, .. } => *bytes,
+        }
+    }
+}
+
+/// Rough number of bytes a decoded tile and its spatial index hold.
+fn loaded_bytes(fc: &FeatureCollection, geo_index: &RTree<MbtGeoEntry>) -> u64 {
+    let index: usize = geo_index
+        .iter()
+        .map(|e| e.vertices.len() * size_of::<[f64; 2]>() + 48)
+        .sum();
+    u64::try_from(fc_memory_estimate(fc) + index).unwrap_or(u64::MAX)
 }
 
 // ---------------------------------------------------------------------------
@@ -193,6 +216,8 @@ pub(crate) struct MbtilesState {
     pub zoom_f: f64,
     /// Last mouse cell during left-button map drag (`Drag` deltas are applied from here).
     pub map_drag_last: Option<(u16, u16)>,
+    /// Memory budget for `tiles`.
+    pub(crate) cache_bytes: u64,
     loading: HashSet<(u8, u32, u32)>,
     request_tx: mpsc::SyncSender<TileLoadRequest>,
     pub result_rx: mpsc::Receiver<TileLoadResult>,
@@ -203,7 +228,7 @@ pub(crate) struct MbtilesState {
 }
 
 impl MbtilesState {
-    pub(crate) fn new(path: PathBuf) -> Self {
+    pub(crate) fn new(path: PathBuf, cache_bytes: u64) -> Self {
         let (req_tx, req_rx) = mpsc::sync_channel::<TileLoadRequest>(200);
         let (res_tx, res_rx) = mpsc::sync_channel::<TileLoadResult>(200);
         let (init_tx, init_rx) = mpsc::sync_channel::<Result<(), String>>(1);
@@ -260,6 +285,7 @@ impl MbtilesState {
             hovered: None,
             zoom_f: 0.0,
             map_drag_last: None,
+            cache_bytes,
             loading: HashSet::new(),
             request_tx: req_tx,
             result_rx: res_rx,
@@ -474,12 +500,16 @@ impl MbtilesState {
             Err(e) => MbtTileData::Error(e),
             Ok(None) => MbtTileData::Empty,
             Ok(Some(raw)) => match decode_and_parse(res.z, res.x, res.y, raw) {
-                Ok(Some((fc, extent, layer_groups, geo_index))) => MbtTileData::Loaded {
-                    fc,
-                    extent,
-                    layer_groups,
-                    geo_index,
-                },
+                Ok(Some((fc, extent, layer_groups, geo_index))) => {
+                    let bytes = loaded_bytes(&fc, &geo_index);
+                    MbtTileData::Loaded {
+                        fc,
+                        extent,
+                        layer_groups,
+                        geo_index,
+                        bytes,
+                    }
+                }
                 Ok(None) => MbtTileData::Empty,
                 Err(e) => MbtTileData::Error(e.to_string()),
             },
@@ -613,10 +643,11 @@ impl MbtilesState {
         out
     }
 
-    /// Drop cached tiles far from the viewport so panning does not grow memory without bound.
+    /// Drop cached tiles far from the viewport once the decoded tiles exceed the memory budget.
+    /// Visible tiles and their ancestors stay.
     pub(crate) fn prune_tile_cache_if_needed(&mut self) {
-        const MAX: usize = 256;
-        if self.tiles.len() <= MAX {
+        let total: u64 = self.tiles.values().map(MbtTileData::memory_estimate).sum();
+        if total <= self.cache_bytes {
             return;
         }
         let keep = self.keep_tile_keys();
@@ -709,6 +740,7 @@ mod tests {
     };
 
     use super::*;
+    use crate::ui::tile::{DEFAULT_CACHE_MB, cache_bytes};
 
     fn c(x: i32, y: i32) -> Coord<i32> {
         Coord { x, y }
@@ -741,7 +773,10 @@ mod tests {
 
     #[test]
     fn integer_zoom_reached_by_half_steps_loads_that_level() {
-        let mut state = MbtilesState::new(PathBuf::from("missing.mbtiles"));
+        let mut state = MbtilesState::new(
+            PathBuf::from("missing.mbtiles"),
+            cache_bytes(DEFAULT_CACHE_MB),
+        );
         state.set_viewport_to_tile(1, 0, 0).unwrap();
         state.zoom_wheel_at(0.3, 0.3, true);
         state.zoom_wheel_at(0.3, 0.3, true);

--- a/rust/mlt/src/ui/mod.rs
+++ b/rust/mlt/src/ui/mod.rs
@@ -48,7 +48,7 @@ use crate::ui::rendering::layers::{
 use crate::ui::rendering::map::{render_map_panel, render_mbtiles_map_panel};
 use crate::ui::scan::start_scan;
 use crate::ui::state::{App, HoveredInfo, LayerGroup, ResizeHandle, TreeItem, ViewMode};
-use crate::ui::tile::{DEFAULT_CACHE_MB, TileCache, cache_bytes, polygon_coord_count};
+use crate::ui::tile::{TileCache, polygon_coord_count};
 
 pub const CLR_POINT: Color = Color::Magenta;
 pub const CLR_MULTI_POINT: Color = Color::LightMagenta;
@@ -81,9 +81,6 @@ pub struct UiArgs {
     /// Start `MBTiles` map centered on this XYZ tile (`z/x/y`, e.g. `6/32/21`). `MBTiles` only.
     #[arg(long = "center-tile", value_name = "Z/X/Y")]
     center_tile: Option<String>,
-    /// Memory budget for decoded tiles kept in the LRU cache, in megabytes.
-    #[arg(long = "cache-mb", value_name = "MB", default_value_t = DEFAULT_CACHE_MB)]
-    cache_mb: u64,
 }
 
 /// Analysis flags for the file browser scan.
@@ -102,10 +99,9 @@ fn build_app(args: &UiArgs) -> anyhow::Result<App> {
     if args.center_tile.is_some() && !is_mbt_extension(&args.path) {
         bail!("--center-tile is only supported when opening an .mbtiles file");
     }
-    let budget = cache_bytes(args.cache_mb);
-    let cache = TileCache::new(budget);
+    let cache = TileCache::default();
     let mut app = if is_mbt_extension(&args.path) {
-        let mut mbt = MbtilesState::new(args.path.clone(), budget);
+        let mut mbt = MbtilesState::new(args.path.clone());
         if let Some(ref s) = args.center_tile {
             let (z, x, y) = parse_center_tile_xyz(s)?;
             mbt.set_viewport_to_tile(z, x, y)

--- a/rust/mlt/src/ui/mod.rs
+++ b/rust/mlt/src/ui/mod.rs
@@ -7,13 +7,14 @@ mod scan;
 mod state;
 #[cfg(test)]
 mod tests;
+mod tile;
 
 use std::collections::HashSet;
 use std::io::Write as _;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::mpsc;
+use std::thread;
 use std::time::{Duration, Instant};
-use std::{fs, thread};
 
 use anyhow::bail;
 use clap::Args;
@@ -22,10 +23,9 @@ use crossterm::event::{
     KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
 };
 use crossterm::execute;
+use mlt_core::GeometryType;
 use mlt_core::geo_types::{Coord, Geometry, Polygon};
 use mlt_core::geojson::FeatureCollection;
-use mlt_core::mvt::mvt_to_feature_collection;
-use mlt_core::{Decoder, GeometryType, Parser};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Margin, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -34,8 +34,7 @@ use ratatui::widgets::{Block, Borders};
 use rstar::{AABB, PointDistance, RTreeObject};
 
 use crate::ls::{
-    FileAlgorithm, FileSortColumn, LsFlags, LsRow, is_mbt_extension, is_mlt_extension,
-    is_tile_extension,
+    FileAlgorithm, FileSortColumn, LsFlags, LsRow, is_mbt_extension, is_tile_extension,
 };
 use crate::ui::mbt::MbtilesState;
 use crate::ui::rendering::files::{
@@ -49,6 +48,7 @@ use crate::ui::rendering::layers::{
 use crate::ui::rendering::map::{render_map_panel, render_mbtiles_map_panel};
 use crate::ui::scan::start_scan;
 use crate::ui::state::{App, HoveredInfo, LayerGroup, ResizeHandle, TreeItem, ViewMode};
+use crate::ui::tile::{DEFAULT_CACHE_MB, TileCache, cache_bytes, polygon_coord_count};
 
 pub const CLR_POINT: Color = Color::Magenta;
 pub const CLR_MULTI_POINT: Color = Color::LightMagenta;
@@ -81,6 +81,9 @@ pub struct UiArgs {
     /// Start `MBTiles` map centered on this XYZ tile (`z/x/y`, e.g. `6/32/21`). `MBTiles` only.
     #[arg(long = "center-tile", value_name = "Z/X/Y")]
     center_tile: Option<String>,
+    /// Memory budget for decoded tiles kept in the LRU cache, in megabytes.
+    #[arg(long = "cache-mb", value_name = "MB", default_value_t = DEFAULT_CACHE_MB)]
+    cache_mb: u64,
 }
 
 /// Analysis flags for the file browser scan.
@@ -99,8 +102,10 @@ fn build_app(args: &UiArgs) -> anyhow::Result<App> {
     if args.center_tile.is_some() && !is_mbt_extension(&args.path) {
         bail!("--center-tile is only supported when opening an .mbtiles file");
     }
-    let app = if is_mbt_extension(&args.path) {
-        let mut mbt = MbtilesState::new(args.path.clone());
+    let budget = cache_bytes(args.cache_mb);
+    let cache = TileCache::new(budget);
+    let mut app = if is_mbt_extension(&args.path) {
+        let mut mbt = MbtilesState::new(args.path.clone(), budget);
         if let Some(ref s) = args.center_tile {
             let (z, x, y) = parse_center_tile_xyz(s)?;
             mbt.set_viewport_to_tile(z, x, y)
@@ -111,10 +116,12 @@ fn build_app(args: &UiArgs) -> anyhow::Result<App> {
         let rx = start_scan(args.path.clone(), SCAN_FLAGS);
         App::new_file_browser(Vec::new(), Some(rx), args.path.clone())
     } else if args.path.is_file() {
-        App::new_single_file(load_fc(&args.path)?, Some(args.path.clone()))
+        let tile = cache.load(&args.path)?;
+        App::new_single_file(tile, Some(args.path.clone()))
     } else {
         bail!("Path is not a file or directory");
     };
+    app.tile_cache = cache;
     Ok(app)
 }
 
@@ -150,39 +157,15 @@ fn parse_center_tile_xyz(spec: &str) -> anyhow::Result<(u8, u32, u32)> {
 
 // --- Data loading ---
 
-fn load_fc(path: &Path) -> anyhow::Result<FeatureCollection> {
-    let buf = fs::read(path)?;
-    if is_mlt_extension(path) {
-        let layers = Decoder::default().decode_all(Parser::default().parse_layers(&buf)?)?;
-        Ok(FeatureCollection::from_layers(layers)?)
-    } else {
-        Ok(mvt_to_feature_collection(buf)?)
-    }
-}
-
-fn extent_from_fc(fc: &FeatureCollection) -> u32 {
-    fc.features
-        .first()
-        .and_then(|f| {
-            f.properties
-                .get("_extent")
-                .and_then(serde_json::Value::as_u64)
-        })
-        .map_or(4096, |v| u32::try_from(v).expect("_extent is valid u32"))
-}
-
+/// Drop the preview when the selection is no longer a tile file.
 fn refresh_tile_preview(app: &mut App) {
-    let path = if let Some(r) = app.get_selected_file() {
-        r.path().to_path_buf()
-    } else {
+    let is_tile = app
+        .get_selected_file()
+        .is_some_and(|r| is_tile_extension(r.path()));
+    if !is_tile {
         app.preview_tile_path = None;
-        app.preview_fc = None;
-        app.preview_load_requested = None;
-        return;
-    };
-    if !is_tile_extension(&path) {
-        app.preview_tile_path = None;
-        app.preview_fc = None;
+        app.preview = None;
+        app.preview_error = None;
         app.preview_load_requested = None;
     }
 }
@@ -608,13 +591,16 @@ fn tick(app: &mut App) {
         app.preview_rx = None;
         app.preview_load_requested = None;
         if app.get_selected_file().map(LsRow::path) == Some(path.as_path()) {
-            if let Ok((fc, ext)) = result {
-                app.preview_tile_path = Some(path);
-                app.preview_fc = Some(fc);
-                app.preview_extent = ext;
-            } else {
-                app.preview_tile_path = Some(path);
-                app.preview_fc = None;
+            app.preview_tile_path = Some(path);
+            match result {
+                Ok(tile) => {
+                    app.preview = Some(tile);
+                    app.preview_error = None;
+                }
+                Err(e) => {
+                    app.preview = None;
+                    app.preview_error = Some(e);
+                }
             }
         }
         app.invalidate();
@@ -624,22 +610,24 @@ fn tick(app: &mut App) {
     {
         let path = selected.path().to_path_buf();
         if is_tile_extension(&path)
-            && (app.preview_tile_path.as_ref() != Some(&path) || app.preview_fc.is_none())
+            && app.preview_tile_path.as_ref() != Some(&path)
             && app.preview_load_requested.as_ref() != Some(&path)
         {
-            let (tx, rx) = mpsc::channel();
-            app.preview_rx = Some(rx);
-            app.preview_load_requested = Some(path.clone());
-            let path_spawn = path.clone();
-            thread::spawn(move || {
-                let result = load_fc(&path_spawn)
-                    .map(|fc| {
-                        let ext = extent_from_fc(&fc);
-                        (fc, ext)
-                    })
-                    .map_err(|_| ());
-                let _ = tx.send((path_spawn, result));
-            });
+            if let Some(tile) = app.tile_cache.get(&path) {
+                app.preview_tile_path = Some(path);
+                app.preview = Some(tile);
+                app.preview_error = None;
+                app.invalidate();
+            } else {
+                let (tx, rx) = mpsc::channel();
+                app.preview_rx = Some(rx);
+                app.preview_load_requested = Some(path.clone());
+                let cache = app.tile_cache.clone();
+                thread::spawn(move || {
+                    let result = cache.load(&path).map_err(|e| e.to_string());
+                    let _ = tx.send((path, result));
+                });
+            }
         }
     }
 }
@@ -804,10 +792,7 @@ fn multi_part_count(geom: &Geometry<i32>) -> usize {
 }
 
 fn poly_ring_stats(poly: &Polygon<i32>) -> (usize, usize) {
-    let ring_count = 1 + poly.interiors().len();
-    let total_verts =
-        poly.exterior().0.len() + poly.interiors().iter().map(|r| r.0.len()).sum::<usize>();
-    (total_verts, ring_count)
+    (polygon_coord_count(poly), 1 + poly.interiors().len())
 }
 
 fn feature_suffix(geom: &Geometry<i32>) -> String {

--- a/rust/mlt/src/ui/rendering/files.rs
+++ b/rust/mlt/src/ui/rendering/files.rs
@@ -16,27 +16,28 @@ use crate::ui::{
 };
 
 pub fn render_tile_preview_panel(f: &mut Frame<'_>, area: Rect, app: &App) {
-    if let Some(ref fc) = app.preview_fc {
-        map::render_tile_preview(f, area, fc, app.preview_extent);
-    } else {
-        let msg = if app
-            .get_selected_file()
-            .and_then(|r| {
-                app.preview_load_requested
-                    .as_ref()
-                    .filter(|p| p.as_path() == r.path())
-            })
-            .is_some()
-        {
-            "Loading…"
-        } else {
-            "Select a tile file (.mlt / .mvt) to preview"
-        };
-        f.render_widget(
-            Paragraph::new(Line::from(msg)).block(block_with_title("Tile Preview")),
-            area,
-        );
+    if let Some(ref tile) = app.preview {
+        map::render_tile_preview(f, area, &tile.fc, tile.extent);
+        return;
     }
+    let selected = app.get_selected_file().map(LsRow::path);
+    let msg = if let Some(err) = app
+        .preview_error
+        .as_ref()
+        .filter(|_| app.preview_tile_path.as_deref() == selected)
+    {
+        format!("Preview failed: {err}")
+    } else if selected.is_some() && app.preview_load_requested.as_deref() == selected {
+        "Loading…".into()
+    } else {
+        "Select a tile file (.mlt / .mvt) to preview".into()
+    };
+    f.render_widget(
+        Paragraph::new(Line::from(msg))
+            .wrap(Wrap { trim: true })
+            .block(block_with_title("Tile Preview")),
+        area,
+    );
 }
 
 pub fn render_file_browser(f: &mut Frame<'_>, area: Rect, app: &mut App) {

--- a/rust/mlt/src/ui/rendering/layers.rs
+++ b/rust/mlt/src/ui/rendering/layers.rs
@@ -10,6 +10,7 @@ use usize_cast::IntoUsize as _;
 
 use crate::ui::mbt::MbtTileData;
 use crate::ui::state::{App, TreeItem, ViewMode};
+use crate::ui::tile::polygon_coord_count;
 use crate::ui::{
     CLR_HOVERED_TREE, STYLE_LABEL, STYLE_SELECTED, block_with_title, feature_suffix,
     geometry_color, geometry_type_name, is_ring_ccw, stat_line, sub_feature_suffix,
@@ -29,11 +30,11 @@ pub fn render_tree_panel(f: &mut Frame<'_>, area: Rect, app: &mut App) {
                     let first = g
                         .feature_indices
                         .first()
-                        .map(|&gi| geometry_type_name(&app.fc.features[gi].geometry));
+                        .map(|&gi| geometry_type_name(&app.tile.fc.features[gi].geometry));
                     let all_same = first.is_some_and(|ft| {
                         g.feature_indices
                             .iter()
-                            .all(|&gi| geometry_type_name(&app.fc.features[gi].geometry) == ft)
+                            .all(|&gi| geometry_type_name(&app.tile.fc.features[gi].geometry) == ft)
                     });
                     let label = if all_same && n > 0 {
                         format!("{}s", first.unwrap())
@@ -216,9 +217,7 @@ fn info_line_string(lines: &mut Vec<Line<'static>>, ls: &LineString<i32>) {
 }
 
 fn info_polygon(lines: &mut Vec<Line<'static>>, poly: &Polygon<i32>) {
-    let total: usize =
-        poly.exterior().0.len() + poly.interiors().iter().map(|r| r.0.len()).sum::<usize>();
-    lines.push(stat_line("Vertices", &total));
+    lines.push(stat_line("Vertices", &polygon_coord_count(poly)));
     lines.push(stat_line("Rings", &(1 + poly.interiors().len())));
     let ext = &poly.exterior().0;
     let w = if is_ring_ccw(ext) { "CCW" } else { "CW" };
@@ -244,12 +243,7 @@ fn info_multi_line_string(lines: &mut Vec<Line<'static>>, mls: &MultiLineString<
 }
 
 fn info_multi_polygon(lines: &mut Vec<Line<'static>>, mpoly: &MultiPolygon<i32>) {
-    let total: usize = mpoly
-        .iter()
-        .flat_map(|p| {
-            std::iter::once(p.exterior().0.len()).chain(p.interiors().iter().map(|r| r.0.len()))
-        })
-        .sum();
+    let total: usize = mpoly.iter().map(polygon_coord_count).sum();
     let total_rings: usize = mpoly.iter().map(|p| 1 + p.interiors().len()).sum();
     lines.push(stat_line("Parts", &mpoly.0.len()));
     lines.push(stat_line("Total vertices", &total));

--- a/rust/mlt/src/ui/rendering/map.rs
+++ b/rust/mlt/src/ui/rendering/map.rs
@@ -35,7 +35,7 @@ pub fn render_map_panel(f: &mut Frame<'_>, area: Rect, app: &App) {
 
             let hov = app.hovered.as_ref();
             let draw_feat = |ctx: &mut Context<'_>, gi: usize| {
-                let geom = &app.fc.features[gi].geometry;
+                let geom = &app.tile.fc.features[gi].geometry;
                 let base = geometry_color(geom);
                 let is_hov = hov.is_some_and(|h| app.global_idx(h.layer, h.feat) == gi);
                 let sel_part = match sel {
@@ -56,7 +56,7 @@ pub fn render_map_panel(f: &mut Frame<'_>, area: Rect, app: &App) {
 
             match sel {
                 TreeItem::All => {
-                    for gi in 0..app.fc.features.len() {
+                    for gi in 0..app.tile.fc.features.len() {
                         draw_feat(ctx, gi);
                     }
                 }

--- a/rust/mlt/src/ui/state.rs
+++ b/rust/mlt/src/ui/state.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::sync::mpsc::{self, TryRecvError};
 use std::time::Instant;
 
@@ -14,9 +15,9 @@ use usize_cast::IntoUsize as _;
 use crate::ls::{FileAlgorithm, FileSortColumn, LsRow};
 use crate::ui::mbt::MbtilesState;
 use crate::ui::scan::ScanEvent;
+use crate::ui::tile::{ParsedTile, TileCache};
 use crate::ui::{
-    GeometryIndexEntry, auto_expand, coord_f64, group_by_layer, is_entry_visible, load_fc,
-    multi_part_count,
+    GeometryIndexEntry, auto_expand, coord_f64, group_by_layer, is_entry_visible, multi_part_count,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -97,7 +98,7 @@ impl LayerGroup {
     }
 }
 
-pub type PreviewValue = (PathBuf, Result<(FeatureCollection, u32), ()>);
+pub type PreviewValue = (PathBuf, Result<Arc<ParsedTile>, String>);
 
 pub struct App {
     pub(crate) mode: ViewMode,
@@ -116,7 +117,8 @@ pub struct App {
     pub(crate) file_table_area: Option<Rect>,
     pub(crate) file_table_widths: Option<[Constraint; 6]>,
     pub(crate) current_file: Option<PathBuf>,
-    pub(crate) fc: FeatureCollection,
+    pub(crate) tile: Arc<ParsedTile>,
+    pub(crate) tile_cache: TileCache,
     pub(crate) layer_groups: Vec<LayerGroup>,
     pub(crate) tree_items: Vec<TreeItem>,
     pub(crate) selected_index: usize,
@@ -151,8 +153,8 @@ pub struct App {
     pub(crate) error_popup: Option<(String, String)>,
     pub(crate) file_info_scroll: u16,
     pub(crate) preview_tile_path: Option<PathBuf>,
-    pub(crate) preview_fc: Option<FeatureCollection>,
-    pub(crate) preview_extent: u32,
+    pub(crate) preview: Option<Arc<ParsedTile>>,
+    pub(crate) preview_error: Option<String>,
     pub(crate) preview_rx: Option<mpsc::Receiver<PreviewValue>>,
     pub(crate) preview_load_requested: Option<PathBuf>,
     /// State for the `MbtilesMap` mode (Some only when mode == `MbtilesMap`).
@@ -175,10 +177,11 @@ impl Default for App {
             file_table_area: None,
             file_table_widths: None,
             current_file: None,
-            fc: FeatureCollection {
+            tile: Arc::new(ParsedTile::from_fc(FeatureCollection {
                 features: Vec::new(),
                 ty: "FeatureCollection".into(),
-            },
+            })),
+            tile_cache: TileCache::default(),
             layer_groups: Vec::new(),
             tree_items: Vec::new(),
             selected_index: 0,
@@ -213,8 +216,8 @@ impl Default for App {
             error_popup: None,
             file_info_scroll: 0,
             preview_tile_path: None,
-            preview_fc: None,
-            preview_extent: 4096,
+            preview: None,
+            preview_error: None,
             preview_rx: None,
             preview_load_requested: None,
             mbt_state: None,
@@ -265,15 +268,15 @@ impl App {
         }
     }
 
-    pub(crate) fn new_single_file(fc: FeatureCollection, path: Option<PathBuf>) -> Self {
-        let layer_groups = group_by_layer(&fc);
+    pub(crate) fn new_single_file(tile: Arc<ParsedTile>, path: Option<PathBuf>) -> Self {
+        let layer_groups = group_by_layer(&tile.fc);
         let expanded_layers = auto_expand(&layer_groups);
         let mut app = Self {
             mode: ViewMode::LayerOverview,
             current_file: path,
             expanded_layers,
             layer_groups,
-            fc,
+            tile,
             ..Self::default()
         };
         app.build_geometry_index();
@@ -392,8 +395,8 @@ impl App {
     }
 
     fn load_file(&mut self, path: &Path) -> anyhow::Result<()> {
-        self.fc = load_fc(path)?;
-        self.layer_groups = group_by_layer(&self.fc);
+        self.tile = self.tile_cache.load(path)?;
+        self.layer_groups = group_by_layer(&self.tile.fc);
         self.current_file = Some(path.to_path_buf());
         self.mode = ViewMode::LayerOverview;
         self.expanded_layers = auto_expand(&self.layer_groups);
@@ -412,11 +415,13 @@ impl App {
     }
 
     pub(crate) fn feature(&self, layer: usize, feat: usize) -> &Feature {
-        &self.fc.features[self.global_idx(layer, feat)]
+        &self.tile.fc.features[self.global_idx(layer, feat)]
     }
 
     pub(crate) fn extent(&self) -> u32 {
-        self.layer_groups.first().map_or(4096, |g| g.extent)
+        self.layer_groups
+            .first()
+            .map_or(self.tile.extent, |g| g.extent)
     }
 
     pub(crate) fn selected_item(&self) -> &TreeItem {
@@ -437,7 +442,7 @@ impl App {
                     feat: fi,
                 });
                 if self.expanded_features.contains(&(li, fi)) {
-                    for part in 0..multi_part_count(&self.fc.features[gi].geometry) {
+                    for part in 0..multi_part_count(&self.tile.fc.features[gi].geometry) {
                         self.tree_items.push(TreeItem::SubFeature {
                             layer: li,
                             feat: fi,
@@ -453,7 +458,7 @@ impl App {
         let mut entries: Vec<GeometryIndexEntry> = Vec::new();
         for (li, group) in self.layer_groups.iter().enumerate() {
             for (fi, &gi) in group.feature_indices.iter().enumerate() {
-                let geom = &self.fc.features[gi].geometry;
+                let geom = &self.tile.fc.features[gi].geometry;
                 let n = multi_part_count(geom);
                 let parts: Vec<Option<usize>> = if n == 0 {
                     vec![None]
@@ -801,11 +806,11 @@ impl App {
         };
 
         let geoms: Vec<&Geometry<i32>> = match sel {
-            TreeItem::All => self.fc.features.iter().map(|f| &f.geometry).collect(),
+            TreeItem::All => self.tile.fc.features.iter().map(|f| &f.geometry).collect(),
             TreeItem::Layer(l) => self.layer_groups[*l]
                 .feature_indices
                 .iter()
-                .map(|&gi| &self.fc.features[gi].geometry)
+                .map(|&gi| &self.tile.fc.features[gi].geometry)
                 .collect(),
             TreeItem::Feature { layer, feat } | TreeItem::SubFeature { layer, feat, .. } => {
                 vec![&self.feature(*layer, *feat).geometry]

--- a/rust/mlt/src/ui/tests.rs
+++ b/rust/mlt/src/ui/tests.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::sync::mpsc;
 use std::time::Duration;
 
@@ -16,13 +17,14 @@ use serde_json::{Value, json};
 
 use super::{
     MouseState, PanelAreas, SCAN_FLAGS, UiArgs, build_app, collect_extensions,
-    collect_file_algorithms, collect_file_geometries, extent_from_fc, handle_filter_click,
-    handle_key, handle_mouse, load_fc, parse_center_tile_xyz, render_frame, tick,
+    collect_file_algorithms, collect_file_geometries, handle_filter_click, handle_key,
+    handle_mouse, parse_center_tile_xyz, render_frame, tick,
 };
 use crate::ls::{FileSortColumn, LsRow, analyze_tile_files, analyze_tile_row};
 use crate::ui::mbt::{MbtHoveredInfo, MbtTileData, MbtilesState};
 use crate::ui::scan::{ScanEvent, start_scan};
 use crate::ui::state::{App, HoveredInfo, ResizeHandle, TreeItem, ViewMode};
+use crate::ui::tile::{DEFAULT_CACHE_MB, ParsedTile, TileCache, cache_bytes};
 
 const WIDTH: u16 = 100;
 const HEIGHT: u16 = 30;
@@ -127,7 +129,8 @@ fn sample_fc() -> FeatureCollection {
 }
 
 fn sample_app() -> App {
-    App::new_single_file(sample_fc(), Some(PathBuf::from("sample.mlt")))
+    let tile = Arc::new(ParsedTile::from_fc(sample_fc()));
+    App::new_single_file(tile, Some(PathBuf::from("sample.mlt")))
 }
 
 /// Fixture paths relative to the package directory, where cargo runs unit tests.
@@ -445,8 +448,8 @@ fn file_browser_lists_the_directory() {
     let mut app = file_browser_app();
     insta::assert_snapshot!(render(&mut app), @r#"
     "┌MLT Files (6 found) - ↑/↓ navigate, Enter open, h help, q quit Click┐┌Tile Preview────────────────┐"
-    "│   File                         Size   Enc % Layers   Features Notes││Select a tile file (.mlt / .│"
-    "│>> line-boolean.mvt              40B      -       1          1      ││                            │"
+    "│   File                         Size   Enc % Layers   Features Notes││Select a tile file (.mlt /  │"
+    "│>> line-boolean.mvt              40B      -       1          1      ││.mvt) to preview            │"
     "│   multiline-boolean.mvt         46B      -       1          1      ││                            │"
     "│   multipoint-boolean.mvt        37B      -       1          1      ││                            │"
     "│   multipolygon-boolean.mvt      65B      -       1          1      ││                            │"
@@ -482,9 +485,7 @@ fn file_browser_previews_the_selected_tile() {
     let mut app = file_browser_app();
     press(&mut app, KeyCode::Down);
     let path = app.get_selected_file().unwrap().path().to_path_buf();
-    let fc = load_fc(&path).unwrap();
-    app.preview_extent = extent_from_fc(&fc);
-    app.preview_fc = Some(fc);
+    app.preview = Some(app.tile_cache.load(&path).unwrap());
     app.preview_tile_path = Some(path);
     insta::assert_snapshot!(render(&mut app), @r#"
     "┌MLT Files (6 found) - ↑/↓ navigate, Enter open, h help, q quit Click┐┌Tile Preview────────────────┐"
@@ -526,8 +527,8 @@ fn file_browser_sorts_by_a_clicked_header() {
     app.handle_file_header_click(FileSortColumn::Size);
     insta::assert_snapshot!(render(&mut app), @r#"
     "┌MLT Files (6 found) - ↑/↓ navigate, Enter open, h help, q quit Click┐┌Tile Preview────────────────┐"
-    "│   File                         Size   Enc % Layers   Features Notes││Select a tile file (.mlt / .│"
-    "│   point-boolean.mvt             35B      -       1          1      ││                            │"
+    "│   File                         Size   Enc % Layers   Features Notes││Select a tile file (.mlt /  │"
+    "│   point-boolean.mvt             35B      -       1          1      ││.mvt) to preview            │"
     "│   multipoint-boolean.mvt        37B      -       1          1      ││                            │"
     "│>> line-boolean.mvt              40B      -       1          1      ││                            │"
     "│   polygon-boolean.mvt           41B      -       1          1      ││                            │"
@@ -565,8 +566,8 @@ fn filter_click_narrows_the_file_list() {
     handle_filter_click(&mut app, first_geometry_row);
     insta::assert_snapshot!(render(&mut app), @r#"
     "┌MLT Files (1/6 found) - ↑/↓ navigate, Enter open, h help, q quit Cli┐┌Tile Preview────────────────┐"
-    "│   File                         Size   Enc % Layers   Features Notes││Select a tile file (.mlt / .│"
-    "│>> point-boolean.mvt             35B      -       1          1      ││                            │"
+    "│   File                         Size   Enc % Layers   Features Notes││Select a tile file (.mlt /  │"
+    "│>> point-boolean.mvt             35B      -       1          1      ││.mvt) to preview            │"
     "│                                                                    ││                            │"
     "│                                                                    ││                            │"
     "│                                                                    ││                            │"
@@ -646,8 +647,8 @@ fn scan_streams_files_into_the_browser() {
     assert!(!app.data_loaded());
     insta::assert_snapshot!(render(&mut app), @r#"
     "┌MLT Files (0 found, scanning…) - ↑/↓ navigate, Enter open, h help, q┐┌Tile Preview────────────────┐"
-    "│   File     Size   Enc % Layers   Features Notes                    ││Select a tile file (.mlt / .│"
-    "│                                                                    ││                            │"
+    "│   File     Size   Enc % Layers   Features Notes                    ││Select a tile file (.mlt /  │"
+    "│                                                                    ││.mvt) to preview            │"
     "│                                                                    ││                            │"
     "│                                                                    ││                            │"
     "│                                                                    ││                            │"
@@ -685,9 +686,63 @@ fn scan_streams_files_into_the_browser() {
     );
 }
 
+#[test]
+fn preview_failures_are_reported() {
+    let mut app = file_browser_app();
+    let path = app.get_selected_file().unwrap().path().to_path_buf();
+    app.preview_tile_path = Some(path);
+    app.preview_error = Some("unexpected end of buffer".into());
+    insta::assert_snapshot!(render(&mut app), @r#"
+    "┌MLT Files (6 found) - ↑/↓ navigate, Enter open, h help, q quit Click┐┌Tile Preview────────────────┐"
+    "│   File                         Size   Enc % Layers   Features Notes││Preview failed: unexpected  │"
+    "│>> line-boolean.mvt              40B      -       1          1      ││end of buffer               │"
+    "│   multiline-boolean.mvt         46B      -       1          1      ││                            │"
+    "│   multipoint-boolean.mvt        37B      -       1          1      ││                            │"
+    "│   multipolygon-boolean.mvt      65B      -       1          1      ││                            │"
+    "│   point-boolean.mvt             35B      -       1          1      ││                            │"
+    "│   polygon-boolean.mvt           41B      -       1          1      ││                            │"
+    "│                                                                    ││                            │"
+    "│                                                                    │└────────────────────────────┘"
+    "│                                                                    │┌Filter (click to toggle)────┐"
+    "│                                                                    ││[Reset filters]             │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││Extensions:                 │"
+    "│                                                                    ││  [ ] mvt                   │"
+    "│                                                                    ││                            │"
+    "│                                                                    ││Geometry Types:             │"
+    "│                                                                    ││  [ ] Point                 │"
+    "│                                                                    ││  [ ] LineString            │"
+    "│                                                                    │└────────────────────────────┘"
+    "│                                                                    │┌File Info───────────────────┐"
+    "│                                                                    ││File: line-boolean.mvt      │"
+    "│                                                                    ││Size: 40B  raw MLT file size│"
+    "│                                                                    ││Encoding: -  MLT / (data +  │"
+    "│                                                                    ││metadata)                   │"
+    "│                                                                    ││Data: -  decoded payload    │"
+    "│                                                                    ││size                        │"
+    "│                                                                    ││Metadata: -  encoding       │"
+    "│                                                                    ││overhead                    │"
+    "└────────────────────────────────────────────────────────────────────┘└────────────────────────────┘"
+    "#);
+}
+
+#[test]
+fn tile_cache_shares_decoded_tiles_and_respects_its_budget() {
+    let path = fixtures_dir().join("line-boolean.mvt");
+    let cache = TileCache::new(1 << 20);
+    let first = cache.load(&path).unwrap();
+    let second = cache.load(&path).unwrap();
+    assert!(Arc::ptr_eq(&first, &second));
+    assert_eq!(cache.cached_paths(), vec![path.clone()]);
+
+    let tiny = TileCache::new(1);
+    tiny.load(&path).unwrap();
+    assert!(tiny.cached_paths().is_empty());
+}
+
 fn mbtiles_app() -> App {
     let path = test_dir("fixtures/omt.max1.mbtiles");
-    let mbt = MbtilesState::new(path.clone());
+    let mbt = MbtilesState::new(path.clone(), cache_bytes(DEFAULT_CACHE_MB));
     App::new_mbtiles(mbt, path)
 }
 
@@ -831,6 +886,34 @@ fn mbtiles_center_tile_zoom_and_pan_move_the_viewport() {
     "│                            ││⡇⠈⠦⠃ ⠾⠶⠟⠋   ⢀⣀⠼⠄                                            ⠘⡶⢴    ⢹│"
     "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
     "#);
+}
+
+#[test]
+fn mbtiles_prunes_tiles_away_from_the_viewport_over_the_budget() {
+    let mut app = mbtiles_app();
+    mbt(&mut app).wait_for_visible_tiles();
+    let state = mbt(&mut app);
+    state.tiles.insert((5, 31, 31), MbtTileData::Empty);
+    state
+        .tiles
+        .insert((5, 0, 0), MbtTileData::Error("boom".into()));
+    state.prune_tile_cache_if_needed();
+    assert!(
+        state.tiles.contains_key(&(5, 31, 31)),
+        "under budget nothing is pruned"
+    );
+
+    state.cache_bytes = 1;
+    state.prune_tile_cache_if_needed();
+    assert!(!state.tiles.contains_key(&(5, 31, 31)));
+    assert!(!state.tiles.contains_key(&(5, 0, 0)));
+    assert!(
+        matches!(
+            state.tiles.get(&(0, 0, 0)),
+            Some(MbtTileData::Loaded { .. })
+        ),
+        "the visible tile survives even over budget"
+    );
 }
 
 fn render_with_areas(app: &mut App, width: u16, height: u16) -> PanelAreas {
@@ -1152,6 +1235,7 @@ fn ui_args(path: PathBuf, center_tile: Option<&str>) -> UiArgs {
     UiArgs {
         path,
         center_tile: center_tile.map(str::to_string),
+        cache_mb: 1,
     }
 }
 
@@ -1190,19 +1274,26 @@ fn tick_until(app: &mut App, done: impl Fn(&App) -> bool) {
 }
 
 #[test]
-fn tick_loads_previews() {
+fn tick_loads_previews_and_serves_repeats_from_the_cache() {
     let mut app = file_browser_app();
-    tick_until(&mut app, |a| a.preview_fc.is_some());
+    tick_until(&mut app, |a| a.preview.is_some());
     let first = app.preview_tile_path.clone().unwrap();
     press(&mut app, KeyCode::Down);
     tick_until(&mut app, |a| a.preview_tile_path.as_ref() != Some(&first));
-    assert!(app.preview_fc.is_some());
+    press(&mut app, KeyCode::Up);
+    tick(&mut app);
+    assert_eq!(
+        app.preview_tile_path.as_ref(),
+        Some(&first),
+        "cache hit is synchronous"
+    );
+    assert!(app.preview.is_some());
 }
 
 #[test]
 fn tick_surfaces_a_loader_failure_as_a_popup() {
     let path = test_dir("missing.mbtiles");
-    let mut app = App::new_mbtiles(MbtilesState::new(path.clone()), path);
+    let mut app = App::new_mbtiles(MbtilesState::new(path.clone(), cache_bytes(1)), path);
     tick_until(&mut app, |a| a.error_popup.is_some());
     let (title, msg) = app.error_popup.clone().unwrap();
     assert!(title.ends_with("missing.mbtiles"));
@@ -1479,8 +1570,8 @@ fn scan_events_drive_the_browser_through_poll() {
     assert!(!app.data_loaded());
     insta::assert_snapshot!(render(&mut app), @r#"
     "┌MLT Files (1 found, 1 analyzing…) - ↑/↓ navigate, Enter open, h help┐┌Tile Preview────────────────┐"
-    "│   File                  Size   Enc % Layers   Features Notes       ││Select a tile file (.mlt / .│"
-    "│>> point-boolean.mvt …        …       …      …                      ││                            │"
+    "│   File                  Size   Enc % Layers   Features Notes       ││Select a tile file (.mlt /  │"
+    "│>> point-boolean.mvt …        …       …      …                      ││.mvt) to preview            │"
     "│                                                                    ││                            │"
     "│                                                                    ││                            │"
     "│                                                                    ││                            │"
@@ -1910,15 +2001,13 @@ fn mbtiles_viewport_edges_and_pruning_at_depth() {
     state.set_viewport_to_tile(2, 1, 1).unwrap();
     state.wait_for_visible_tiles();
     state.find_hovered(0.3, 0.3);
-    for x in 0..300u32 {
-        state.tiles.insert((9, x, 511), MbtTileData::Empty);
-    }
     state.tiles.insert((5, 31, 31), MbtTileData::Empty);
     state.hovered = Some(MbtHoveredInfo {
         tile: (5, 31, 31),
         layer_idx: 0,
         feat_idx: 0,
     });
+    state.cache_bytes = 1;
     state.prune_tile_cache_if_needed();
     assert!(
         state.hovered.is_none(),

--- a/rust/mlt/src/ui/tests.rs
+++ b/rust/mlt/src/ui/tests.rs
@@ -24,7 +24,7 @@ use crate::ls::{FileSortColumn, LsRow, analyze_tile_files, analyze_tile_row};
 use crate::ui::mbt::{MbtHoveredInfo, MbtTileData, MbtilesState};
 use crate::ui::scan::{ScanEvent, start_scan};
 use crate::ui::state::{App, HoveredInfo, ResizeHandle, TreeItem, ViewMode};
-use crate::ui::tile::{DEFAULT_CACHE_MB, ParsedTile, TileCache, cache_bytes};
+use crate::ui::tile::{ParsedTile, TileCache};
 
 const WIDTH: u16 = 100;
 const HEIGHT: u16 = 30;
@@ -742,7 +742,7 @@ fn tile_cache_shares_decoded_tiles_and_respects_its_budget() {
 
 fn mbtiles_app() -> App {
     let path = test_dir("fixtures/omt.max1.mbtiles");
-    let mbt = MbtilesState::new(path.clone(), cache_bytes(DEFAULT_CACHE_MB));
+    let mbt = MbtilesState::new(path.clone());
     App::new_mbtiles(mbt, path)
 }
 
@@ -1235,7 +1235,6 @@ fn ui_args(path: PathBuf, center_tile: Option<&str>) -> UiArgs {
     UiArgs {
         path,
         center_tile: center_tile.map(str::to_string),
-        cache_mb: 1,
     }
 }
 
@@ -1293,7 +1292,7 @@ fn tick_loads_previews_and_serves_repeats_from_the_cache() {
 #[test]
 fn tick_surfaces_a_loader_failure_as_a_popup() {
     let path = test_dir("missing.mbtiles");
-    let mut app = App::new_mbtiles(MbtilesState::new(path.clone(), cache_bytes(1)), path);
+    let mut app = App::new_mbtiles(MbtilesState::new(path.clone()), path);
     tick_until(&mut app, |a| a.error_popup.is_some());
     let (title, msg) = app.error_popup.clone().unwrap();
     assert!(title.ends_with("missing.mbtiles"));

--- a/rust/mlt/src/ui/tile.rs
+++ b/rust/mlt/src/ui/tile.rs
@@ -13,13 +13,8 @@ use moka::sync::Cache;
 
 use crate::ls::is_mlt_extension;
 
-/// Default size of the decoded tile cache, in megabytes.
-pub const DEFAULT_CACHE_MB: u64 = 256;
-
-/// The `--cache-mb` budget in bytes.
-pub(crate) const fn cache_bytes(megabytes: u64) -> u64 {
-    megabytes.saturating_mul(1024 * 1024)
-}
+/// Memory budget for decoded tiles.
+pub(crate) const CACHE_BYTES: u64 = 256 * 1024 * 1024;
 
 /// A decoded tile and its extent.
 pub(crate) struct ParsedTile {
@@ -130,7 +125,7 @@ impl TileCache {
 
 impl Default for TileCache {
     fn default() -> Self {
-        Self::new(cache_bytes(DEFAULT_CACHE_MB))
+        Self::new(CACHE_BYTES)
     }
 }
 

--- a/rust/mlt/src/ui/tile.rs
+++ b/rust/mlt/src/ui/tile.rs
@@ -1,0 +1,200 @@
+//! Decoded tile data shared by the file browser and the layer view.
+//! The LRU cache keeps recently decoded tiles around.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use mlt_core::geo_types::{Coord, Geometry, Polygon};
+use mlt_core::geojson::FeatureCollection;
+use mlt_core::mvt::mvt_to_feature_collection;
+use mlt_core::{Decoder, Parser};
+use moka::sync::Cache;
+
+use crate::ls::is_mlt_extension;
+
+/// Default size of the decoded tile cache, in megabytes.
+pub const DEFAULT_CACHE_MB: u64 = 256;
+
+/// The `--cache-mb` budget in bytes.
+pub(crate) const fn cache_bytes(megabytes: u64) -> u64 {
+    megabytes.saturating_mul(1024 * 1024)
+}
+
+/// A decoded tile and its extent.
+pub(crate) struct ParsedTile {
+    pub fc: FeatureCollection,
+    pub extent: u32,
+}
+
+impl ParsedTile {
+    pub(crate) fn from_fc(fc: FeatureCollection) -> Self {
+        let extent = extent_from_fc(&fc);
+        Self { fc, extent }
+    }
+
+    pub(crate) fn load(path: &Path) -> anyhow::Result<Self> {
+        let buf = fs::read(path)?;
+        let fc = if is_mlt_extension(path) {
+            let layers = Decoder::default().decode_all(Parser::default().parse_layers(&buf)?)?;
+            FeatureCollection::from_layers(layers)?
+        } else {
+            mvt_to_feature_collection(buf)?
+        };
+        Ok(Self::from_fc(fc))
+    }
+
+    /// Rough number of bytes this tile occupies, used to weigh it in the cache.
+    pub(crate) fn memory_estimate(&self) -> usize {
+        fc_memory_estimate(&self.fc)
+    }
+}
+
+/// Rough number of bytes a decoded feature collection occupies.
+/// The per-property and per-feature constants stand in for map node, string, and struct overhead.
+pub(crate) fn fc_memory_estimate(fc: &FeatureCollection) -> usize {
+    let coord = size_of::<Coord<i32>>();
+    fc.features
+        .iter()
+        .map(|f| {
+            let verts = geometry_coord_count(&f.geometry) * coord;
+            let props: usize = f
+                .properties
+                .iter()
+                .map(|(k, v)| k.len() + v.as_str().map_or(16, str::len) + 48)
+                .sum();
+            verts + props + 128
+        })
+        .sum()
+}
+
+pub(crate) fn extent_from_fc(fc: &FeatureCollection) -> u32 {
+    fc.features
+        .first()
+        .and_then(|f| {
+            f.properties
+                .get("_extent")
+                .and_then(serde_json::Value::as_u64)
+        })
+        .map_or(4096, |v| u32::try_from(v).unwrap_or(4096))
+}
+
+pub(crate) fn geometry_coord_count(geom: &Geometry<i32>) -> usize {
+    match geom {
+        Geometry::<i32>::Point(_) => 1,
+        Geometry::<i32>::Line(_) | Geometry::<i32>::Rect(_) => 2,
+        Geometry::<i32>::Triangle(_) => 3,
+        Geometry::<i32>::LineString(ls) => ls.0.len(),
+        Geometry::<i32>::Polygon(p) => polygon_coord_count(p),
+        Geometry::<i32>::MultiPoint(mp) => mp.0.len(),
+        Geometry::<i32>::MultiLineString(mls) => mls.iter().map(|ls| ls.0.len()).sum(),
+        Geometry::<i32>::MultiPolygon(mp) => mp.iter().map(polygon_coord_count).sum(),
+        Geometry::<i32>::GeometryCollection(gc) => gc.iter().map(geometry_coord_count).sum(),
+    }
+}
+
+pub(crate) fn polygon_coord_count(poly: &Polygon<i32>) -> usize {
+    poly.exterior().0.len() + poly.interiors().iter().map(|r| r.0.len()).sum::<usize>()
+}
+
+/// Memory-bounded LRU cache of decoded tiles keyed by path.
+#[derive(Clone)]
+pub(crate) struct TileCache(Cache<PathBuf, Arc<ParsedTile>>);
+
+impl TileCache {
+    pub(crate) fn new(max_bytes: u64) -> Self {
+        Self(
+            Cache::builder()
+                .max_capacity(max_bytes)
+                .weigher(|_, tile: &Arc<ParsedTile>| {
+                    u32::try_from(tile.memory_estimate()).unwrap_or(u32::MAX)
+                })
+                .build(),
+        )
+    }
+
+    pub(crate) fn get(&self, path: &Path) -> Option<Arc<ParsedTile>> {
+        self.0.get(path)
+    }
+
+    /// Return the cached tile for `path`, decoding and caching it first if needed.
+    pub(crate) fn load(&self, path: &Path) -> anyhow::Result<Arc<ParsedTile>> {
+        if let Some(tile) = self.0.get(path) {
+            return Ok(tile);
+        }
+        let tile = Arc::new(ParsedTile::load(path)?);
+        self.0.insert(path.to_path_buf(), Arc::clone(&tile));
+        Ok(tile)
+    }
+}
+
+impl Default for TileCache {
+    fn default() -> Self {
+        Self::new(cache_bytes(DEFAULT_CACHE_MB))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mlt_core::geo_types::{GeometryCollection, Line, LineString, Point, Rect, Triangle};
+
+    use super::*;
+
+    fn c(x: i32, y: i32) -> Coord<i32> {
+        Coord { x, y }
+    }
+
+    impl TileCache {
+        pub(crate) fn cached_paths(&self) -> Vec<PathBuf> {
+            self.0.run_pending_tasks();
+            let mut paths: Vec<PathBuf> = self.0.iter().map(|(k, _)| (*k).clone()).collect();
+            paths.sort();
+            paths
+        }
+    }
+
+    #[test]
+    fn coord_counts_cover_every_geometry_kind() {
+        let ring = LineString(vec![c(0, 0), c(4, 0), c(4, 4)]);
+        assert_eq!(geometry_coord_count(&Geometry::Point(Point(c(1, 1)))), 1);
+        assert_eq!(
+            geometry_coord_count(&Geometry::Line(Line::new(c(0, 0), c(1, 1)))),
+            2
+        );
+        assert_eq!(
+            geometry_coord_count(&Geometry::Rect(Rect::new(c(0, 0), c(1, 1)))),
+            2
+        );
+        assert_eq!(
+            geometry_coord_count(&Geometry::Triangle(Triangle::new(
+                c(0, 0),
+                c(1, 0),
+                c(0, 1)
+            ))),
+            3
+        );
+        assert_eq!(geometry_coord_count(&Geometry::LineString(ring.clone())), 3);
+        assert_eq!(
+            geometry_coord_count(&Geometry::Polygon(Polygon::new(
+                ring.clone(),
+                vec![ring.clone()]
+            ))),
+            8,
+            "geo closes both rings"
+        );
+        let gc = GeometryCollection(vec![
+            Geometry::LineString(ring),
+            Geometry::Point(Point(c(0, 0))),
+        ]);
+        assert_eq!(geometry_coord_count(&Geometry::GeometryCollection(gc)), 4);
+    }
+
+    #[test]
+    fn extent_falls_back_when_the_property_is_missing_or_huge() {
+        let fc = FeatureCollection {
+            features: Vec::new(),
+            ty: "FeatureCollection".into(),
+        };
+        assert_eq!(extent_from_fc(&fc), 4096);
+    }
+}


### PR DESCRIPTION
Part of #971.

Third piece of #1626. Moving between files decoded the same tile again on every visit. Decoded tiles now go through a memory-bounded LRU cache shared by the preview, the layer view, and Enter; the budget is 256 MB, and the mbtiles map prunes its decoded tiles by the same budget instead of a fixed tile count, keeping the visible tiles and their ancestors. A preview that fails to decode now says so instead of retrying every frame