### PR TITLE
feat(rust): draw tessellation triangles in the mlt ui

### DIFF
--- a/rust/mlt/README.md
+++ b/rust/mlt/README.md
@@ -68,6 +68,7 @@ Features:
 - **Map Panel (right)**: Visual representation of the geometries
   - Shows the extent boundary as a thin gray rectangle
   - Draws the selected level in color and the rest in gray as context
+  - Tessellation triangles stored in the tile are drawn in gray behind the selected polygon, or behind a hovered one inside a layer
   - **Color coding by geometry type**:
     - Points: Magenta (multipoint: light magenta)
     - `LineStrings`: Cyan (multi-linestring: light cyan)

--- a/rust/mlt/README.md
+++ b/rust/mlt/README.md
@@ -68,7 +68,7 @@ Features:
 - **Map Panel (right)**: Visual representation of the geometries
   - Shows the extent boundary as a thin gray rectangle
   - Draws the selected level in color and the rest in gray as context
-  - Tessellation triangles stored in the tile are drawn in gray behind the selected polygon, or behind a hovered one inside a layer
+  - Tessellation edges stored in the tile are drawn in dark gray inside the selected polygon, or inside a hovered one in a layer
   - **Color coding by geometry type**:
     - Points: Magenta (multipoint: light magenta)
     - `LineStrings`: Cyan (multi-linestring: light cyan)

--- a/rust/mlt/src/ui/mod.rs
+++ b/rust/mlt/src/ui/mod.rs
@@ -70,7 +70,7 @@ pub const CLR_HINT: Color = Color::DarkGray;
 pub const CLR_CONTEXT_LAYER: Color = Color::DarkGray;
 /// Other features of the selected feature's layer.
 pub const CLR_CONTEXT_FEATURE: Color = Color::Gray;
-pub const CLR_TRIANGLE: Color = Color::Gray;
+pub const CLR_TRIANGLE: Color = Color::DarkGray;
 
 pub const STYLE_SELECTED: Style = Style::new().fg(CLR_SELECTED).add_modifier(Modifier::BOLD);
 pub const STYLE_LABEL: Style = Style::new().fg(CLR_LABEL);

--- a/rust/mlt/src/ui/mod.rs
+++ b/rust/mlt/src/ui/mod.rs
@@ -70,6 +70,7 @@ pub const CLR_HINT: Color = Color::DarkGray;
 pub const CLR_CONTEXT_LAYER: Color = Color::DarkGray;
 /// Other features of the selected feature's layer.
 pub const CLR_CONTEXT_FEATURE: Color = Color::Gray;
+pub const CLR_TRIANGLE: Color = Color::Gray;
 
 pub const STYLE_SELECTED: Style = Style::new().fg(CLR_SELECTED).add_modifier(Modifier::BOLD);
 pub const STYLE_LABEL: Style = Style::new().fg(CLR_LABEL);

--- a/rust/mlt/src/ui/rendering/help.rs
+++ b/rust/mlt/src/ui/rendering/help.rs
@@ -186,7 +186,7 @@ fn help_layer_overview() -> Vec<Line<'static>> {
         color(CLR_INNER_RING, "Red", "Inner ring (hole, CW)"),
         color(CLR_BAD_WINDING, "Light red", "Non-standard winding"),
         color(CLR_EXTENT, "Dark gray", "Tile extent boundary"),
-        color(CLR_TRIANGLE, "Gray", "Tessellation triangles"),
+        color(CLR_TRIANGLE, "Dark gray", "Tessellation edges"),
         Line::from(""),
         heading("Selection Colors"),
         color(CLR_SELECTED, "Yellow", "Selected feature/part"),

--- a/rust/mlt/src/ui/rendering/help.rs
+++ b/rust/mlt/src/ui/rendering/help.rs
@@ -9,8 +9,8 @@ use crate::ui::state::{App, ViewMode};
 use crate::ui::{
     CLR_BAD_WINDING, CLR_CONTEXT_FEATURE, CLR_CONTEXT_LAYER, CLR_DIMMED, CLR_EXTENT, CLR_HOVERED,
     CLR_INNER_RING, CLR_INNER_RING_SEL, CLR_LINE, CLR_MULTI_LINE, CLR_MULTI_POINT,
-    CLR_MULTI_POLYGON, CLR_POINT, CLR_POLYGON, CLR_SELECTED, STYLE_LABEL, STYLE_SELECTED,
-    block_with_title,
+    CLR_MULTI_POLYGON, CLR_POINT, CLR_POLYGON, CLR_SELECTED, CLR_TRIANGLE, STYLE_LABEL,
+    STYLE_SELECTED, block_with_title,
 };
 
 const CLR_ERROR: Color = Color::Red;
