### PR TITLE
ci: gate hotpath profiling on the bench label

### DIFF
--- a/.github/workflows/hotpath-profile.yml
+++ b/.github/workflows/hotpath-profile.yml
@@ -2,6 +2,7 @@ name: Rust Hotpath Profile
 
 on:
   pull_request:
+    types: [ opened, synchronize, reopened, labeled ]
     paths:
       - "rust/**"
 
@@ -14,6 +15,7 @@ concurrency:
 
 jobs:
   profile:
+    if: contains(github.event.pull_request.labels.*.name, 'bench')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
Hotpath profiling now runs only on PRs carrying the `bench` label (label created in the repo).