### PR TITLE
chore(ci): run the heavy jobs on pull requests outside a stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       ts: ${{ steps.filter.outputs.ts }}
       cpp: ${{ steps.filter.outputs.cpp }}
       docs: ${{ steps.filter.outputs.docs }}
-      top-of-stack: ${{ github.event.pull_request.stack != null && github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
+      run-heavy: ${{ github.event.pull_request.stack == null || github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
@@ -62,7 +62,7 @@ jobs:
     uses: ./.github/workflows/rust.yml
     with:
       run-release: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      run-heavy: ${{ needs.changes.outputs.top-of-stack == 'true' }}
+      run-heavy: ${{ needs.changes.outputs.run-heavy == 'true' }}
     secrets: inherit
     permissions: { contents: write, id-token: write }
 
@@ -85,7 +85,7 @@ jobs:
     if: needs.changes.outputs.cpp == 'true'
     uses: ./.github/workflows/cpp.yml
     with:
-      run-heavy: ${{ needs.changes.outputs.top-of-stack == 'true' }}
+      run-heavy: ${{ needs.changes.outputs.run-heavy == 'true' }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
`github.event.pull_request.stack` is only present on stacked pull requests, so the gate from #1632 evaluated to false for every standalone pull request and skipped cpp-build, fuzz, the release binaries and the wasm package on all of them, not only mid-stack. Every standalone pull request since then ran without them, #1634 to #1639 included, and Dependabot bumps are standalone too. A pull request outside a stack has nothing above it, so it gets the heavy jobs; inside a stack only the top does. The output is renamed to match the `run-heavy` input it feeds.

Run 33895274920 (#1638, created 16:27 UTC) shows cpp, Fuzz, Build release binaries and the wasm package all skipped.
