### PR TITLE
chore(rust): release

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1286,18 +1286,18 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.16"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+checksum = "98b0cc327b5bc766e7fda9c9260cc0fa81b43a8e240440422dff70788e3f9ef1"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1305,27 +1305,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+checksum = "03e8bd762f7479489c70ed6c768ddca99d7296857de437a68dcb2a94365b3fae"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crossterm"
@@ -3005,9 +3005,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.1"
+version = "2.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
 
 [[package]]
 name = "is-macro"
@@ -3459,7 +3459,7 @@ dependencies = [
 
 [[package]]
 name = "mlt"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-py"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "mlt-core",
  "pyo3",
@@ -4018,9 +4018,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
+checksum = "6d45aeb61b4bf818e12d4205f2466f8c4748f85f4fce0146d1c03d69d753f0ad"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -4028,9 +4028,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
+checksum = "89cc5a242e25ed4e7704d0be240f2cfbe20a8c27e7e252d94835be93d92dc39f"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4038,9 +4038,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
+checksum = "7abf21475cc3820fe4b2ca2dc2142902f67a02189f3b5b3a229f4febc01a43e5"
 dependencies = [
  "pest",
  "pest_meta",
@@ -4051,9 +4051,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
+checksum = "adba4db388f687393c18c51348d44a41d870ca9df71a2c98172ea3035dc6936e"
 dependencies = [
  "pest",
 ]

--- a/rust/mlt-py/CHANGELOG.md
+++ b/rust/mlt-py/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.29...python-mlt-v0.1.30) - 2026-09-06
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.29](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.28...python-mlt-v0.1.29) - 2026-09-04
 
 ### Added

--- a/rust/mlt-py/Cargo.toml
+++ b/rust/mlt-py/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-py"
 description = "Python bindings for MapLibre Tile (MLT) format via PyO3"
-version = "0.1.29"
+version = "0.1.30"
 repository.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/rust/mlt/CHANGELOG.md
+++ b/rust/mlt/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.29](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.28...rust-mlt-v0.1.29) - 2026-09-06
+
+### Added
+
+- *(rust)* scrollbars on every mlt ui panel and a sideways tree scroll ([#1626](https://github.com/maplibre/maplibre-tile-spec/pull/1626))
+
 ## [0.1.28](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.27...rust-mlt-v0.1.28) - 2026-09-05
 
 ### Added

--- a/rust/mlt/Cargo.toml
+++ b/rust/mlt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt"
 description = "MapLibre Tile Tools"
-version = "0.1.28"
+version = "0.1.29"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `mlt`: 0.1.28 -> 0.1.29
* `mlt-py`: 0.1.29 -> 0.1.30

<details><summary><i><b>Changelog</b></i></summary><p>

## `mlt`

<blockquote>

## [0.1.29](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.28...rust-mlt-v0.1.29) - 2026-09-06

### Added

- *(rust)* scrollbars on every mlt ui panel and a sideways tree scroll ([#1626](https://github.com/maplibre/maplibre-tile-spec/pull/1626))
</blockquote>

## `mlt-py`

<blockquote>

## [0.1.30](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.29...python-mlt-v0.1.30) - 2026-09-06

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).