@@ -186,6 +186,7 @@ fn help_layer_overview() -> Vec<Line<'static>> {
         color(CLR_INNER_RING, "Red", "Inner ring (hole, CW)"),
         color(CLR_BAD_WINDING, "Light red", "Non-standard winding"),
         color(CLR_EXTENT, "Dark gray", "Tile extent boundary"),
+        color(CLR_TRIANGLE, "Gray", "Tessellation triangles"),
         Line::from(""),
         heading("Selection Colors"),
         color(CLR_SELECTED, "Yellow", "Selected feature/part"),

--- a/rust/mlt/src/ui/rendering/layers.rs
+++ b/rust/mlt/src/ui/rendering/layers.rs
@@ -378,6 +378,21 @@ fn subpart_stats_lines(geom: &Geometry<i32>, part: usize) -> Vec<Line<'static>> 
     lines
 }
 
+/// Triangle count line for a tessellated feature or one of its parts.
+fn tessellation_line(
+    app: &App,
+    layer: usize,
+    feat: usize,
+    part: Option<usize>,
+) -> Option<Line<'static>> {
+    let tess = app.tessellation(layer, feat)?;
+    let n: usize = match part {
+        Some(p) => tess.get(p)?.len(),
+        None => tess.iter().map(Vec::len).sum(),
+    };
+    Some(stat_line("Triangles", &n))
+}
+
 // ---------------------------------------------------------------------------
 // MBTiles hover properties panel
 // ---------------------------------------------------------------------------
@@ -448,14 +463,16 @@ fn render_geometry_stats(f: &mut Frame<'_>, area: Rect, app: &App) {
             format!("Geometry (layer {})", app.layer_groups[l].name),
             geometry_count_lines(app, Some(l)),
         ),
-        TreeItem::Feature { layer, feat } => (
-            "Geometry".to_string(),
-            geometry_stats_lines(&app.feature(layer, feat).geometry),
-        ),
-        TreeItem::SubFeature { layer, feat, part } => (
-            "Geometry".to_string(),
-            subpart_stats_lines(&app.feature(layer, feat).geometry, part),
-        ),
+        TreeItem::Feature { layer, feat } => {
+            let mut lines = geometry_stats_lines(&app.feature(layer, feat).geometry);
+            lines.extend(tessellation_line(app, layer, feat, None));
+            ("Geometry".to_string(), lines)
+        }
+        TreeItem::SubFeature { layer, feat, part } => {
+            let mut lines = subpart_stats_lines(&app.feature(layer, feat).geometry, part);
+            lines.extend(tessellation_line(app, layer, feat, Some(part)));
+            ("Geometry".to_string(), lines)
+        }
     };
 
     let para = Paragraph::new(lines)

--- a/rust/mlt/src/ui/rendering/map.rs
+++ b/rust/mlt/src/ui/rendering/map.rs
@@ -10,10 +10,11 @@ use ratatui::widgets::canvas::{Canvas, Context, Line as CanvasLine, Rectangle};
 
 use crate::ui::mbt::{MbtHoveredInfo, MbtTileData, TileTransform};
 use crate::ui::state::{App, LayerGroup, TreeItem};
+use crate::ui::tile::{Tessellation, Triangle};
 use crate::ui::{
     CLR_CONTEXT_FEATURE, CLR_CONTEXT_LAYER, CLR_DIMMED, CLR_EXTENT, CLR_HOVERED, CLR_INNER_RING,
-    CLR_INNER_RING_SEL, CLR_POLYGON, CLR_SELECTED, block_with_title, coord_f64, geometry_color,
-    is_ring_ccw,
+    CLR_INNER_RING_SEL, CLR_POLYGON, CLR_SELECTED, CLR_TRIANGLE, block_with_title, coord_f64,
+    geometry_color, is_ring_ccw,
 };
 
 /// How a geometry is colored.
@@ -83,6 +84,7 @@ pub fn render_map_panel(f: &mut Frame<'_>, area: Rect, app: &App) {
                         }
                     }
                     if let Some(fi) = hov_feat {
+                        draw_tessellation(ctx, app.tessellation(*l, fi), None);
                         let geom = &app.feature(*l, fi).geometry;
                         draw_feature(ctx, geom, Paint::Highlight(CLR_HOVERED), None, None);
                     }
