### PR TITLE
chore(rust): release

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -255,7 +255,7 @@ dependencies = [
  "base64",
  "http 1.5.0",
  "log",
- "rustls 0.23.43",
+ "rustls 0.23.44",
  "serde",
  "serde_json",
  "url",
@@ -507,7 +507,7 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.43",
+ "rustls 0.23.44",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -2754,7 +2754,7 @@ dependencies = [
  "http 1.5.0",
  "hyper 1.11.1",
  "hyper-util",
- "rustls 0.23.43",
+ "rustls 0.23.44",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.26.5",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "mlt"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-core"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "arbitrary",
  "bitvec",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-ffi"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
@@ -3583,7 +3583,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-py"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "mlt-core",
  "pyo3",
@@ -3604,7 +3604,7 @@ dependencies = [
 
 [[package]]
 name = "mlt-wasm"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "js-sys",
  "mlt-core",
@@ -4536,7 +4536,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.3",
- "rustls 0.23.43",
+ "rustls 0.23.44",
  "socket2 0.6.5",
  "thiserror 2.0.20",
  "tokio",
@@ -4558,7 +4558,7 @@ dependencies = [
  "rand_pcg",
  "ring",
  "rustc-hash 2.1.3",
- "rustls 0.23.43",
+ "rustls 0.23.44",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.20",
@@ -4990,7 +4990,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.43",
+ "rustls 0.23.44",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5030,7 +5030,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.43",
+ "rustls 0.23.44",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -5289,9 +5289,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5336,7 +5336,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.43",
+ "rustls 0.23.44",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.15",
@@ -6603,7 +6603,7 @@ version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
- "rustls 0.23.43",
+ "rustls 0.23.44",
  "tokio",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -50,7 +50,7 @@ js-sys = "0.3"
 martin-tile-utils = "0.7"
 mbtiles = { version = "0.19", default-features = false, features = ["transcode"] }
 mimalloc = "0.1.52"
-mlt-core = { version = "0.12.8", path = "mlt-core" }
+mlt-core = { version = "0.12.9", path = "mlt-core" }
 moka = { version = "0.12", features = ["sync"] }
 num-traits = "0.2.19"
 num_enum = "0.7.6"

--- a/rust/mlt-core/CHANGELOG.md
+++ b/rust/mlt-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.9](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-core-v0.12.8...rust-mlt-core-v0.12.9) - 2026-09-07
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.12.8](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-core-v0.12.7...rust-mlt-core-v0.12.8) - 2026-09-04
 
 ### Added

--- a/rust/mlt-core/Cargo.toml
+++ b/rust/mlt-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-core"
 description = "MapLibre Tile library code"
-version = "0.12.8"
+version = "0.12.9"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/rust/mlt-ffi/CHANGELOG.md
+++ b/rust/mlt-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-ffi-v0.1.16...rust-mlt-ffi-v0.1.17) - 2026-09-07
+
+### Other
+
+- updated the following local packages: mlt-core
+
 ## [0.1.16](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-ffi-v0.1.15...rust-mlt-ffi-v0.1.16) - 2026-09-04
 
 ### Other

--- a/rust/mlt-ffi/Cargo.toml
+++ b/rust/mlt-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-ffi"
 description = "Diplomat FFI bindings for mlt-core"
-version = "0.1.16"
+version = "0.1.17"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/rust/mlt-py/CHANGELOG.md
+++ b/rust/mlt-py/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.31](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.30...python-mlt-v0.1.31) - 2026-09-07
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.30](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.29...python-mlt-v0.1.30) - 2026-09-06
 
 ### Other

--- a/rust/mlt-py/Cargo.toml
+++ b/rust/mlt-py/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-py"
 description = "Python bindings for MapLibre Tile (MLT) format via PyO3"
-version = "0.1.30"
+version = "0.1.31"
 repository.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/rust/mlt-py/pyproject.toml
+++ b/rust/mlt-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "maplibre-tiles"
-version = "0.1.29"
+version = "0.1.31"
 description = "Python bindings for MapLibre Tile (MLT) format"
 requires-python = ">=3.10"
 license = { text = "MIT OR Apache-2.0" }

--- a/rust/mlt-wasm/CHANGELOG.md
+++ b/rust/mlt-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.23](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-wasm-v0.1.22...rust-mlt-wasm-v0.1.23) - 2026-09-07
+
+### Other
+
+- updated the following local packages: mlt-core
+
 ## [0.1.22](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-wasm-v0.1.21...rust-mlt-wasm-v0.1.22) - 2026-09-04
 
 ### Other

--- a/rust/mlt-wasm/Cargo.toml
+++ b/rust/mlt-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt-wasm"
 description = "WebAssembly bindings for the MapLibre Tile (MLT) format"
-version = "0.1.22"
+version = "0.1.23"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/rust/mlt-wasm/package-lock.json
+++ b/rust/mlt-wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/mlt-wasm",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/mlt-wasm",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@mapbox/point-geometry": "1.1.0"

--- a/rust/mlt-wasm/package.json
+++ b/rust/mlt-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/mlt-wasm",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "WebAssembly-backed MapLibre Tile (MLT) decoder",
   "type": "module",
   "main": "dist/index.js",

--- a/rust/mlt/CHANGELOG.md
+++ b/rust/mlt/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.31](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.30...rust-mlt-v0.1.31) - 2026-09-07
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.30](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.29...rust-mlt-v0.1.30) - 2026-09-07
 
 ### Added

--- a/rust/mlt/Cargo.toml
+++ b/rust/mlt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlt"
 description = "MapLibre Tile Tools"
-version = "0.1.30"
+version = "0.1.31"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `mlt-core`: 0.12.8 -> 0.12.9 (✓ API compatible changes)
* `mlt`: 0.1.30 -> 0.1.31
* `mlt-py`: 0.1.30 -> 0.1.31
* `mlt-ffi`: 0.1.16 -> 0.1.17
* `mlt-wasm`: 0.1.22 -> 0.1.23

<details><summary><i><b>Changelog</b></i></summary><p>

## `mlt-core`

<blockquote>

## [0.12.9](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-core-v0.12.8...rust-mlt-core-v0.12.9) - 2026-09-07

### Other

- update Cargo.toml dependencies
</blockquote>

## `mlt`

<blockquote>

## [0.1.31](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-v0.1.30...rust-mlt-v0.1.31) - 2026-09-07

### Other

- update Cargo.toml dependencies
</blockquote>

## `mlt-py`

<blockquote>

## [0.1.31](https://github.com/maplibre/maplibre-tile-spec/compare/python-mlt-v0.1.30...python-mlt-v0.1.31) - 2026-09-07

### Other

- update Cargo.lock dependencies
</blockquote>

## `mlt-ffi`

<blockquote>

## [0.1.17](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-ffi-v0.1.16...rust-mlt-ffi-v0.1.17) - 2026-09-07

### Other

- updated the following local packages: mlt-core
</blockquote>

## `mlt-wasm`

<blockquote>

## [0.1.23](https://github.com/maplibre/maplibre-tile-spec/compare/rust-mlt-wasm-v0.1.22...rust-mlt-wasm-v0.1.23) - 2026-09-07

### Other

- updated the following local packages: mlt-core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).