### PR TITLE
feat(rust): summarize layers and the whole tile in the mlt ui info panels

### DIFF
--- a/rust/mlt/README.md
+++ b/rust/mlt/README.md
@@ -61,9 +61,9 @@ cargo run -- ui path/to/directory
 
 Features:
 - **Tree View Panel (left)**: Browse layers and features in a hierarchical tree
-- "All Layers" - shows all features from all layers
-  - Individual layers - shows all features in that layer
-  - Individual features - shows only the selected feature
+  - "All" - every layer, with layer and feature counts and the tile's geometry types
+  - Individual layers - the layer's features, with each property's value types and the layer's geometry types
+  - Individual features - the feature's properties and geometry statistics
   - Hovered features are highlighted with underlined green text
 - **Map Panel (right)**: Visual representation of the geometries
   - Shows the extent boundary as a thin gray rectangle

--- a/rust/mlt/src/ui/rendering/layers.rs
+++ b/rust/mlt/src/ui/rendering/layers.rs
@@ -1,3 +1,6 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use mlt_core::GeometryType;
 use mlt_core::geo_types::{
     Geometry, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
 };
@@ -10,7 +13,7 @@ use usize_cast::IntoUsize as _;
 
 use crate::ui::mbt::MbtTileData;
 use crate::ui::state::{App, TreeItem, ViewMode};
-use crate::ui::tile::polygon_coord_count;
+use crate::ui::tile::{geometry_coord_count, polygon_coord_count};
 use crate::ui::{
     CLR_HOVERED_TREE, STYLE_LABEL, STYLE_SELECTED, block_with_title, feature_suffix,
     geometry_color, geometry_type_name, is_ring_ccw, stat_line, sub_feature_suffix,
@@ -147,6 +150,84 @@ fn feature_property_lines(feat: &Feature) -> Vec<Line<'static>> {
     }
 }
 
+fn value_type_name(v: &serde_json::Value) -> &'static str {
+    match v {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "bool",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
+/// Layer count and per-layer feature counts for the whole tile.
+fn tile_summary_lines(app: &App) -> Vec<Line<'static>> {
+    let mut lines = vec![
+        stat_line("Layers", &app.layer_groups.len()),
+        stat_line("Features", &app.tile.fc.features.len()),
+    ];
+    for g in &app.layer_groups {
+        lines.push(Line::from(format!(
+            "  {}: {} features",
+            g.name,
+            g.feature_indices.len()
+        )));
+    }
+    lines
+}
+
+/// Feature count and property names with their value types for one layer, in name order.
+fn layer_summary_lines(app: &App, layer: usize) -> Vec<Line<'static>> {
+    let group = &app.layer_groups[layer];
+    let mut types: BTreeMap<&str, BTreeSet<&'static str>> = BTreeMap::new();
+    for &gi in &group.feature_indices {
+        for (k, v) in &app.tile.fc.features[gi].properties {
+            if k == "_layer" || k == "_extent" {
+                continue;
+            }
+            types.entry(k).or_default().insert(value_type_name(v));
+        }
+    }
+    let mut lines = vec![
+        stat_line("Features", &group.feature_indices.len()),
+        stat_line("Properties", &types.len()),
+    ];
+    for (name, kinds) in types {
+        let kinds: Vec<&str> = kinds.into_iter().collect();
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {name}: "), STYLE_LABEL),
+            Span::raw(kinds.join(" | ")),
+        ]));
+    }
+    lines
+}
+
+/// Geometry types with counts, over one layer or the whole tile, in type order.
+fn geometry_count_lines(app: &App, layer: Option<usize>) -> Vec<Line<'static>> {
+    let mut counts: BTreeMap<GeometryType, usize> = BTreeMap::new();
+    let mut vertices = 0usize;
+    let groups = app
+        .layer_groups
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| layer.is_none_or(|l| l == *i));
+    for (_, group) in groups {
+        for &gi in &group.feature_indices {
+            let geom = &app.tile.fc.features[gi].geometry;
+            if let Ok(t) = GeometryType::try_from(geom) {
+                *counts.entry(t).or_default() += 1;
+            }
+            vertices += geometry_coord_count(geom);
+        }
+    }
+    let mut lines = vec![stat_line("Vertices", &vertices)];
+    for (t, n) in counts {
+        lines.push(stat_line(&t.to_string(), &n));
+    }
+    lines
+}
+
 pub fn render_properties_panel(f: &mut Frame<'_>, area: Rect, app: &mut App) -> Rect {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -161,42 +242,31 @@ pub fn render_properties_panel(f: &mut Frame<'_>, area: Rect, app: &mut App) -> 
     chunks[1]
 }
 
