### PR TITLE
feat(ts): export `encodeTile()`

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -17,7 +17,7 @@
 | Implementation | Language | Type | Notes |
 |---|---|---|---|
 | [maplibre-tile-spec/cpp](https://github.com/maplibre/maplibre-tile-spec/tree/main/cpp) | C++ | Decoder | Used by MapLibre Native |
-| [maplibre-tile-spec/js](https://github.com/maplibre/maplibre-tile-spec/tree/main/ts) | TypeScript | Decoder | Used by MapLibre GL JS |
+| [maplibre-tile-spec/js](https://github.com/maplibre/maplibre-tile-spec/tree/main/ts) | TypeScript | Decoder / Encoder | Used by MapLibre GL JS. The encoder is still experimental. |
 | [maplibre-tile-spec/java](https://github.com/maplibre/maplibre-tile-spec/tree/main/java) | Java | Encoder | |
 | [maplibre-tile-spec/rust/mlt](https://github.com/maplibre/maplibre-tile-spec/blob/main/rust/mlt/README.md) | Rust | Decoder / Encoder | Includes bundled `mlt` CLI, TUI, and conversion tooling. |
 | [maplibre-tile-spec/rust/mlt-core](https://github.com/maplibre/maplibre-tile-spec/blob/main/rust/mlt-core/README.md) | Rust | Decoder / Encoder | Used in Martin. Includes bundled `mlt` CLI, TUI, and conversion tooling. |

--- a/ts/README.md
+++ b/ts/README.md
@@ -4,14 +4,14 @@ This package contains a JavaScript encoder and decoder for the experimental MapL
 
 ## Install
 
-`npm install @maplibre/maplibre-tile-spec`
+`npm install @maplibre/mlt`
 
 ## Quickstart
 
 ### Decode a tile
 
 ```js
-import { decodeTile } from '@maplibre/maplibre-tile-spec';
+import { decodeTile } from '@maplibre/mlt';
 
 const data = fs.readFileSync(tilePath);
 const tile = decodeTile(data);
@@ -20,7 +20,7 @@ const tile = decodeTile(data);
 ### Encode a tile
 
 ```ts
-import { encodeTile, type Layer } from '@maplibre/maplibre-tile-spec';
+import { encodeTile, type Layer } from '@maplibre/mlt';
 
 const layers: Layer[] = [
     {

--- a/ts/README.md
+++ b/ts/README.md
@@ -1,6 +1,6 @@
 # maplibre-tile-spec
 
-This package contains a JavaScript decoder for the experimental MapLibre Tile (MLT) vector tile format.
+This package contains a JavaScript encoder and decoder for the experimental MapLibre Tile (MLT) vector tile format.
 
 ## Install
 
@@ -8,7 +8,7 @@ This package contains a JavaScript decoder for the experimental MapLibre Tile (M
 
 ## Quickstart
 
-To decode a tile, you will want to load `MltDecoder`:
+### Decode a tile
 
 ```js
 import { decodeTile } from '@maplibre/maplibre-tile-spec';
@@ -16,6 +16,28 @@ import { decodeTile } from '@maplibre/maplibre-tile-spec';
 const data = fs.readFileSync(tilePath);
 const tile = decodeTile(data);
 ```
+
+### Encode a tile
+
+```ts
+import { encodeTile, type Layer } from '@maplibre/maplibre-tile-spec';
+
+const layers: Layer[] = [
+    {
+        name: 'places',
+        features: [
+            {
+                id: 1,
+                geometry: { type: 'Point', coordinates: [10, 20] },
+                properties: { name: 'Example' },
+            },
+        ],
+    },
+];
+
+const data = encodeTile(layers);
+```
+
 ## Contents
 
 ### Code

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -8,6 +8,7 @@ export { GEOMETRY_TYPE } from "./vector/geometry/geometryType";
 export type { TileSetMetadata } from "./metadata/tileset/tilesetMetadata";
 export type { Geometry } from "./vector/geometry/geometryVector";
 export type { Feature } from "./vector/featureTable";
+export type { MapEncodingOptions } from "./encoding/mapPropertyEncoder";
 export type {
     EncodeOptions,
     Feature as FeatureInput,

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -1,4 +1,5 @@
 export { default as decodeTile } from "./mltDecoder";
+export { encodeTile } from "./encoding/mltEncoder";
 export { default as FeatureTable } from "./vector/featureTable";
 export { GeometryVector } from "./vector/geometry/geometryVector";
 export { GpuVector } from "./vector/geometry/gpuVector";
@@ -7,3 +8,12 @@ export { GEOMETRY_TYPE } from "./vector/geometry/geometryType";
 export type { TileSetMetadata } from "./metadata/tileset/tilesetMetadata";
 export type { Geometry } from "./vector/geometry/geometryVector";
 export type { Feature } from "./vector/featureTable";
+export type {
+    EncodeOptions,
+    Feature as FeatureInput,
+    FeatureGeometry,
+    Layer,
+    Position,
+    PropertyType,
+    PropertyValue,
+} from "./encoding/mltEncoder";


### PR DESCRIPTION
Close #1685

#1554 added `encodeTile()`, but didn't export. While the implementation might not be very mature, I think it's usable and can be exported. So, this pull request simply exports it along with the related types.

```ts
import { encodeTile, type Layer } from '@maplibre/mlt';

const layers: Layer[] = [
    {
        name: 'places',
        features: [
            {
                id: 1,
                geometry: { type: 'Point', coordinates: [10, 20] },
                properties: { name: 'Example' },
            },
        ],
    },
];

const data = encodeTile(layers);
```