### PR TITLE
fix(ts): keep byte RLE within the lengths its headers can express

### DIFF
--- a/ts/src/decoding/decodingUtils.spec.ts
+++ b/ts/src/decoding/decodingUtils.spec.ts
@@ -140,6 +140,16 @@ describe("decodingUtils", () => {
             // All 8 bits should be set in the first byte
             expect(result[0]).toBe(0xff);
         });
+
+        it("should round trip more booleans than one literal run can hold", () => {
+            // 1032 booleans pack into 129 bytes, one more than a literal run can carry
+            const data = Array.from({ length: 1032 }, (_, i) => i % 3 === 0);
+            const encoded = encodeBooleanRle(data);
+            const offset = new IntWrapper(0);
+            const bits = new BitVector(decodeBooleanRle(encoded, data.length, encoded.length, offset), data.length);
+
+            expect(data.map((_, i) => bits.get(i))).toEqual(data);
+        });
     });
 
     describe("decodeByteRle", () => {
@@ -199,6 +209,16 @@ describe("decodingUtils", () => {
             const encoded = encodeByteRle(data);
             const offset = new IntWrapper(0);
             const result = decodeByteRle(encoded, 130, encoded.length, offset);
+
+            expect(result).toEqual(data);
+        });
+
+        it("should handle 130 run max", () => {
+            // A run of 131 identical bytes needs a 130 byte run plus a literal
+            const data = new Uint8Array(131).fill(7);
+            const encoded = encodeByteRle(data);
+            const offset = new IntWrapper(0);
+            const result = decodeByteRle(encoded, 131, encoded.length, offset);
 
             expect(result).toEqual(data);
         });

--- a/ts/src/encoding/encodingUtils.ts
+++ b/ts/src/encoding/encodingUtils.ts
@@ -51,11 +51,7 @@ export function encodeBooleanRle(values: boolean[]): Uint8Array {
         }
     }
 
-    const result = new Uint8Array(1 + numBytes);
-    result[0] = 256 - numBytes;
-    result.set(packed, 1);
-
-    return result;
+    return encodeByteRle(packed);
 }
 
 export function encodeByteRle(values: Uint8Array): Uint8Array {
@@ -66,13 +62,13 @@ export function encodeByteRle(values: Uint8Array): Uint8Array {
         const currentByte = values[i];
         let runLength = 1;
 
-        while (i + runLength < values.length && values[i + runLength] === currentByte && runLength < 131) {
+        while (i + runLength < values.length && values[i + runLength] === currentByte && runLength < 130) {
             runLength++;
         }
 
         if (runLength >= 3) {
             const header = runLength - 3;
-            result.push(Math.min(header, 0x7f));
+            result.push(header);
             result.push(currentByte);
             i += runLength;
         } else {


### PR DESCRIPTION
`encodeBooleanRle` in `ts/src/encoding/encodingUtils.ts` wrote the packed bits as one literal run with the header `256 - numBytes`. A literal header only spans 1 to 128 bytes, so from 1025 booleans upward it wrapped into the run range: 1032 booleans pack into 129 bytes and gave header 127, which `decodeByteRle` reads back as a run of 130 copies of the first packed byte. Every boolean column and every PRESENT stream longer than 1024 values decoded to garbage, and `propertyEncoder`, `stringEncoder` and `mapPropertyEncoder` all build their nullability streams through it. It now packs the bits and hands them to `encodeByteRle`, the same shape `encode_byte_rle` in `rust/mlt-core/src/codecs/rle.rs` uses.

Right next to it, `encodeByteRle` let a run grow to 131 bytes, clamped the header with `Math.min(header, 0x7f)`, and still advanced 131 positions. A run of 131 identical bytes came out as a run of 130 and lost the last byte. The scan now stops at 130, the longest run a header can name, and the clamp that hid the overflow is gone. The Rust encoder already stops at 130.

Two round trips in `ts/src/decoding/decodingUtils.spec.ts` cover both: 1032 booleans, and 131 identical bytes. Both fail on `main` (the first mismatches from index 8, the second decodes 0 for the last byte) and pass with the change.

Verified from `ts/` with `npx vitest run src` (32 files, 2486 tests passed), `npm run lint`, `npm run format:check` and `npm run build`, all clean.