+/// The hovered item when there is one, else the selection.
+fn info_target(app: &App) -> (TreeItem, bool) {
+    match app.hovered.as_ref() {
+        Some(h) => (h.item(), true),
+        None => (app.selected_item().clone(), false),
+    }
+}
+
 fn render_properties_top(f: &mut Frame<'_>, area: Rect, app: &mut App) {
-    let item = app.tree_items.get(app.selected_index);
-    let hov = app.hovered.as_ref();
-    let (title, lines): (String, Vec<Line<'static>>) = match item {
-        None | Some(TreeItem::All | TreeItem::Layer(_)) => {
-            if let Some(h) = hov {
-                let key = (h.layer, h.feat);
-                if app.last_properties_key != Some(key) {
-                    app.properties_scroll = 0;
-                    app.last_properties_key = Some(key);
-                }
-                (
-                    format!("Properties (feat {}, hover)", h.feat),
-                    feature_property_lines(app.feature(h.layer, h.feat)),
-                )
-            } else {
-                app.last_properties_key = None;
-                (
-                    "Properties".into(),
-                    vec![Line::from(
-                        "Select or hover over a feature to view properties",
-                    )],
-                )
-            }
-        }
-        Some(TreeItem::Feature { layer, feat } | TreeItem::SubFeature { layer, feat, .. }) => {
-            let key = (*layer, *feat);
-            if app.last_properties_key != Some(key) {
-                app.properties_scroll = 0;
-                app.last_properties_key = Some(key);
-            }
-            (
-                format!("Properties (feat {feat})"),
-                feature_property_lines(app.feature(*layer, *feat)),
-            )
-        }
+    let (target, hover) = info_target(app);
+    if app.last_properties_key.as_ref() != Some(&target) {
+        app.properties_scroll = 0;
+        app.last_properties_key = Some(target.clone());
+    }
+    let suffix = if hover { ", hover" } else { "" };
+    let (title, lines): (String, Vec<Line<'static>>) = match &target {
+        TreeItem::All => ("Properties (all layers)".into(), tile_summary_lines(app)),
+        TreeItem::Layer(l) => (
+            format!("Properties (layer {}{suffix})", app.layer_groups[*l].name),
+            layer_summary_lines(app, *l),
+        ),
+        TreeItem::Feature { layer, feat } | TreeItem::SubFeature { layer, feat, .. } => (
+            format!("Properties (feat {feat}{suffix})"),
+            feature_property_lines(app.feature(*layer, *feat)),
+        ),
     };
     let inner = area.height.saturating_sub(2);
     let max = u16::try_from(lines.len().saturating_sub(inner.into_usize())).unwrap_or(0);
@@ -364,33 +434,28 @@ fn mbt_hover_title_and_lines(app: &App) -> (String, Vec<Line<'static>>) {
 }
 
 fn render_geometry_stats(f: &mut Frame<'_>, area: Rect, app: &App) {
-    let item = app.tree_items.get(app.selected_index);
-    let hov = app.hovered.as_ref();
-
-    let lines = match item {
-        Some(TreeItem::SubFeature { layer, feat, part }) => {
-            subpart_stats_lines(&app.feature(*layer, *feat).geometry, *part)
-        }
-        Some(TreeItem::Feature { layer, feat }) => {
-            geometry_stats_lines(&app.feature(*layer, *feat).geometry)
-        }
-        _ => {
-            if let Some(h) = hov {
-                let geom = &app.feature(h.layer, h.feat).geometry;
-                match h.part {
-                    Some(p) => subpart_stats_lines(geom, p),
-                    None => geometry_stats_lines(geom),
-                }
-            } else {
-                vec![Line::from(
-                    "Select or hover over a feature to view geometry info",
-                )]
-            }
-        }
+    let (target, _) = info_target(app);
+    let (title, lines) = match target {
+        TreeItem::All => (
+            "Geometry (all layers)".to_string(),
+            geometry_count_lines(app, None),
+        ),
+        TreeItem::Layer(l) => (
+            format!("Geometry (layer {})", app.layer_groups[l].name),
+            geometry_count_lines(app, Some(l)),
+        ),
+        TreeItem::Feature { layer, feat } => (
+            "Geometry".to_string(),
+            geometry_stats_lines(&app.feature(layer, feat).geometry),
+        ),
+        TreeItem::SubFeature { layer, feat, part } => (
+            "Geometry".to_string(),
+            subpart_stats_lines(&app.feature(layer, feat).geometry, part),
+        ),
     };
 
     let para = Paragraph::new(lines)
-        .block(block_with_title("Geometry"))
+        .block(block_with_title(title))
         .wrap(Wrap { trim: false });
     f.render_widget(para, area);
 }

--- a/rust/mlt/src/ui/state.rs
+++ b/rust/mlt/src/ui/state.rs
@@ -80,6 +80,15 @@ impl HoveredInfo {
             part,
         }
     }
+
+    /// The hovered feature or part as a tree item.
+    pub(crate) fn item(&self) -> TreeItem {
+        let (layer, feat) = (self.layer, self.feat);
+        match self.part {
+            Some(part) => TreeItem::SubFeature { layer, feat, part },
+            None => TreeItem::Feature { layer, feat },
+        }
+    }
 }
 
 pub struct LayerGroup {
@@ -136,7 +145,7 @@ pub struct App {
     pub(crate) properties_scroll: u16,
     pub(crate) tree_scroll: u16,
     pub(crate) tree_inner_height: usize,
-    pub(crate) last_properties_key: Option<(usize, usize)>,
+    pub(crate) last_properties_key: Option<TreeItem>,
     pub(crate) properties_pct: u16,
     geometry_index: Option<RTree<GeometryIndexEntry>>,
     pub(crate) file_left_pct: u16,

--- a/rust/mlt/src/ui/tests.rs
+++ b/rust/mlt/src/ui/tests.rs
@@ -9,6 +9,7 @@ use mlt_core::GeometryType;
 use mlt_core::geo_types::{
     Coord, Geometry, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
 };
+use mlt_core::geo_types::{GeometryCollection, Line, Rect as GeoRect, Triangle};
 use mlt_core::geojson::{Feature, FeatureCollection};
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
@@ -170,20 +171,20 @@ fn layer_overview_starts_on_all_layers() {
     "│                            ││     ⢸      ⢸             ⡖⠒⠒⠒⠒⠒⠒⢺⠒⠒⠒⠒⠒⡲⡎⠁           ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸             ⡇      ⢸  ⢀⠔⠊ ⡇            ⢸        ⡇     │"
     "└────────────────────────────┘│     ⢸      ⢸             ⡇      ⢸⡠⠒⠁   ⡇            ⢸        ⡇     │"
-    "┌Properties──────────────────┐│     ⢸⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⢉⠭⢻⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⡇     │"
-    "│Select or hover over a      ││     ⢸      ⢸             ⡇  ⡠⠔⠁ ⢸      ⡇            ⢸        ⡇     │"
-    "│feature to view properties  ││     ⢸      ⢸             ⣇⡠⠊    ⢸      ⡇            ⢸        ⡇     │"
-    "│                            ││     ⢸      ⢸           ⢀⠔⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠁            ⢸        ⡇     │"
-    "│                            ││     ⢸      ⢸         ⡠⠊⠁        ⢸               ×   ⢸        ⡇     │"
-    "│                            ││     ⢸      ⢸      ⢀⠔⠉           ⢸            ×      ⢸        ⡇     │"
+    "┌Properties (all layers)─────┐│     ⢸⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⢉⠭⢻⠉⠉⠉⠉⠉⠉⡏⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⡇     │"
+    "│Layers: 3                   ││     ⢸      ⢸             ⡇  ⡠⠔⠁ ⢸      ⡇            ⢸        ⡇     │"
+    "│Features: 6                 ││     ⢸      ⢸             ⣇⡠⠊    ⢸      ⡇            ⢸        ⡇     │"
+    "│water: 2 features           ││     ⢸      ⢸           ⢀⠔⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠁            ⢸        ⡇     │"
+    "│roads: 2 features           ││     ⢸      ⢸         ⡠⠊⠁        ⢸               ×   ⢸        ⡇     │"
+    "│poi: 2 features             ││     ⢸      ⢸      ⢀⠔⠉           ⢸            ×      ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸    ⡠⠒⠁             ⢸                   ⢸        ⡇     │"
     "└────────────────────────────┘│     ⢸  ⢸⠉⠉⠉⢹⠉⢉⠭⢻                ⢸                   ⢸        ⡇     │"
-    "┌Geometry────────────────────┐│     ⢸  ⢸   ⡸⠴⠥⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼        ⡇     │"
-    "│Select or hover over a      ││     ⢸  ⢸⢀⡠⠊    ⢸                ⢸                            ⡇     │"
-    "│feature to view geometry    ││     ⢸ ⢀⠜⠓⠒⠒⠒⠒⠒⠒⠚                ⢸                            ⡇     │"
-    "│info                        ││     ⠸⠮⠥⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
-    "│                            ││                                                                    │"
-    "│                            ││                                                                    │"
+    "┌Geometry (all layers)───────┐│     ⢸  ⢸   ⡸⠴⠥⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼        ⡇     │"
+    "│Vertices: 29                ││     ⢸  ⢸⢀⡠⠊    ⢸                ⢸                            ⡇     │"
+    "│Point: 1                    ││     ⢸ ⢀⠜⠓⠒⠒⠒⠒⠒⠒⠚                ⢸                            ⡇     │"
+    "│LineString: 1               ││     ⠸⠮⠥⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
+    "│Polygon: 1                  ││                                                                    │"
+    "│MultiPoint: 1               ││                                                                    │"
     "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
     "#);
 }
@@ -369,20 +370,20 @@ fn help_overlay_lists_the_layer_overview_keys() {
     "│                  │  *                   Expand/collapse all layers            │   ⢸        ⡇     │"
     "│                  │  Left                Jump to parent node                   │   ⢸        ⡇     │"
     "└──────────────────│  Ctrl+h / Ctrl+l     Resize left/right split               │   ⢸        ⡇     │"
-    "┌Properties────────│  Shift+J / Shift+K   Resize top/bottom split               │⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⡇     │"
-    "│Select or hover ov│                                                            │   ⢸        ⡇     │"
-    "│feature to view pr│Mouse                                                       │   ⢸        ⡇     │"
-    "│                  │  Click tree item     Select (drill into level)             │   ⢸        ⡇     │"
-    "│                  │  Double-click        Expand/collapse                       │   ⢸        ⡇     │"
-    "│                  │  Hover tree/map      Highlight geometry                    │   ⢸        ⡇     │"
+    "┌Properties (all la│  Shift+J / Shift+K   Resize top/bottom split               │⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠉⠉⡇     │"
+    "│Layers: 3         │                                                            │   ⢸        ⡇     │"
+    "│Features: 6       │Mouse                                                       │   ⢸        ⡇     │"
+    "│water: 2 features │  Click tree item     Select (drill into level)             │   ⢸        ⡇     │"
+    "│roads: 2 features │  Double-click        Expand/collapse                       │   ⢸        ⡇     │"
+    "│poi: 2 features   │  Hover tree/map      Highlight geometry                    │   ⢸        ⡇     │"
     "│                  │  Click on map        Select hovered feature                │   ⢸        ⡇     │"
     "└──────────────────│  Scroll panels       Scroll tree/properties                │   ⢸        ⡇     │"
-    "┌Geometry──────────│  Drag dividers       Resize panels                         │⠤⠤⠤⠼        ⡇     │"
-    "│Select or hover ov│                                                            │            ⡇     │"
-    "│feature to view ge│Map Colors                                                  │            ⡇     │"
-    "│info              │  Magenta             Point                                 │⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
-    "│                  │  Light magenta       MultiPoint                            │                  │"
-    "│                  └────────────────────────────────────────────────────────────┘                  │"
+    "┌Geometry (all laye│  Drag dividers       Resize panels                         │⠤⠤⠤⠼        ⡇     │"
+    "│Vertices: 29      │                                                            │            ⡇     │"
+    "│Point: 1          │Map Colors                                                  │            ⡇     │"
+    "│LineString: 1     │  Magenta             Point                                 │⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
+    "│Polygon: 1        │  Light magenta       MultiPoint                            │                  │"
+    "│MultiPoint: 1     └────────────────────────────────────────────────────────────┘                  │"
     "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
     "#);
     press(&mut app, KeyCode::Char('x'));
@@ -410,19 +411,19 @@ fn error_popup_shows_the_message_until_a_key_is_pressed() {
     "│         │                                                                              │   ⡇     │"
     "└─────────│                           unexpected end of buffer                           │   ⡇     │"
     "┌Propertie│                                                                              │⠉⠉⠉⡇     │"
-    "│Select or│                                                                              │   ⡇     │"
-    "│feature t└──────────────────────────────────────────────────────────────any key to close┘   ⡇     │"
-    "│                            ││     ⢸      ⢸           ⢀⠔⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠁            ⢸        ⡇     │"
-    "│                            ││     ⢸      ⢸         ⡠⠊⠁        ⢸               ×   ⢸        ⡇     │"
-    "│                            ││     ⢸      ⢸      ⢀⠔⠉           ⢸            ×      ⢸        ⡇     │"
+    "│Layers: 3│                                                                              │   ⡇     │"
+    "│Features:└──────────────────────────────────────────────────────────────any key to close┘   ⡇     │"
+    "│water: 2 features           ││     ⢸      ⢸           ⢀⠔⠉⠉⠉⠉⠉⠉⠉⢹⠉⠉⠉⠉⠉⠉⠁            ⢸        ⡇     │"
+    "│roads: 2 features           ││     ⢸      ⢸         ⡠⠊⠁        ⢸               ×   ⢸        ⡇     │"
+    "│poi: 2 features             ││     ⢸      ⢸      ⢀⠔⠉           ⢸            ×      ⢸        ⡇     │"
     "│                            ││     ⢸      ⢸    ⡠⠒⠁             ⢸                   ⢸        ⡇     │"
     "└────────────────────────────┘│     ⢸  ⢸⠉⠉⠉⢹⠉⢉⠭⢻                ⢸                   ⢸        ⡇     │"
-    "┌Geometry────────────────────┐│     ⢸  ⢸   ⡸⠴⠥⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼        ⡇     │"
-    "│Select or hover over a      ││     ⢸  ⢸⢀⡠⠊    ⢸                ⢸                            ⡇     │"
-    "│feature to view geometry    ││     ⢸ ⢀⠜⠓⠒⠒⠒⠒⠒⠒⠚                ⢸                            ⡇     │"
-    "│info                        ││     ⠸⠮⠥⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
-    "│                            ││                                                                    │"
-    "│                            ││                                                                    │"
+    "┌Geometry (all layers)───────┐│     ⢸  ⢸   ⡸⠴⠥⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⢼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼        ⡇     │"
+    "│Vertices: 29                ││     ⢸  ⢸⢀⡠⠊    ⢸                ⢸                            ⡇     │"
+    "│Point: 1                    ││     ⢸ ⢀⠜⠓⠒⠒⠒⠒⠒⠒⠚                ⢸                            ⡇     │"
+    "│LineString: 1               ││     ⠸⠮⠥⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
+    "│Polygon: 1                  ││                                                                    │"
+    "│MultiPoint: 1               ││                                                                    │"
     "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
     "#);
     press(&mut app, KeyCode::Enter);
@@ -619,24 +620,63 @@ fn enter_opens_a_file_and_escape_returns_to_the_browser() {
     "│                            ││     ⢸                                                        ⡇     │"
     "│                            ││     ⢸                                                        ⡇     │"
     "└────────────────────────────┘│     ⢸                                                        ⡇     │"
-    "┌Properties──────────────────┐│     ⢸                                                        ⡇     │"
-    "│Select or hover over a      ││     ⢸                                                        ⡇     │"
-    "│feature to view properties  ││     ⢸                                                        ⡇     │"
-    "│                            ││     ⢸                                                        ⡇     │"
+    "┌Properties (all layers)─────┐│     ⢸                                                        ⡇     │"
+    "│Layers: 1                   ││     ⢸                                                        ⡇     │"
+    "│Features: 1                 ││     ⢸                                                        ⡇     │"
+    "│layer: 1 features           ││     ⢸                                                        ⡇     │"
     "│                            ││     ⢸                                                        ⡇     │"
     "│                            ││     ⢸                                                        ⡇     │"
     "│                            ││     ⢸                                                        ⡇     │"
     "└────────────────────────────┘│     ⢸                                                        ⡇     │"
-    "┌Geometry────────────────────┐│     ⢸                                                        ⡇     │"
-    "│Select or hover over a      ││     ⢸                                                        ⡇     │"
-    "│feature to view geometry    ││     ⢸                                                        ⡇     │"
-    "│info                        ││     ⠸⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
+    "┌Geometry (all layers)───────┐│     ⢸                                                        ⡇     │"
+    "│Vertices: 3                 ││     ⢸                                                        ⡇     │"
+    "│LineString: 1               ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⠸⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
     "│                            ││                                                                    │"
     "│                            ││                                                                    │"
     "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
     "#);
     press(&mut app, KeyCode::Esc);
     assert_eq!(app.mode, ViewMode::FileBrowser);
+}
+
+#[test]
+fn layer_selection_summarizes_properties_and_geometry() {
+    let mut app = sample_app();
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Down);
+    insta::assert_snapshot!(render(&mut app), @r#"
+    "┌sample.mlt - Enter/+/-:expan┐┌Map View────────────────────────────────────────────────────────────┐"
+    "│   All                      ││                                                                    │"
+    "│     Layer: water (2 feature││                                                                    │"
+    "│>>   Layer: roads (2 feature││     ⢰⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⢲⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⢒⡲⡆     │"
+    "│     Layer: poi (2 features,││     ⢸                           ⢸                        ⢀⠔⠁ ⡇     │"
+    "│                            ││     ⢸                           ⢸                      ⡠⠊⠁   ⡇     │"
+    "│                            ││     ⢸                           ⢸                   ⢀⠔⠊      ⡇     │"
+    "│                            ││     ⢸                           ⢸                 ⡠⠒⠁        ⡇     │"
+    "│                            ││     ⢸                           ⢸              ⢀⠤⠊           ⡇     │"
+    "│                            ││     ⢸                           ⢸            ⣀⠔⠁             ⡇     │"
+    "│                            ││     ⢸                           ⢸         ⢀⡠⠊                ⡇     │"
+    "│                            ││     ⢸                           ⢸       ⢀⠔⠁                  ⡇     │"
+    "│                            ││     ⢸                           ⢸     ⡠⠊⠁                    ⡇     │"
+    "│                            ││     ⢸                           ⢸  ⢀⠔⠊                       ⡇     │"
+    "└────────────────────────────┘│     ⢸                           ⢸⡠⠒⠁                         ⡇     │"
+    "┌Properties (layer roads)────┐│     ⢸⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢉⠭⢻⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⡇     │"
+    "│Features: 2                 ││     ⢸                       ⡠⠔⠁ ⢸                            ⡇     │"
+    "│Properties: 2               ││     ⢸                    ⢀⡠⠊    ⢸                            ⡇     │"
+    "│class: string               ││     ⢸                  ⢀⠔⠁      ⢸                            ⡇     │"
+    "│oneway: bool                ││     ⢸                ⡠⠊⠁        ⢸                            ⡇     │"
+    "│                            ││     ⢸             ⢀⠔⠉           ⢸                            ⡇     │"
+    "│                            ││     ⢸           ⡠⠒⠁             ⢸                            ⡇     │"
+    "└────────────────────────────┘│     ⢸        ⢀⠤⠊                ⢸                            ⡇     │"
+    "┌Geometry (layer roads)──────┐│     ⢸      ⡠⠔⠁                  ⢸                            ⡇     │"
+    "│Vertices: 6                 ││     ⢸   ⢀⡠⠊                     ⢸                            ⡇     │"
+    "│LineString: 1               ││     ⢸ ⢀⠔⠁                       ⢸                            ⡇     │"
+    "│MultiLineString: 1          ││     ⠸⠮⠥⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠼⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
+    "│                            ││                                                                    │"
+    "│                            ││                                                                    │"
+    "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
+    "#);
 }
 
 #[test]
@@ -2021,6 +2061,75 @@ fn help_renders_for_the_file_browser() {
     let mut app = file_browser_app();
     press(&mut app, KeyCode::Char('?'));
     assert!(render(&mut app).contains("Double-click row"));
+}
+
+#[test]
+fn layer_summary_lists_every_value_type_and_skips_unknown_geometries() {
+    let odd = vec![
+        feature(
+            "odd",
+            Point(c(1, 1)),
+            &[
+                ("n", Value::Null),
+                ("a", json!([1, 2])),
+                ("o", json!({"k": 1})),
+                ("b", json!(true)),
+            ],
+        ),
+        feature(
+            "odd",
+            GeoRect::new(c(10, 10), c(20, 20)),
+            &[("n", json!("text"))],
+        ),
+        feature("odd", Line::new(c(0, 0), c(9, 9)), &[]),
+        feature("odd", Triangle::new(c(0, 0), c(4, 0), c(0, 4)), &[]),
+        feature(
+            "odd",
+            Geometry::<i32>::GeometryCollection(GeometryCollection(vec![Geometry::Point(Point(
+                c(7, 7),
+            ))])),
+            &[],
+        ),
+    ];
+    let fc = FeatureCollection {
+        features: odd,
+        ty: "FeatureCollection".into(),
+    };
+    let tile = Arc::new(ParsedTile::from_fc(fc));
+    let mut app = App::new_single_file(tile, Some(PathBuf::from("odd.mlt")));
+    press(&mut app, KeyCode::Down);
+    insta::assert_snapshot!(render(&mut app), @r#"
+    "┌odd.mlt - Enter/+/-:expand, ┐┌Map View────────────────────────────────────────────────────────────┐"
+    "│   All                      ││                                                                    │"
+    "│>>   Layer: odd (5 features,││                                                                    │"
+    "│       Feat 0: Point        ││     ⢰⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⡆     │"
+    "│       Feat 1: Unknown      ││     ⢸                                                        ⡇     │"
+    "│       Feat 2: Unknown      ││     ⢸                                                        ⡇     │"
+    "│       Feat 3: Unknown      ││     ⢸                                                        ⡇     │"
+    "│       Feat 4: Unknown      ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "└────────────────────────────┘│     ⢸                                                        ⡇     │"
+    "┌Properties (layer odd)──────┐│     ⢸                                                        ⡇     │"
+    "│Features: 5                 ││     ⢸                                                        ⡇     │"
+    "│Properties: 4               ││     ⢸                                                        ⡇     │"
+    "│a: array                    ││     ⢸                                                        ⡇     │"
+    "│b: bool                     ││     ⢸                                                        ⡇     │"
+    "│n: null | string            ││     ⢸                                                        ⡇     │"
+    "│o: object                   ││     ⢸                                                        ⡇     │"
+    "└────────────────────────────┘│     ⢸                                                        ⡇     │"
+    "┌Geometry (layer odd)────────┐│     ⢸                                                        ⡇     │"
+    "│Vertices: 9                 ││     ⢸                                                        ⡇     │"
+    "│Point: 1                    ││     ×                                                        ⡇     │"
+    "│                            ││     ⠸⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
+    "│                            ││                                                                    │"
+    "│                            ││                                                                    │"
+    "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
+    "#);
 }
 
 #[test]


### PR DESCRIPTION
Part of #971.

Fourth piece of #1626. With all layers or a layer selected the info panels only said to select a feature. They now summarize the selection. For all layers that is the layer and feature counts and the tile's geometry types, for a layer each property's value types and the geometry-type counts. The panels describe the hovered item when there is one