@@ -112,6 +114,7 @@ pub fn render_map_panel(f: &mut Frame<'_>, area: Rect, app: &App) {
                         hov,
                         Some(TreeItem::Feature { layer: hl, feat: hf }) if hl == layer && hf == feat
                     );
+                    draw_tessellation(ctx, app.tessellation(*layer, *feat), sel_part);
                     let geom = &app.feature(*layer, *feat).geometry;
                     let paint = if whole_hovered {
                         Paint::Highlight(CLR_HOVERED)
@@ -137,6 +140,22 @@ fn draw_other_layers(ctx: &mut Context<'_>, app: &App, except: usize) {
     for (li, group) in app.layer_groups.iter().enumerate() {
         if li != except {
             draw_group(ctx, &app.tile.fc, group, Paint::Flat(CLR_CONTEXT_LAYER));
+        }
+    }
+}
+
+/// Tessellation triangles of a feature (`part` restricts a multipolygon to one polygon).
+fn draw_tessellation(ctx: &mut Context<'_>, tess: Option<&Tessellation>, part: Option<usize>) {
+    let Some(parts) = tess else {
+        return;
+    };
+    let selected: &[Vec<Triangle>] = match part {
+        Some(p) => parts.get(p).map_or(&[][..], std::slice::from_ref),
+        None => parts,
+    };
+    for tris in selected {
+        for [a, b, c] in tris {
+            draw_line(ctx, &[*a, *b, *c, *a], CLR_TRIANGLE);
         }
     }
 }

--- a/rust/mlt/src/ui/rendering/map.rs
+++ b/rust/mlt/src/ui/rendering/map.rs
@@ -84,8 +84,8 @@ pub fn render_map_panel(f: &mut Frame<'_>, area: Rect, app: &App) {
                         }
                     }
                     if let Some(fi) = hov_feat {
-                        draw_tessellation(ctx, app.tessellation(*l, fi), None);
                         let geom = &app.feature(*l, fi).geometry;
+                        draw_tessellation(ctx, app.tessellation(*l, fi), geom, None);
                         draw_feature(ctx, geom, Paint::Highlight(CLR_HOVERED), None, None);
                     }
                 }
@@ -114,8 +114,8 @@ pub fn render_map_panel(f: &mut Frame<'_>, area: Rect, app: &App) {
                         hov,
                         Some(TreeItem::Feature { layer: hl, feat: hf }) if hl == layer && hf == feat
                     );
-                    draw_tessellation(ctx, app.tessellation(*layer, *feat), sel_part);
                     let geom = &app.feature(*layer, *feat).geometry;
+                    draw_tessellation(ctx, app.tessellation(*layer, *feat), geom, sel_part);
                     let paint = if whole_hovered {
                         Paint::Highlight(CLR_HOVERED)
                     } else {
@@ -144,8 +144,14 @@ fn draw_other_layers(ctx: &mut Context<'_>, app: &App, except: usize) {
     }
 }
 
