### PR TITLE
fix(ci): install hotpath-utils at the version the profile ran with

### DIFF
--- a/.github/workflows/hotpath-comment.yml
+++ b/.github/workflows/hotpath-comment.yml
@@ -30,8 +30,11 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Install hotpath-utils CLI
-        run: cargo install hotpath --bin hotpath-utils --features=utils
+      - name: Install hotpath-utils at the version the profile ran with
+        run: |
+          version=$(cargo tree --manifest-path rust/Cargo.toml -p mlt --depth 1 --prefix none --features hotpath \
+            | awk '$1 == "hotpath" { print substr($2, 2); exit }')
+          cargo install "hotpath@${version}" --bin hotpath-utils --features=utils
 
       - name: Compose comment (hotpath + per-tile size diff)
         env:


### PR DESCRIPTION
Every Rust Hotpath Comment run on main since the #1638 merge fails in the compose step with `Failed to parse /tmp/metrics/base_timing.json: missing field version` (run 33927783832). The workflow installs `hotpath-utils` unpinned, so since hotpath 0.25.0 was published on 2026-09-03 it parses metrics written by the workspace's hotpath 0.24.0 with a newer format. The install now reads the hotpath version `mlt` resolves to and installs that one, so the two sides stay together when dependabot bumps hotpath