-/// Tessellation triangles of a feature (`part` restricts a multipolygon to one polygon).
-fn draw_tessellation(ctx: &mut Context<'_>, tess: Option<&Tessellation>, part: Option<usize>) {
+/// Tessellation edges of a feature that are not already ring edges.
+/// `part` restricts a multipolygon to one polygon.
+fn draw_tessellation(
+    ctx: &mut Context<'_>,
+    tess: Option<&Tessellation>,
+    geom: &Geometry<i32>,
+    part: Option<usize>,
+) {
     let Some(parts) = tess else {
         return;
     };
@@ -153,11 +159,57 @@ fn draw_tessellation(ctx: &mut Context<'_>, tess: Option<&Tessellation>, part: O
         Some(p) => parts.get(p).map_or(&[][..], std::slice::from_ref),
         None => parts,
     };
+    let ring_edges = ring_edges(geom);
     for tris in selected {
         for [a, b, c] in tris {
-            draw_line(ctx, &[*a, *b, *c, *a], CLR_TRIANGLE);
+            for (p, q) in [(a, b), (b, c), (c, a)] {
+                if !ring_edges.contains(&edge_key(*p, *q)) {
+                    draw_line(ctx, &[*p, *q], CLR_TRIANGLE);
+                }
+            }
         }
     }
+}
+
+/// An edge as an unordered pair of vertices.
+fn edge_key(a: Coord<i32>, b: Coord<i32>) -> (Coord<i32>, Coord<i32>) {
+    if (a.x, a.y) <= (b.x, b.y) {
+        (a, b)
+    } else {
+        (b, a)
+    }
+}
+
+/// Every ring edge of a polygon or multipolygon, including the closing edge of each ring.
+fn ring_edges(geom: &Geometry<i32>) -> HashSet<(Coord<i32>, Coord<i32>)> {
+    let mut edges = HashSet::new();
+    let mut add_ring = |ring: &[Coord<i32>]| {
+        for w in ring.windows(2) {
+            edges.insert(edge_key(w[0], w[1]));
+        }
+        if let (Some(&first), Some(&last)) = (ring.first(), ring.last()) {
+            edges.insert(edge_key(last, first));
+        }
+    };
+    let mut add_polygon = |poly: &Polygon<i32>| {
+        add_ring(&poly.exterior().0);
+        for ring in poly.interiors() {
+            add_ring(&ring.0);
+        }
+    };
+    match geom {
+        Geometry::<i32>::Polygon(poly) => add_polygon(poly),
+        Geometry::<i32>::MultiPolygon(mp) => mp.iter().for_each(&mut add_polygon),
+        Geometry::<i32>::Point(_)
+        | Geometry::<i32>::Line(_)
+        | Geometry::<i32>::LineString(_)
+        | Geometry::<i32>::MultiPoint(_)
+        | Geometry::<i32>::MultiLineString(_)
+        | Geometry::<i32>::GeometryCollection(_)
+        | Geometry::<i32>::Rect(_)
+        | Geometry::<i32>::Triangle(_) => {}
+    }
+    edges
 }
 
 /// Full-tile preview for file browser (all layers, no r-tree/mouse).

--- a/rust/mlt/src/ui/state.rs
+++ b/rust/mlt/src/ui/state.rs
@@ -15,7 +15,7 @@ use usize_cast::IntoUsize as _;
 use crate::ls::{FileAlgorithm, FileSortColumn, LsRow};
 use crate::ui::mbt::MbtilesState;
 use crate::ui::scan::ScanEvent;
-use crate::ui::tile::{ParsedTile, TileCache};
+use crate::ui::tile::{ParsedTile, Tessellation, TileCache};
 use crate::ui::{
     GeometryIndexEntry, auto_expand, coord_f64, group_by_layer, is_entry_visible, multi_part_count,
 };
@@ -405,6 +405,11 @@ impl App {
 
     pub(crate) fn feature(&self, layer: usize, feat: usize) -> &Feature {
         &self.tile.fc.features[self.global_idx(layer, feat)]
+    }
+
+    /// Tessellation triangles of a feature, one list per polygon part, if the tile stores them.
+    pub(crate) fn tessellation(&self, layer: usize, feat: usize) -> Option<&Tessellation> {
+        self.tile.triangles[self.global_idx(layer, feat)].as_ref()
     }
 
     pub(crate) fn extent(&self) -> u32 {

--- a/rust/mlt/src/ui/tests.rs
+++ b/rust/mlt/src/ui/tests.rs
@@ -861,6 +861,59 @@ fn hovering_a_tree_row_targets_that_row() {
 }
 
 #[test]
+fn tessellated_polygons_show_their_triangles() {
+    let path = test_dir("synthetic/0x01/mix_2_poly_polyh_tes.mlt");
+    let tile = TileCache::default().load(&path).unwrap();
+    assert!(tile.triangles.iter().all(Option::is_some));
+    let triangles: usize = tile.triangles[1]
+        .as_ref()
+        .unwrap()
+        .iter()
+        .map(Vec::len)
+        .sum();
+    assert!(
+        triangles > 0,
+        "feature 1 should carry tessellation triangles"
+    );
+    let mut app = App::new_single_file(tile, Some(path));
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Down);
+    insta::assert_snapshot!(render(&mut app), @r#"
+    "┌mix_2_poly_polyh_tes.mlt - E┐┌Map View────────────────────────────────────────────────────────────┐"
+    "│   All                      ││                                                                    │"
+    "│     Layer: layer1 (2 Polygo││                                                                    │"
+    "│       Feat 0: Polygon (4v) ││     ⢰⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⡆     │"
+    "│>>     Feat 1: Polygon (8v, ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                         ⢀⡀             ⡇     │"
+    "│                            ││     ⢸                                  ⢀⣀⣠⡤⠶⠚⠋⢱⠁             ⡇     │"
+    "│                            ││     ⢸                           ⢀⣀⡠⠤⣒⡲⠭⠓⠉⠁    ⡎              ⡇     │"
+    "│                            ││     ⢸                     ⣀⡠⠤⠔⠒⣉⠥⠔⠒⠉         ⢸               ⡇     │"
+    "│                            ││     ⢸              ⣀⡠⣤⣔⣒⠭⠭⣔⠶⠖⢫⠛⡄            ⢀⠇               ⡇     │"
+    "│                            ││     ⢸         ⠠⢴⣶⣾⢏⣉⣉⣀⡠⠔⠒⠉  ⢠⠃ ⠈⢢           ⡸                ⡇     │"
+    "│                            ││     ⢸           ⠈⠑⠛⠭⣒⠒⠬⠵⣢⣄⡀⢠⠃    ⠑⡄        ⢠⠃                ⡇     │"
+    "│                            ││     ⢸                ⠉⠒⠢⢄⡀⠉⠑⠢⢄    ⠈⢢       ⡜                 ⡇     │"
+    "│                            ││     ⢸                    ⠈⠉⠒⠤⣀⡉⠒⢄⡀  ⠑⡄    ⢰⠁                 ⡇     │"
+    "└────────────────────────────┘│     ⢸                         ⠈⠑⠢⠬⣑⠤⡀⠈⢢   ⡎                  ⡇     │"
+    "┌Properties (feat 1)─────────┐│     ⢸                              ⠉⠚⠵⢦⣑⡄⢸                   ⡇     │"
+    "│(no properties)             ││     ⢸                                  ⠈⠙⠃                   ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                        ⢰⠢⠤⢄⣀           ⡇     │"
+    "│                            ││     ⢸                                        ⡎    ⠉⠉⠒⠢⠤⣀⣀    ⡇     │"
+    "│                            ││     ⢸                                        ⡇         ⢀⠔⠋   ⡇     │"
+    "│                            ││     ⢸                                       ⢸       ⢀⠤⠊⠁     ⡇     │"
+    "└────────────────────────────┘│     ⢸                                       ⡜    ⢀⡠⠒⠁        ⡇     │"
+    "┌Geometry────────────────────┐│     ⢸                                       ⡇  ⡠⠔⠁           ⡇     │"
+    "│Type: Polygon               ││     ⢸                                      ⢰⣁⠔⠉              ⡇     │"
+    "│Vertices: 8                 ││     ⢸                                      ⠈                 ⡇     │"
+    "│Rings: 2                    ││     ⠸⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠇     │"
+    "│  Ring 0: 4v, CW            ││                                                                    │"
+    "│  Ring 1: 4v, CCW           ││                                                                    │"
+    "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
+    "#);
+}
+
+#[test]
 fn scan_streams_files_into_the_browser() {
     let base = fixtures_dir();
     let rx = start_scan(base.clone(), SCAN_FLAGS);
@@ -2347,6 +2400,89 @@ fn layer_summary_lists_every_value_type_and_skips_unknown_geometries() {
     "│                            ││                                                                    │"
     "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
     "#);
+}
+
+#[test]
+fn tessellated_multipolygon_parts_carry_their_own_triangles() {
+    let cache = TileCache::default();
+    let tile = cache
+        .load(&test_dir("synthetic/0x01/mix_2_poly_mpoly_tes.mlt"))
+        .unwrap();
+    let parts = tile.triangles[1].as_ref().unwrap();
+    assert!(parts.len() > 1 && parts.iter().all(|p| !p.is_empty()));
+    let mut app = App::new_single_file(tile, None);
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Down);
+    press(&mut app, KeyCode::Char('+'));
+    press(&mut app, KeyCode::Down);
+    insta::assert_snapshot!(render_sized(&mut app, 100, 50), @r#"
+    "┌unknown - Enter/+/-:expand, ┐┌Map View────────────────────────────────────────────────────────────┐"
+    "│   All                      ││                                                                    │"
+    "│     Layer: layer1 (2 featur││                                                                    │"
+    "│       Feat 0: Polygon (4v) ││                                                                    │"
+    "│       Feat 1: MultiPolygon ││                                                                    │"
+    "│>>       Part 0: Polygon (8v││     ⢸⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⡇     │"
+    "│         Part 1: Polygon (4v││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                 ⢸⢆     ⡇     │"
+    "│                            ││     ⢸                                                 ⡇⢠⠃    ⡇     │"
+    "│                            ││     ⢸                                                ⢠⢣⠃     ⡇     │"
+    "│                            ││     ⢸                                                ⢸⠎      ⡇     │"
+    "│                            ││     ⢸                                                ⠏       ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "└────────────────────────────┘│     ⢸                                                        ⡇     │"
+    "┌Properties (feat 1)─────────┐│     ⢸                                                        ⡇     │"
+    "│(no properties)             ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸                                                        ⡇     │"
+    "│                            ││     ⢸             ⢀⣴                                         ⡇     │"
+    "│                            ││     ⢸            ⡔⢡⠋⡆                        ⢀⡀              ⡇     │"
+    "│                            ││     ⢸          ⡠⠊ ⡎ ⢇                        ⢸⠈⠑⠢⢄⡀          ⡇     │"
+    "│                            ││     ⢸        ⡠⠊ ⡠⣼⡀ ⢸                        ⡎    ⠈⠑⠢⢄⡀      ⡇     │"
+    "│                            ││     ⢸      ⢀⢎⡠⠒⠉⡰⠹⣣ ⠈⡆                       ⡇        ⠈⠑⠢⢄   ⡇     │"
+    "│                            ││     ⢸    ⢀⣴⣓⣁⣀⣀⡰⠁ ⡏⡆ ⡇                       ⡇          ⡰⠁   ⡇     │"
+    "│                            ││     ⢸     ⠙⠲⡤⣀ ⠘⢄ ⡇⠸⡀⢸                      ⢰⠁        ⡠⠊     ⡇     │"
+    "│                            ││     ⢸       ⠈⠢⢕⠢⢌⡢⣱ ⢣⠘⡄                     ⢸       ⢀⠔⠁      ⡇     │"
+    "└────────────────────────────┘│     ⢸          ⠑⠤⡈⠙⡄ ⢇⡇                     ⢸      ⡰⠁        ⡇     │"
+    "┌Geometry────────────────────┐│     ⢸            ⠈⠢⢌⢢⠘⣼                     ⡇    ⢠⠊          ⡇     │"
+    "│Component: part #0 of a     ││     ⢸               ⠑⢕⣽⡄                    ⡇  ⢀⠔⠁           ⡇     │"
+    "│MultiPolygon                ││     ⢸                 ⠈⠃                    ⡇ ⡠⠃             ⡇     │"
+    "│Type: Polygon               ││     ⢸                                      ⢸⢠⠊               ⡇     │"
+    "│Vertices: 8                 ││     ⢸                                      ⠘⠁                ⡇     │"
+    "│Rings: 2                    ││     ⢸                                                        ⡇     │"
+    "│  Ring 0: 4v, CW            ││     ⢸⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⡇     │"
+    "│  Ring 1: 4v, CCW           ││                                                                    │"
+    "│Triangles: 6                ││                                                                    │"
+    "│                            ││                                                                    │"
+    "│                            ││                                                                    │"
+    "└────────────────────────────┘└────────────────────────────────────────────────────────────────────┘"
+    "#);
+
+    let mixed = cache
+        .load(&test_dir("synthetic/0x01-rust/mix_2_line_poly_tes.mlt"))
+        .unwrap();
+    assert!(mixed.triangles[0].is_none() && mixed.triangles[1].is_some());
+    let plain = cache
+        .load(&test_dir(
+            "synthetic/0x01/mix_7_pt_line_poly_polyh_mpt_mline_mpoly.mlt",
+        ))
+        .unwrap();
+    assert!(plain.triangles.iter().all(Option::is_none));
+    let mut app = App::new_single_file(plain, None);
+    press(&mut app, KeyCode::Char('*'));
+    press(&mut app, KeyCode::End);
+    render(&mut app);
 }
 
 #[test]

--- a/rust/mlt/src/ui/tile.rs
+++ b/rust/mlt/src/ui/tile.rs
@@ -5,43 +5,69 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use mlt_core::geo_types::{Coord, Geometry, Polygon};
+use mlt_core::geo_types::{Coord, Geometry, LineString, Polygon};
 use mlt_core::geojson::FeatureCollection;
 use mlt_core::mvt::mvt_to_feature_collection;
-use mlt_core::{Decoder, Parser};
+use mlt_core::{Decoder, LendingIterator as _, ParsedLayer, Parser};
 use moka::sync::Cache;
+use usize_cast::IntoUsize as _;
 
 use crate::ls::is_mlt_extension;
 
 /// Memory budget for decoded tiles.
 pub(crate) const CACHE_BYTES: u64 = 256 * 1024 * 1024;
 
-/// A decoded tile and its extent.
+/// One tessellation triangle in tile coordinates.
+pub(crate) type Triangle = [Coord<i32>; 3];
+
+/// Triangles of a tessellated feature, one list per polygon part (a plain polygon has one).
+pub(crate) type Tessellation = Vec<Vec<Triangle>>;
+
+/// A decoded tile with the tessellation triangles the encoder stored for its polygons.
+/// `triangles` is indexed like `fc.features`.
 pub(crate) struct ParsedTile {
     pub fc: FeatureCollection,
     pub extent: u32,
+    pub triangles: Vec<Option<Tessellation>>,
 }
 
 impl ParsedTile {
     pub(crate) fn from_fc(fc: FeatureCollection) -> Self {
         let extent = extent_from_fc(&fc);
-        Self { fc, extent }
+        let triangles = vec![None; fc.features.len()];
+        Self {
+            fc,
+            extent,
+            triangles,
+        }
     }
 
     pub(crate) fn load(path: &Path) -> anyhow::Result<Self> {
         let buf = fs::read(path)?;
-        let fc = if is_mlt_extension(path) {
+        if is_mlt_extension(path) {
             let layers = Decoder::default().decode_all(Parser::default().parse_layers(&buf)?)?;
-            FeatureCollection::from_layers(layers)?
+            let mut triangles = layer_triangles(&layers)?;
+            let fc = FeatureCollection::from_layers(layers)?;
+            triangles.resize(fc.features.len(), None);
+            Ok(Self {
+                extent: extent_from_fc(&fc),
+                fc,
+                triangles,
+            })
         } else {
-            mvt_to_feature_collection(buf)?
-        };
-        Ok(Self::from_fc(fc))
+            Ok(Self::from_fc(mvt_to_feature_collection(buf)?))
+        }
     }
 
     /// Rough number of bytes this tile occupies, used to weigh it in the cache.
     pub(crate) fn memory_estimate(&self) -> usize {
-        fc_memory_estimate(&self.fc)
+        let triangles: usize = self
+            .triangles
+            .iter()
+            .flatten()
+            .flat_map(|parts| parts.iter().map(Vec::len))
+            .sum();
+        fc_memory_estimate(&self.fc) + triangles * size_of::<Triangle>()
     }
 }
 
@@ -92,6 +118,96 @@ pub(crate) fn polygon_coord_count(poly: &Polygon<i32>) -> usize {
     poly.exterior().0.len() + poly.interiors().iter().map(|r| r.0.len()).sum::<usize>()
 }
 
+/// Polygon vertices in the order the encoder tessellated them, plus where each part starts.
+/// Rings drop their closing vertex, and anything that is not a polygon yields `None`.
+fn tessellation_vertices(geom: &Geometry<i32>) -> Option<(Vec<Coord<i32>>, Vec<usize>)> {
+    fn push_ring(out: &mut Vec<Coord<i32>>, ring: &LineString<i32>) {
+        let coords = &ring.0;
+        let closed = coords.len() > 1 && coords.first() == coords.last();
+        let n = if closed {
+            coords.len() - 1
+        } else {
+            coords.len()
+        };
+        out.extend_from_slice(&coords[..n]);
+    }
+    fn push_polygon(out: &mut Vec<Coord<i32>>, starts: &mut Vec<usize>, poly: &Polygon<i32>) {
+        starts.push(out.len());
+        push_ring(out, poly.exterior());
+        for ring in poly.interiors() {
+            push_ring(out, ring);
+        }
+    }
+    let mut out = Vec::new();
+    let mut starts = Vec::new();
+    match geom {
+        Geometry::<i32>::Polygon(poly) => push_polygon(&mut out, &mut starts, poly),
+        Geometry::<i32>::MultiPolygon(mp) => {
+            for poly in mp {
+                push_polygon(&mut out, &mut starts, poly);
+            }
+        }
+        Geometry::<i32>::Point(_)
+        | Geometry::<i32>::Line(_)
+        | Geometry::<i32>::LineString(_)
+        | Geometry::<i32>::MultiPoint(_)
+        | Geometry::<i32>::MultiLineString(_)
+        | Geometry::<i32>::GeometryCollection(_)
+        | Geometry::<i32>::Rect(_)
+        | Geometry::<i32>::Triangle(_) => return None,
+    }
+    Some((out, starts))
+}
+
+/// Per-feature triangles from the tessellation streams, in [`FeatureCollection::from_layers`] order.
+fn layer_triangles(layers: &[ParsedLayer<'_>]) -> anyhow::Result<Vec<Option<Tessellation>>> {
+    let mut out = Vec::new();
+    for layer in layers {
+        let Some(layer) = layer.as_layer01() else {
+            continue;
+        };
+        let values = layer.geometry_values();
+        let (Some(counts), Some(indices)) = (values.triangles(), values.index_buffer()) else {
+            out.extend(std::iter::repeat_n(None, layer.feature_count()));
+            continue;
+        };
+        let mut counts = counts.iter();
+        let mut next_index = 0usize;
+        let mut features = layer.iter_features();
+        while let Some(feat) = features.next() {
+            let feat = feat?;
+            let Some((verts, starts)) = tessellation_vertices(feat.geometry()) else {
+                out.push(None);
+                continue;
+            };
+            let Some(count) = counts.next() else {
+                out.push(None);
+                continue;
+            };
+            let end = next_index + count.into_usize() * 3;
+            let mut parts: Tessellation = vec![Vec::new(); starts.len()];
+            let feature_indices = indices.get(next_index..end).unwrap_or(&[]);
+            for t in feature_indices.as_chunks::<3>().0 {
+                let idx = [t[0].into_usize(), t[1].into_usize(), t[2].into_usize()];
+                let Some(tri) = idx
+                    .iter()
+                    .map(|&i| verts.get(i).copied())
+                    .collect::<Option<Vec<_>>>()
+                else {
+                    continue;
+                };
+                let part = starts.partition_point(|&s| s <= idx[0]).saturating_sub(1);
+                if let Some(slot) = parts.get_mut(part) {
+                    slot.push([tri[0], tri[1], tri[2]]);
+                }
+            }
+            next_index = end;
+            out.push(Some(parts));
+        }
+    }
+    Ok(out)
+}
+
 /// Memory-bounded LRU cache of decoded tiles keyed by path.
 #[derive(Clone)]
 pub(crate) struct TileCache(Cache<PathBuf, Arc<ParsedTile>>);
@@ -131,7 +247,9 @@ impl Default for TileCache {
 
 #[cfg(test)]
 mod tests {
-    use mlt_core::geo_types::{GeometryCollection, Line, LineString, Point, Rect, Triangle};
+    use mlt_core::geo_types::{
+        GeometryCollection, Line, LineString, MultiPolygon, Point, Rect, Triangle,
+    };
 
     use super::*;
 
@@ -146,6 +264,24 @@ mod tests {
             paths.sort();
             paths
         }
+    }
+
+    #[test]
+    fn tessellation_vertices_drop_closing_points_and_mark_part_starts() {
+        let closed = LineString(vec![c(0, 0), c(4, 0), c(4, 4), c(0, 4), c(0, 0)]);
+        let open = LineString(vec![c(1, 1), c(2, 1), c(2, 2)]);
+        let poly = Polygon::new(closed.clone(), vec![open.clone()]);
+        let (verts, starts) = tessellation_vertices(&Geometry::Polygon(poly.clone())).unwrap();
+        assert_eq!(verts.len(), 7, "four exterior and three interior vertices");
+        assert_eq!(starts, vec![0]);
+
+        let multi = MultiPolygon(vec![poly, Polygon::new(open, vec![])]);
+        let (verts, starts) = tessellation_vertices(&Geometry::MultiPolygon(multi)).unwrap();
+        assert_eq!(verts.len(), 10);
+        assert_eq!(starts, vec![0, 7]);
+
+        assert!(tessellation_vertices(&Geometry::Point(Point(c(1, 1)))).is_none());
+        assert!(tessellation_vertices(&Geometry::LineString(closed)).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Part of #971.

Sixth piece of #1626. Tiles that carry the `Triangles` and `IndexBuffer` streams get their triangles decoded next to the feature collection, one list per polygon part, so a tile's tessellation can be checked by eye instead of by reading index buffers. The map draws them in gray behind the selected polygon feature or part and behind a hovered polygon inside a layer, and the geometry panel shows the triangle count.